### PR TITLE
Added support for numpy complex types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,19 +29,23 @@ script:
   - echo "Installing wheel file from $whl_file..."
   - pip install $whl_file
   - python -c "import tiledb ; tiledb.libtiledb.version()"
-  - python $TRAVIS_BUILD_DIR/examples/quickstart_dense.py
-  - python $TRAVIS_BUILD_DIR/examples/quickstart_sparse.py
-  - python $TRAVIS_BUILD_DIR/examples/quickstart_kv.py
-  - python $TRAVIS_BUILD_DIR/examples/reading_dense_layouts.py
-  - python $TRAVIS_BUILD_DIR/examples/reading_sparse_layouts.py
-  - python $TRAVIS_BUILD_DIR/examples/writing_dense_multiple.py
-  - python $TRAVIS_BUILD_DIR/examples/writing_dense_padding.py
-  - python $TRAVIS_BUILD_DIR/examples/writing_sparse_multiple.py
-  - python $TRAVIS_BUILD_DIR/examples/config.py
-  - python $TRAVIS_BUILD_DIR/examples/errors.py
-  - python $TRAVIS_BUILD_DIR/examples/fragments_consolidation.py
-  - python $TRAVIS_BUILD_DIR/examples/kv.py
-  - python $TRAVIS_BUILD_DIR/examples/multi_attribute.py
-  - rm -rf my_group && python $TRAVIS_BUILD_DIR/examples/object.py
-  - python $TRAVIS_BUILD_DIR/examples/vfs.py
-  - python $TRAVIS_BUILD_DIR/examples/using_tiledb_stats.py
+  - mkdir -p $TRAVIS_BUILD_DIR/test_examples && cd $TRAVIS_BUILD_DIR/test_examples
+  - python ../examples/quickstart_dense.py
+  - python ../examples/quickstart_sparse.py
+  - python ../examples/quickstart_kv.py
+  - python ../examples/reading_dense_layouts.py
+  - python ../examples/reading_sparse_layouts.py
+  - python ../examples/writing_dense_multiple.py
+  - python ../examples/writing_dense_padding.py
+  - python ../examples/writing_sparse_multiple.py
+  - python ../examples/config.py
+  - python ../examples/fragments_consolidation.py
+  - python ../examples/kv.py
+  - python ../examples/multi_attribute.py
+  - python ../examples/errors.py
+  - rm -rf my_group
+  - python ../examples/object.py
+  - python ../examples/vfs.py
+  - python ../examples/using_tiledb_stats.py
+  - cd ..
+  - rm -rf test_examples

--- a/examples/multi_attribute.py
+++ b/examples/multi_attribute.py
@@ -57,7 +57,7 @@ def create_array():
     schema = tiledb.ArraySchema(domain=dom, sparse=False,
                                 attrs=[tiledb.Attr(name="a1", dtype=np.uint8),
                                        tiledb.Attr(name="a2",
-                                                   dtype=np.dtype([("", np.float32), ("", np.float32)]))])
+                                                   dtype=np.dtype([("", np.float32), ("", np.float32), ("", np.float32)]))])
 
     # Create the (empty) array on disk.
     tiledb.DenseArray.create(array_name, schema)
@@ -68,11 +68,11 @@ def write_array():
     with tiledb.DenseArray(array_name, mode='w') as A:
         data_a1 = np.array((list(map(ord, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
                                            'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p']))))
-        data_a2 = np.array(([(1.1, 1.2), (2.1, 2.2), (3.1, 3.2), (4.1, 4.2),
-                             (5.1, 5.2), (6.1, 6.2), (7.1, 7.2), (8.1, 8.2),
-                             (9.1, 9.2), (10.1, 10.2), (11.1, 11.2), (12.1, 12.2),
-                             (13.1, 13.2), (14.1, 14.2), (15.1, 15.2), (16.1, 16.2)]),
-                           dtype=[("", np.float32), ("", np.float32)])
+        data_a2 = np.array(([(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3), (4.1, 4.2, 4.3),
+                             (5.1, 5.2, 5.3), (6.1, 6.2, 6.3), (7.1, 7.2, 7.3), (8.1, 8.2, 8.3),
+                             (9.1, 9.2, 9.3), (10.1, 10.2, 10.3), (11.1, 11.2, 11.3), (12.1, 12.2, 12.3),
+                             (13.1, 13.2, 13.3), (14.1, 14.2, 14.3), (15.1, 15.2, 15.3), (16.1, 16.2, 16.3)]),
+                           dtype=[("", np.float32), ("", np.float32), ("", np.float32)])
         A[:, :] = {"a1": data_a1, "a2": data_a2}
 
 
