### PR TITLE
Search over lib${ARCH} and libmultiarch paths when building extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ notifications:
 
 install:
   - pip install -U tox-travis pip
-  - pip install -r requirements.txt
+  - pip install -r requirements_dev.txt
 
 script:
   # Build and test extension module

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-cmake==3.11.0
-cython==0.27.3
-numpy==1.7.2
-setuptools==18.0.1
-setuptools-scm==1.5.4
-wheel==0.30.0
+cmake>=3.11.0
+cython>=0.27.3
+numpy>=1.7.2
+setuptools>=18.0.1
+setuptools-scm>=1.5.4
+wheel>=0.30.0


### PR DESCRIPTION
with custom tiledb install directory

switch to strict lower bound for requirements.txt