### PR TITLE
Mac10.14 out-of-source fix and minor docs clean-up

### DIFF
--- a/doc/source/conda-env.yml
+++ b/doc/source/conda-env.yml
@@ -3,6 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.5
+  - python=3.7
   - gcc
   - scikit-build

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -25,9 +25,9 @@ copyright = '2018, TileDB, Inc.'
 author = 'TileDB, Inc.'
 
 # The short X.Y version
-version = '0.2'
+version = '0.4'
 # The full version, including alpha/beta/rc tags
-release = '0.2.0'
+release = '0.4.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1479,15 +1479,6 @@ cdef class Attr(object):
     :type dtype: bool
     :param filters: List of filters to apply
     :type filters: FilterList
-    :param compressor: <todo: reimplement?> The compressor name and level for attribute values.
-                       Available compressors:
-                         - "gzip"
-                         - "zstd"
-                         - "lz4"
-                         - "rle"
-                         - "bzip2"
-                         - "double-delta"
-    :type compressor: tuple(str, int)
     :raises TypeError: invalid dtype
     :raises: :py:exc:`tiledb.TileDBError`
 
@@ -1940,7 +1931,7 @@ cdef class Dim(object):
 cdef class Domain(object):
     """Class representing the domain of a TileDB Array.
 
-    :param *dims: one or more tiledb.Dim objects up to the Domain's ndim
+    :param *dims*: one or more tiledb.Dim objects up to the Domain's ndim
     :raises TypeError: All dimensions must have the same dtype
     :raises: :py:exc:`TileDBError`
     :param tiledb.Ctx ctx: A TileDB Context
@@ -2558,7 +2549,7 @@ cdef class KV(object):
     def dict(self):
         """Return a dict representation of the KV array object
 
-        :rtype: dict
+        :rtype: :py:class:`dict`
         :return: Python dict of keys and attribute value (tuples)
 
         """


### PR DESCRIPTION
- fixes building against out-of-source libtiledb on newer macOS: previously the deployment target override only applied when building libtiledb from source w/in setup.py, but the cython build also needs this setting.
- minor doc fixes/clean-ups