@@ -84,7 +84,7 @@ def read_array():
         print("Reading both attributes a1 and a2:")
         a1, a2 = data["a1"].flat, data["a2"].flat
         for i, v in enumerate(a1):
-            print("a1: '%s', a2: (%.1f, %.1f)" % (chr(v), a2[i][0], a2[i][1]))
+            print("a1: '%s', a2: (%.1f,%.1f,%.1f)" % (chr(v), a2[i][0], a2[i][1], a2[i][2]))
 
 
 def read_array_subselect():

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1657,7 +1657,7 @@ cdef class Attr(object):
             if typ == TILEDB_CHAR:
                 return np.dtype((nptyp, ncells))
             # special case for complex types of size 2
-            if ncells == 2:
+            if ncells == 2 and (nptyp == np.float32 or nptyp == np.float64):
                 return np.dtype(_numpy_type(typ, 2))
             # create an anon record dtype
             return np.dtype([('', nptyp)] * ncells)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -823,10 +823,19 @@ class DenseArrayTest(DiskTestCase):
         ctx = tiledb.Ctx()
         a = np.array(['ab', 'cd', 'ef', 'gh', 'ij', 'kl'], dtype='|S2')
         with tiledb.from_numpy(self.path('fixed_string'), a) as T:
-            R = tiledb.open(self.path('fixed_string'))
-            self.assertEqual(T.dtype, R.dtype)
-            self.assertEqual(R.attr(0).ncells, 2)
-            assert_array_equal(T,R)
+            with tiledb.open(self.path('fixed_string')) as R:
+                self.assertEqual(T.dtype, R.dtype)
+                self.assertEqual(R.attr(0).ncells, 2)
+                assert_array_equal(T,R)
+
+    def test_ncell_int(self):
+        a = np.array([(1, 2), (3, 4), (5, 6)], dtype=[("", np.int16), ("", np.int16)])
+        with tiledb.from_numpy(self.path('ncell_int16'), a) as T:
+            with tiledb.open(self.path('ncell_int16')) as R:
+                self.assertEqual(T.dtype, R.dtype)
+                self.assertEqual(R.attr(0).ncells, 2)
+                assert_array_equal(T,R)
+
 
     def test_open_with_timestamp(self):
         import time

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -819,6 +819,15 @@ class DenseArrayTest(DiskTestCase):
             assert_array_equal(A[310:], T[310:])
             assert_array_equal(A[:, 7:], T[:, 7:])
 
+    def test_fixed_string(self):
+        ctx = tiledb.Ctx()
+        a = np.array(['ab', 'cd', 'ef', 'gh', 'ij', 'kl'], dtype='|S2')
+        with tiledb.from_numpy(self.path('fixed_string'), a) as T:
+            R = tiledb.open(self.path('fixed_string'))
+            self.assertEqual(T.dtype, R.dtype)
+            self.assertEqual(R.attr(0).ncells, 2)
+            assert_array_equal(T,R)
+
     def test_open_with_timestamp(self):
         import time
         A = np.zeros(3)
@@ -901,7 +910,7 @@ class DenseArrayTest(DiskTestCase):
         attr = tiledb.Attr(ctx=ctx, dtype=np.complex64)
         schema = tiledb.ArraySchema(ctx=ctx, domain=dom, attrs=(attr,))
         tiledb.DenseArray.create(self.path("foo"), schema)
-        A = np.ones(10, dtype=np.complex64) + 1j
+        A = np.random.rand(20).astype(np.float32).view(dtype=np.complex64)
         attr.dump()
         self.assertEqual(A.dtype, attr.dtype)
 


### PR DESCRIPTION
Added support and tests for numpy complex data types.

There is an assumption that array sizes that are equal to two and are of type float 32/64 are to be interpreted as complex data types. This seems reasonable and follows numpy. 