### PR TITLE
Update quickstart_dense.py URL in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ This may take a while, as the pip package will automatically download and build 
 
 Next, save the `quickstart program <https://github.com/TileDB-Inc/TileDB-Py/blob/dev/examples/quickstart_dense.py>`_ into a file and run it::
 
-    $ wget https://github.com/TileDB-Inc/TileDB-Py/blob/dev/examples/quickstart_dense.py
+    $ wget https://raw.githubusercontent.com/TileDB-Inc/TileDB-Py/dev/examples/quickstart_dense.py
     $ python quickstart_dense.py
     [[2 3 4]
      [6 7 8]]


### PR DESCRIPTION
`wget https://github.com/TileDB-Inc/TileDB-Py/blob/dev/examples/quickstart_dense.py' pulls
the rich github web page. We should update this to the raw file URL:
https://raw.githubusercontent.com/TileDB-Inc/TileDB-Py/dev/examples/quickstart_dense.py