### PR TITLE
Rework setup process to download/install TileDB if necessary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.dylib
 
 # Cython extensions
 *.cpp
@@ -109,3 +110,5 @@ tiledb/version.py
 
 # IntelliJ
 .idea
+
+*.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,24 +11,17 @@ notifications:
   email: false
 
 install:
-  # Install TileDB in the Python repo's build directory
-  - mkdir build
-  - pushd ./build # . -> ./build
-  - git clone https://github.com/TileDB-Inc/TileDB
-  - pushd TileDB # ./build -> ./build/TileDB
-  - git checkout dev
-  - mkdir build
-  - pushd ./build  # ./build/TileDB/build
-  - ../bootstrap
-  - make && make -C tiledb install
-  - popd # ./build/TileDB/build -> ./build/TileDB
-  - popd # ./build/TileDB -> ./build
-  - popd # ./build -> .
-  # Build and install extension module
   - pip install -U tox-travis pip setuptools wheel
   - pip install -r requirements_dev.txt
-  - python setup.py build_ext --inplace --tiledb=./build/TileDB/dist
 
 script:
-  - env LD_LIBRARY_PATH="${TRAVIS_BUILD_DIR}/build/TileDB/dist/lib:$LD_LIBRARY_PATH" python -m unittest tiledb.tests.all.suite_test
-
+  # Build and test extension module
+  - python setup.py build_ext --inplace
+  - LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/tiledb:$LD_LIBRARY_PATH" python -m unittest tiledb.tests.all.suite_test;
+  # Check wheel build
+  - python setup.py bdist_wheel
+  - whl_file=`pwd`/dist/`ls dist`
+  - pushd /tmp
+  - echo "Installing wheel file from $whl_file..."
+  - pip install $whl_file
+  - python -c "import tiledb ; tiledb.libtiledb.version()"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+global-exclude .gitignore
+
+exclude MANIFEST.in
+exclude .readthedocs.yml
+exclude .travis.yml
+exclude requirements_dev.txt
+exclude tox.ini
+
+prune doc

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Build Dependencies
 * Numpy
 * Cython
 * C++11 compiler
+* CMake
 
 Install
 =======
@@ -37,11 +38,7 @@ A pre-built Conda package is available that will install TileDB as well.
 Pip
 '''
 
-A PyPI package is available which can be installed with Pip.
-
-You will need to build / install an up-to-date version of TileDB.
-See https://docs.tiledb.io/docs/installation for instructions.
-
+A PyPI package is available which can be installed with Pip. This package will download and install TileDB inside the site package if TileDB is not already installed on your system.
 
 :: 
 
@@ -49,7 +46,7 @@ See https://docs.tiledb.io/docs/installation for instructions.
     
 **Note** if the Numpy and Cython dependencies are not installed, pip will try to build them from source.  This can take a **long** time and make the install appear to "hang."  Pass the ``-v`` flag to pip to monitor the build process.
 
-If the install location of TileDB is not in compiler search path, create a requirements.txt file that specifies the tiledb install path manually.
+If you wish to use a custom version of the TileDB library and the install location is not in the compiler search path, create a requirements.txt file that specifies the tiledb install path manually.
 
 ::
     
@@ -74,7 +71,7 @@ Installing on Linux / OSX
    $ python setup.py build_ext --inplace
    $ python setup.py install
 
-If TileDB is installed in a non-standard location, pass the path to `setup.py` with the ``--tiledb=`` flag.
+If you wish to use a custom version of the TileDB library and it is installed in a non-standard location, pass the path to `setup.py` with the ``--tiledb=`` flag.
 If you want to pass extra compiler/linker flags during the c++ extension compilation step use ``--cxxflags=`` or ``--lflags=``.
 
 ::

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,4 @@ numpy==1.14.5
 Cython==0.28.3
 tox==3.0.0
 setuptools-scm==2.1.0
+cmake==3.11.0

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -1,5 +1,23 @@
 from __future__ import absolute_import
 
+import ctypes
+import os
+import sys
+
+if os.name == "posix":
+    if sys.platform == "darwin":
+        lib_name = "libtiledb.dylib"
+    else:
+        lib_name = "libtiledb.so"
+
+# Load the bundled TileDB dynamic library if it exists. This must occur before importing from libtiledb.
+try:
+    lib_dir = os.path.join(os.path.dirname(__file__), "native")
+    ctypes.CDLL(os.path.join(lib_dir, lib_name))
+except OSError as e:
+    # Otherwise try loading by name only.
+    ctypes.CDLL(lib_name)
+
 from .libtiledb import (
      Ctx,
      Config,


### PR DESCRIPTION
The native library is installed with the wheel (as "package data") if setup.py downloads and builds libtiledb.