### PR TITLE
Add ReadQuery class (query->buffer), and refactor both array classes to use

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -431,7 +431,10 @@ cy_extension=Extension(
     )
 if TILEDB_DEBUG_BUILD:
   # monkey patch to tell Cython to generate debug mapping
-  cy_extension.__setattr__('cython_gdb', True)
+  if sys.version_info < (3,0):
+      cy_extension.__dict__['cython_gdb'] = True
+  else:
+      cy_extension.__setattr__('cython_gdb', True)
 
 setup(
     name='tiledb',


### PR DESCRIPTION
This PR adds a lower-level "ReadQuery" class, which executes a query and stores the result as simple numpy byte buffers. The dense and sparse array subclasses are refactored to use this class, which consolidates `tiledb_*` read logic in one place, and simplifies the implementation. (also useful for integration prototyping and debugging)