### PR TITLE
 Add Dockerfile to make manylinux1 wheels (e.g. for PyPI)

### DIFF
--- a/misc/pypi_linux/Dockerfile
+++ b/misc/pypi_linux/Dockerfile
@@ -1,0 +1,45 @@
+FROM quay.io/pypa/manylinux1_x86_64
+
+###############################################
+# settings
+# NOTE: MUST USE the 'mu' variant here to be compatible
+#       with ~most~ linux distros (see manylinux README)
+ENV PYTHON_BASE /opt/python/cp27-cp27mu/bin/
+ENV TILEDB_VERSION 1.5.0
+ENV TILEDB_PY_VERSION 0.4.0
+
+RUN useradd tiledb
+ENV HOME /home/tiledb
+
+# dependencies:
+# - cmake (need recent) and auditwheel from pip
+# - perl 5.10.0 for openssl
+RUN  $PYTHON_BASE/pip install cmake auditwheel && \
+  curl -L https://install.perlbrew.pl | bash && \
+  source $HOME/perl5/perlbrew/etc/bashrc && \
+  perlbrew --notest install perl-5.10.0
+
+ENV CMAKE /opt/python/cp27-cp27mu/bin/cmake
+# build libtiledb (core)
+# notes:
+#    1) we are using auditwheel from https://github.com/pypa/auditwheel
+#       this verifies and tags wheel products with the manylinux1 label,
+#       and allows us to build libtiledb once, install it to a normal
+#       system path, and then use it to build wheels for all of the python
+#       versions.
+#    2) perl-5.10.0, buit above, is required to build OpenSSL
+RUN cd /home/tiledb/ && \
+  source $HOME/perl5/perlbrew/etc/bashrc && \
+  perlbrew use perl-5.10.0 && \
+  git clone https://github.com/TileDB-Inc/TileDB && \
+  git -C TileDB checkout $TILEDB_VERSION && \
+  mkdir build && \
+  cd build && \
+  $CMAKE -DTILEDB_S3=ON -DTILEDB_HDFS=ON -DTILEDB_TESTS=OFF \
+         -DTILEDB_FORCE_ALL_DEPS:BOOL=ON -DSANITIZER="OFF;-DCOMPILER_SUPPORTS_AVX2:BOOL=FALSE" \
+         ../TileDB && \
+  make -j2 && \
+  make install-tiledb
+
+ADD build.sh /usr/bin/build.sh
+RUN chmod +x /usr/bin/build.sh

--- a/misc/pypi_linux/build.sh
+++ b/misc/pypi_linux/build.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# USAGE
+#------
+# 1) docker build .
+# - copy resulting IMAGE_HASH
+# 2) docker run -v wheels:/wheels -ti IMAGE_HASH build.sh
+#
+# testing (e.g. using the official python docker images)
+# - $ docker run -v `pwd`/wheels:/wheels --rm -ti python bash
+# -- pip3 install /wheels/*cp37*.whl
+# -- python3.7 -c "import tiledb; print(tiledb.libtiledb.version())"
+set -ex
+
+# build python27 wheel
+cd /home/tiledb
+git clone https://github.com/TileDB-Inc/TileDB-Py
+git -C TileDB-Py checkout $TILEDB_PY_VERSION
+
+cd /home/tiledb/TileDB-Py
+/opt/python/cp27-cp27mu/bin/python2.7 setup.py build_ext bdist_wheel --tiledb=/usr/local
+auditwheel repair dist/*.whl
+
+# build python37 wheel
+cd /home/tiledb
+git clone https://github.com/TileDB-Inc/TileDB-Py TileDB-Py3
+git -C TileDB-Py3 checkout $TILEDB_PY_VERSION
+
+cd /home/tiledb/TileDB-Py3
+/opt/python/cp37-cp37m/bin/python3.7 setup.py build_ext bdist_wheel --tiledb=/usr/local
+auditwheel repair dist/*.whl
+
+# copy build products out
+cp /home/tiledb/TileDB-Py/wheelhouse/* /wheels && \
+cp /home/tiledb/TileDB-Py3/wheelhouse/* /wheels
+

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -12,9 +12,12 @@ if os.name == "posix":
 else:
     lib_name = "tiledb"
 
-# Load the bundled TileDB dynamic library if it exists. This must occur before importing from libtiledb.
-# On Windows we put the DLLs next to .pyd out of necessity, so this can be skipped.
-if os.name != 'nt':
+# On Windows and whl builds, we may have a shared library already linked, or
+# adjacent to, the cython .pyd shared object. In this case, we can import directly
+# from .libtiledb
+try:
+    from .libtiledb import Ctx
+except:
     try:
         lib_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "native")
         ctypes.CDLL(os.path.join(lib_dir, lib_name))


### PR DESCRIPTION
Adds Dockerfile and associated build script to create manylinux1
wheels for TileDB-Py targeting py27 and py37
- introduce Dockerfile inheriting from manylinux1
- improve build system support for linux wheel packaging

(also includes a fix to allow overriding the cmake binary, which should help to fix doc builds on RTD)