### PR TITLE
Fix macOS 10.14 build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from pkg_resources import resource_filename
 import sys
 from sys import version_info as ver
 
-TILEDB_VERSION = "dev"
+TILEDB_VERSION = "master"
 
 # Directory containing this file
 CONTAINING_DIR = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ import os
 import shutil
 import subprocess
 import zipfile
+import platform
+from distutils.sysconfig import get_config_var
+from distutils.version import LooseVersion
 
 try:
     # For Python 3
@@ -109,10 +112,26 @@ def build_libtiledb(src_dir):
     :param src_dir: Path to libtiledb source directory.
     :return: Path to the directory where the library was installed.
     """
+
+    # From https://github.com/pandas-dev/pandas/pull/24274
+    # 3-Clause BSD License: https://github.com/pandas-dev/pandas/blob/master/LICENSE
+    # For mac, ensure extensions are built for macos 10.9 when compiling on a
+    # 10.9 system or above, overriding distutils behaviour which is to target
+    # the version that python was built for. This may be overridden by setting
+    # MACOSX_DEPLOYMENT_TARGET before calling setup.py
+    if sys.platform == 'darwin':
+      if 'MACOSX_DEPLOYMENT_TARGET' not in os.environ:
+          current_system = LooseVersion(platform.mac_ver()[0])
+          python_target = LooseVersion(
+              get_config_var('MACOSX_DEPLOYMENT_TARGET'))
+          if python_target < '10.9' and current_system >= '10.9':
+              os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
+
     libtiledb_build_dir = os.path.join(src_dir, "build")
     libtiledb_install_dir = os.path.join(src_dir, "dist")
     if not os.path.exists(libtiledb_build_dir):
         os.makedirs(libtiledb_build_dir)
+
     print("Building libtiledb in directory {}...".format(libtiledb_build_dir))
     cmake_cmd = ["cmake", "-DCMAKE_INSTALL_PREFIX={}".format(libtiledb_install_dir),
                  "-DCMAKE_BUILD_TYPE=Release",


### PR DESCRIPTION
- as discussed, change target to TileDB stable while working on CI improvements.
- fix build on macOS 10.14, where libstdc++ is no longer available. The deployment target needs to be set in order to properly use libc++ (see `https://github.com/pandas-dev/pandas/pull/24274`)