### PR TITLE
varlen array support

### DIFF
--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -16,6 +16,9 @@ cdef extern from "tiledb/tiledb.h":
     enum: TILEDB_MAX_PATH
     unsigned int tiledb_max_path()
 
+    enum: TILEDB_OFFSET_SIZE
+    unsigned int tiledb_offset_size()
+
     # Version
     void tiledb_version(int* major, int* minor, int* rev)
 
@@ -54,6 +57,12 @@ cdef extern from "tiledb/tiledb.h":
         TILEDB_UINT16
         TILEDB_UINT32
         TILEDB_UINT64
+        TILEDB_STRING_ASCII
+        TILEDB_STRING_UTF8
+        TILEDB_STRING_UTF16
+        TILEDB_STRING_UTF32
+        TILEDB_STRING_UCS2
+        TILEDB_STRING_UCS4
 
     ctypedef enum tiledb_array_type_t:
         TILEDB_DENSE

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2826,8 +2826,10 @@ def index_domain_subarray(Domain dom, tuple idx):
         if start is not None:
             # don't round / promote fp slices
             if np.issubdtype(dim.dtype, np.integer):
-                if not isinstance(start, _inttypes):
+                if isinstance(start, (np.float32, np.float64)):
                     raise IndexError("cannot index integral domain dimension with floating point slice")
+                elif not isinstance(start, _inttypes):
+                    raise IndexError("cannot index integral domain dimension with non-integral slice (dtype: {})".format(type(start)))
             # apply negative indexing (wrap-around semantics)
             if start < 0:
                 start += int(dim_ub) + 1

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1475,7 +1475,7 @@ cdef class Attr(object):
     :param str name: Attribute name, empty if anonymous
     :param dtype: Attribute value datatypes
     :type dtype: numpy.dtype object or type or string
-    :param var: Attribute is variable-length (automatic for byte/string tyeps)
+    :param var: Attribute is variable-length (automatic for byte/string types)
     :type dtype: bool
     :param filters: List of filters to apply
     :type filters: FilterList

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1051,7 +1051,7 @@ class DenseVarlen(DiskTestCase):
 
 
     def test_varlen_write_ints(self):
-        A = np.array([np.random.randint(0,pow(10,6),x, dtype=np.uint64) for x in np.random.randint(1,12,8)], dtype=np.object)
+        A = np.array([np.uint64(np.random.randint(0,pow(10,6),x)) for x in np.random.randint(1,12,8)], dtype=np.object)
 
         print("random sub-length test array: {}".format(A))
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1477,20 +1477,20 @@ class NumpyToArray(DiskTestCase):
 
     def test_bytes_to_array1d(self):
         np_array = np.array([b'abcdef', b'gh', b'ijkl', b'mnopqrs', b'1234545lkjalsdfj'], dtype=object)
-        arr = tiledb.DenseArray.from_numpy(self.path("foo"), np_array)
-        assert_array_equal(arr[:], np_array)
+        with tiledb.DenseArray.from_numpy(self.path("foo"), np_array) as arr:
+            assert_array_equal(arr[:], np_array)
 
-        arr_reload = tiledb.DenseArray(self.path("foo"))
-        assert_array_equal(arr_reload[:], np_array)
+        with tiledb.DenseArray(self.path("foo")) as arr_reload:
+            assert_array_equal(arr_reload[:], np_array)
 
     def test_unicode_to_array1d(self):
         np_array = np.array(['1234545lkjalsdfj', 'mnopqrs', 'ijkl', 'gh', 'abcdef',
                              'aαbββcγγγdδδδδ', '"aαbββc', 'γγγdδδδδ'], dtype=object)
-        arr = tiledb.DenseArray.from_numpy(self.path("foo"), np_array)
-        assert_array_equal(arr[:], np_array)
+        with tiledb.DenseArray.from_numpy(self.path("foo"), np_array) as arr:
+            assert_array_equal(arr[:], np_array)
 
-        arr_reload = tiledb.DenseArray(self.path("foo"))
-        assert_array_equal(arr_reload[:], np_array)
+        with tiledb.DenseArray(self.path("foo")) as arr_reload:
+            assert_array_equal(arr_reload[:], np_array)
 
     def test_array_interface(self):
         # Tests that __array__ interface works


### PR DESCRIPTION
Output of reading the var length C++ example output array:

```
import tiledb
ctx = tiledb.Ctx()

uri = "/Users/inorton/work/scratch/varlen_scratch-20190214/varlen.cc/variable_length_array"

v1 = tiledb.DenseArray(ctx, uri)

print(v1[1:5 , 1:5])
```

```
OrderedDict([('a1', array([[b'a', b'bb', b'ccc', b'dd'],
       [b'eee', b'f', b'g', b'hhh'],
       [b'i', b'jjj', b'kk', b'l'],
       [b'm', b'n', b'oo', b'p']], dtype=object)), ('a2', array([[array([1, 1], dtype=int32), array([2, 2], dtype=int32),
        array([3], dtype=int32), array([4], dtype=int32)],
       [array([5], dtype=int32), array([6, 6], dtype=int32),
        array([7, 7], dtype=int32), array([8, 8, 8], dtype=int32)],
       [array([9, 9], dtype=int32), array([10], dtype=int32),
        array([11], dtype=int32), array([12, 12], dtype=int32)],
       [array([13], dtype=int32), array([14, 14, 14], dtype=int32),
        array([15], dtype=int32), array([16], dtype=int32)]], dtype=object))])
```

---

fixes #57 