### PR TITLE
HL API additions for dask

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ steps:
 
 
 - script: |
-    python -m unittest -v
+    python -m unittest tiledb.tests.all.suite_test
   displayName: 'Run tests'
 
 - task: PublishTestResults@2

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -26,6 +26,7 @@ except:
         ctypes.CDLL(lib_name)
 
 from .libtiledb import (
+     Array,
      Ctx,
      Config,
      Dim,
@@ -61,8 +62,10 @@ from .libtiledb import (
      stats_enable,
      stats_disable,
      stats_reset,
-     stats_dump
+     stats_dump,
 )
+
+from .highlevel import *
 #
 # __all__ = [Ctx, Config, Dim, Domain, Attr, KV, ArraySchema, SparseArray, TileDBError, VFS,
 #            array_consolidate, group_create, object_type, ls, walk, remove]

--- a/tiledb/highlevel.py
+++ b/tiledb/highlevel.py
@@ -1,0 +1,69 @@
+import tiledb
+from tiledb.libtiledb import *
+
+import numpy as np
+
+import pdb
+def open(uri, key=None, attr=None, mode='r', config=None):
+    if config:
+        cfg = tiledb.Config(config)
+        ctx = tiledb.Ctx(cfg)
+    else:
+        ctx = default_ctx()
+
+    schema = ArraySchema.load(uri, ctx=ctx)
+    if not schema:
+        raise Exception("Unable to load tiledb ArraySchema from URI: '{}'".format(uri))
+
+    if schema.sparse:
+        return tiledb.SparseArray(uri, mode=mode, key=key, attr=attr, ctx=ctx)
+    elif not schema.sparse:
+        return tiledb.DenseArray(uri, mode=mode, key=key, attr=attr, ctx=ctx)
+    else:
+        raise Exception("Unknown TileDB array type")
+
+
+def save(uri, array, config=None, **kw):
+    if not isinstance(array, np.ndarray):
+        raise ValueError("expected NumPy ndarray, not '{}'".format(type(array)))
+    if config:
+        cfg = Config(config)
+        ctx = tiledb.Ctx(cfg)
+    else:
+        ctx = default_ctx()
+
+    tiledb.from_numpy(uri, array, ctx=ctx)
+
+
+def empty_like(uri, arr, config=None, key=None, tile=None):
+    """
+    Create and return an empty, writeable DenseArray with schema based on
+    a NumPy-array like object.
+
+    :param uri:
+    :param arr: NumPy ndarray, or shape tuple
+    :param ctx:
+    :param kw:
+    :return:
+    """
+    if config:
+        cfg = tiledb.Config(config)
+        ctx = tiledb.Ctx(cfg)
+    else:
+        ctx = default_ctx()
+
+    if arr is ArraySchema:
+        schema = arr
+    else:
+        schema = schema_like(arr, tile=tile, ctx=ctx)
+
+    tiledb.DenseArray.create(uri, key=key, schema=schema)
+    return tiledb.DenseArray(uri, mode='w', key=key, ctx=ctx)
+
+
+def from_numpy(uri, array, ctx=default_ctx(), **kw):
+    if not isinstance(array, np.ndarray):
+        raise Exception("from_numpy is only currently supported for numpy.ndarray")
+
+    return DenseArray.from_numpy(uri, array, ctx=ctx, **kw)
+

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -199,72 +199,9 @@ cdef bytes unicode_path(object path):
 cdef class Config(object):
     """TileDB Config class
 
-    Valid parameters (unknown parameters will be ignored):
+    See: https://docs.tiledb.io/en/stable/tutorials/config.html#summary-of-parameters
 
-    - ``sm.tile_cache_size``
-       The tile cache size in bytes. Any ``uint64_t`` value is acceptable.
-       **Default**: 10,000,000
-    - ``sm.array_schema_cache_size``
-       The array schema cache size in bytes. Any ``uint64_t`` value is acceptable.
-       **Default**: 10,000,000
-    - ``sm.fragment_metadata_cache_size``
-       The fragment metadata cache size in bytes. Any ``uint64_t`` value is
-       acceptable.
-    - ``sm.enable_signal_handlers``
-       Whether or not TileDB will install signal handlers.
-       **Default**: true
-       **Default**: 10,000,000
-    - ``sm.number_of_threads``
-       The number of allocated threads per TileDB context.
-       **Default**: number of cores
-    - ``vfs.max_parallel_ops``
-       The maximum number of VFS parallel operations.
-       **Default**: number of cores
-    - ``vfs.min_parallel_size``
-       The minimum number of bytes in a parallel VFS operation. (Does not
-       affect parallel S3 writes.)
-       **Default**: 10MB
-    - ``vfs.s3.region``
-       The S3 region, if S3 is enabled.
-       **Default**: us-east-1
-    - ``vfs.s3.scheme``
-       The S3 scheme (``http`` or ``https``), if S3 is enabled.
-       **Default**: https
-    - ``vfs.s3.endpoint_override``
-       The S3 endpoint, if S3 is enabled.
-       **Default**: ""
-    - ``vfs.s3.use_virtual_addressing``
-       The S3 use of virtual addressing (``true`` or ``false``), if S3 is
-       enabled.
-       **Default**: true
-    - ``vfs.s3.multipart_part_size``
-       The part size (in bytes) used in S3 multipart writes, if S3 is enabled.
-       Any ``uint64_t`` value is acceptable. Note: ``vfs.s3.multipart_part_size *
-       vfs.max_parallel_ops`` bytes will be buffered before issuing multipart
-       uploads in parallel.
-       **Default**: 5*1024*1024
-    - ``vfs.s3.connect_timeout_ms``
-       The connection timeout in ms. Any ``long`` value is acceptable.
-       **Default**: 3000
-    - ``vfs.s3.connect_max_tries``
-       The maximum tries for a connection. Any ``long`` value is acceptable.
-       **Default**: 5
-    - ``vfs.s3.connect_scale_factor``
-       The scale factor for exponential backofff when connecting to S3.
-       Any ``long`` value is acceptable.
-       **Default**: 25
-    - ``vfs.s3.request_timeout_ms``
-       The request timeout in ms. Any ``long`` value is acceptable.
-       **Default**: 3000
-    - ``vfs.hdfs.name_node"``
-       Name node for HDFS.
-       **Default**: ""
-    - ``vfs.hdfs.username``
-       HDFS username.
-       **Default**: ""
-    - ``vfs.hdfs.kerb_ticket_cache_path``
-       HDFS kerb ticket cache path.
-       **Default**: ""
+    Unknown parameters will be ignored!
 
     :param dict params: Set parameter values from dict like object
     :param str path: Set parameter values from persisted Config parameter file

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1674,7 +1674,7 @@ cdef class Dim(object):
         return dim
 
     def __init__(self, name=u"", domain=None, tile=0, dtype=np.uint64, Ctx ctx=default_ctx()):
-        if len(domain) != 2:
+        if domain is None or len(domain) != 2:
             raise ValueError('invalid domain extent, must be a pair')
         if dtype is not None:
             dtype = np.dtype(dtype)
@@ -1789,8 +1789,8 @@ cdef class Dim(object):
 
     cdef _shape(self):
         domain = self.domain
-        return ((np.asscalar(domain[1]) -
-                 np.asscalar(domain[0]) + 1),)
+        return ((domain[1].item() -
+                 domain[0].item() + 1),)
 
     @property
     def shape(self):

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -6,13 +6,6 @@ import shutil
 import tempfile
 from unittest import TestCase
 
-
-def remove_tree(rootdir):
-    # Remove every directory starting with rootdir
-    for dirpath in glob.glob(rootdir + "*"):
-        shutil.rmtree(dirpath)
-
-
 class DiskTestCase(TestCase):
 
     def setUp(self):
@@ -20,7 +13,14 @@ class DiskTestCase(TestCase):
         self.rootdir = tempfile.mkdtemp(prefix=prefix)
 
     def tearDown(self):
-        remove_tree(self.rootdir)
+        # Remove every directory starting with rootdir
+        for dirpath in glob.glob(self.rootdir + "*"):
+            try:
+                shutil.rmtree(dirpath)
+            except OSError as exc:
+                print("test '{}' error deleting '{}'".format(self.__class__.__name__,
+                                                             dirpath))
+                raise
 
     def path(self, path):
         return os.path.abspath(os.path.join(self.rootdir, path))

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -1,0 +1,84 @@
+try:
+    import dask, dask.array as da
+    import_failed = False
+except ImportError:
+    import_failed = True
+
+import unittest
+
+import tiledb
+from tiledb.tests.common import DiskTestCase
+
+import numpy as np
+from numpy.testing import assert_array_equal, assert_approx_equal
+
+
+class DaskSupport(DiskTestCase):
+    def setUp(self):
+        if import_failed:
+            self.skipTest("Dask not available")
+        else:
+            super().setUp()
+
+    @unittest.expectedFailure
+    def test_dask_from_numpy_1d(self):
+        uri = self.path("np_1attr")
+        A = np.random.randn(50,50)
+        T = tiledb.from_numpy(uri, A, tile=50)
+        T.close()
+
+        with tiledb.open(uri) as T:
+            D = da.from_tiledb(T)
+            assert_array_equal(D, A)
+
+        D2 = da.from_tiledb(uri)
+        assert_array_equal(D2, A)
+        self.assertAlmostEqual(np.mean(A), D2.mean().compute(scheduler='single-threaded'))
+
+    def _make_multiattr_2d(self, uri, shape=(0,100), tile=10):
+        dom = tiledb.Domain(
+                tiledb.Dim("x", (0,10), dtype=np.uint64, tile=tile),
+                tiledb.Dim("y", (0,50), dtype=np.uint64, tile=tile))
+        schema = tiledb.ArraySchema(
+                    attrs=(tiledb.Attr("attr1"),
+                           tiledb.Attr("attr2")),
+                    domain=dom)
+
+        tiledb.DenseArray.create(uri, schema)
+
+
+    @unittest.expectedFailure
+    def test_dask_multiattr_2d(self):
+        uri = self.path("multiattr")
+
+        self._make_multiattr_2d(uri)
+
+        with tiledb.DenseArray(uri, 'w') as T:
+            ar1 = np.random.randn(*T.schema.shape)
+            ar2 = np.random.randn(*T.schema.shape)
+            T[:] = {'attr1': ar1,
+                    'attr2': ar2}
+        with tiledb.DenseArray(uri, mode='r', attr='attr2') as T:
+            # basic round-trip from dask.array
+            D = da.from_tiledb(T, attribute='attr2')
+            assert_array_equal(ar2, np.array(D))
+
+        # smoke-test computation
+        # note: re-init from_tiledb each time, or else dask just uses the cached materialization
+        D = da.from_tiledb(uri, attribute='attr2')
+        self.assertAlmostEqual(np.mean(ar2), D.mean().compute(scheduler='threads', num_workers=4))
+        D = da.from_tiledb(uri, attribute='attr2')
+        self.assertAlmostEqual(np.mean(ar2), D.mean().compute(scheduler='single-threaded'))
+
+        # test dask.distributed
+        from dask.distributed import Client
+        with Client() as client:
+            assert_approx_equal(D.mean().compute(), np.mean(ar2))
+
+    @unittest.expectedFailure
+    def test_dask_write(self):
+        uri = self.path("dask_w")
+        D = da.random.random(10,10)
+        D.to_tiledb(uri)
+        DT = da.from_tiledb(uri)
+        assert_array_equal(D, DT)

--- a/tiledb/tests/test_util.py
+++ b/tiledb/tests/test_util.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import tiledb
+from tiledb import *
+from tiledb.libtiledb import index_as_tuple, replace_ellipsis
+from tiledb.tests.common import DiskTestCase
+
+import numpy as np
+from numpy.testing import assert_equal, assert_approx_equal,\
+                          assert_array_equal, assert_raises
+
+import unittest
+from unittest import TestCase
+
+
+class UtilTest(DiskTestCase):
+    def test_empty_like(self):
+        arr = np.zeros((10,10), dtype=np.float32)
+
+        def check_schema(self, s):
+            self.assertEqual(s.attr(0).dtype, np.float32)
+            self.assertEqual(s.shape, (10,10))
+            self.assertEqual(s.domain.dim(0).shape, (10,))
+            self.assertEqual(s.domain.dim(1).shape, (10,))
+
+        with self.assertRaises(ValueError):
+            schema_like('', None)
+
+        schema = schema_like(arr, tile=1)
+        self.assertIsInstance(schema, ArraySchema)
+        check_schema(self, schema)
+
+        uri = self.path("empty_like")
+        T = empty_like(uri, arr)
+        check_schema(self, T.schema)
+        self.assertEqual(T.shape, arr.shape)
+        self.assertEqual(T.dtype, arr.dtype)
+
+
+        # test a fake object with .shape, .ndim, .dtype
+        class FakeArray(object):
+            def __init__(self, shape, dtype):
+                self.shape = shape
+                self.ndim = len(shape)
+                self.dtype = dtype
+
+        fake = FakeArray((3,3), np.int16)
+        schema2 = empty_like(self.path('fake_like'), fake)
+        self.assertIsInstance(schema2, Array)
+        self.assertEqual(schema2.shape, fake.shape)
+        self.assertEqual(schema2.dtype, fake.dtype)
+        self.assertEqual(schema2.ndim, fake.ndim)
+
+        # test passing shape and dtype directly
+        schema3 = schema_like(shape=(4,4), dtype=np.float32)
+        self.assertIsInstance(schema3, ArraySchema)
+        self.assertEqual(schema3.attr(0).dtype, np.float32)
+        self.assertEqual(schema3.domain.dim(0).tile, 4)
+        schema3 = schema_like(shape=(4,4), dtype=np.float32, tile=1)
+        self.assertEqual(schema3.domain.dim(0).tile, 1)
+
+    def test_open(self):
+        uri = self.path("load")
+        with tiledb.from_numpy(uri, np.array(np.arange(3))) as T:
+            with tiledb.open(uri) as T2:
+                self.assertEqual(T.schema, T2.schema)
+                assert_array_equal(T, T2)
+
+    def test_save(self):
+        uri = self.path("test_save")
+        arr = np.array(np.arange(3))
+        tiledb.save(uri, arr)
+
+        with tiledb.open(uri) as T:
+            assert_array_equal(arr, T)


### PR DESCRIPTION
This PR contains

- rework DenseArray to support single-attribute view on a multi-attribute array

- set  of API additions, motivated by dask support (but hopefully generally useful):
  - convenience functions:
    - `open`, `save`
    - aliased `from_numpy` to allow use as simply `tiledb.from_numpy`
  - util functions to make schema and array from numpy-style specifiers (rather than spelling out `Dim`,`Domain`)
    - `schema_like`: create ArraySchema based on a numpy ndarray template, or numpy-style `shape` and `dtype` kwargs
    - `empty_like`: returns a writable, emtpy array similar to an existing ndarray-like object (`.dtype`, `.shape`).

- basic CI for dask integration to make sure we don't break that here, going forward