### PR TITLE
FilterList.append and bug-fix

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1480,6 +1480,24 @@ cdef class FilterList(object):
             return filters[0]
         return filters
 
+    def append(self, Filter filter):
+        """Appends `filter` to the end of filter list
+
+        :param filter: filter object to add
+        :type filter: Filter
+        :returns: None
+        """
+        cdef tiledb_ctx_t* ctx_ptr = self.ctx.ptr
+        cdef tiledb_filter_list_t* filter_list_ptr = self.ptr
+        assert(filter_list_ptr != NULL)
+
+        cdef tiledb_filter_t* filter_ptr = filter.ptr
+
+        cdef int rc = TILEDB_OK
+        rc = tiledb_filter_list_add_filter(ctx_ptr, filter_list_ptr, filter_ptr)
+        if rc != TILEDB_OK:
+             _raise_ctx_err(ctx_ptr, rc)
+
 
 cdef class Attr(object):
     """Class representing a TileDB array attribute.

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1386,15 +1386,17 @@ cdef class FilterList(object):
             _raise_ctx_err(ctx_ptr, rc)
         cdef tiledb_filter_t* filter_ptr = NULL
         cdef Filter filter
-        try:
-            for f in filters:
-                filter_ptr = (<Filter> f).ptr
-                rc = tiledb_filter_list_add_filter(ctx_ptr, filter_list_ptr, filter_ptr)
-                if rc != TILEDB_OK:
-                    _raise_ctx_err(ctx_ptr, rc)
-        except:
-            tiledb_filter_list_free(&filter_list_ptr)
-            raise
+
+        if filters is not None:
+            try:
+                    for f in filters:
+                        filter_ptr = (<Filter> f).ptr
+                        rc = tiledb_filter_list_add_filter(ctx_ptr, filter_list_ptr, filter_ptr)
+                        if rc != TILEDB_OK:
+                            _raise_ctx_err(ctx_ptr, rc)
+            except:
+                tiledb_filter_list_free(&filter_list_ptr)
+                raise
         if chunksize is not None:
             rc = tiledb_filter_list_set_max_chunk_size(ctx_ptr, filter_list_ptr, chunksize)
             if rc != TILEDB_OK:

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -299,6 +299,11 @@ class AttributeTest(unittest.TestCase):
         self.assertEqual(len(attr.filters), 2)
         self.assertEqual(attr.filters.chunksize, filter_list.chunksize)
 
+    def test_filter_list(self):
+        ctx = tiledb.Ctx()
+
+        # should be constructible without a `filters` keyword arg set
+        filter_list1 = tiledb.FilterList()
 
 class ArraySchemaTest(unittest.TestCase):
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -301,9 +301,10 @@ class AttributeTest(unittest.TestCase):
 
     def test_filter_list(self):
         ctx = tiledb.Ctx()
-
         # should be constructible without a `filters` keyword arg set
-        filter_list1 = tiledb.FilterList()
+        filter_list1 = tiledb.FilterList(ctx)
+        filter_list1.append(tiledb.GzipFilter(ctx))
+        self.assertEqual(len(filter_list1), 1)
 
 class ArraySchemaTest(unittest.TestCase):
 


### PR DESCRIPTION
- add `FilterList::append`
- bug fix: FilterList(filters) constructor kwarg was not actually optional (tried to iterate over `None` -> error)