### PR TITLE
Fix memory leak

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
     architecture: 'x64'
 
 - script: |
-    python -m pip install --upgrade pip setuptools wheel numpy tox setuptools-scm cython
+    python -m pip install --upgrade pip setuptools wheel numpy tox setuptools-scm cython psutil
   displayName: 'Install dependencies'
 
 - script: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.7.2
 setuptools>=18.0.1
 setuptools-scm>=1.5.4
 wheel>=0.30.0
+psutil

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,4 @@ setuptools==40.8.0
 setuptools-scm==1.5.4
 wheel==0.30.0
 tox==3.0.0
+psutil

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ import sys
 from sys import version_info as ver
 
 # Target branch
-TILEDB_VERSION = "dev"
+TILEDB_VERSION = "1.5.1"
 
 # Use `setup.py [] --debug` for a debug build of libtiledb
 TILEDB_DEBUG_BUILD = False

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3823,11 +3823,11 @@ cdef class Array(object):
                 # note: must not divide by itemsize for a string, because it may be zero (e.g 'S0')
                 dims[0] = el_bytelen / el_dtype.base.itemsize
                 newobj = \
-                    PyArray_NewFromDescr(
+                    np.copy(PyArray_NewFromDescr(
                         <PyTypeObject*> np.ndarray,
                         el_dtype.base, 1, dims, NULL,
                         el_ptr,
-                        np.NPY_ENSURECOPY, <object> NULL)
+                        0, <object> NULL))
 
             # set the output object
             out_flat[el] = newobj

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2377,7 +2377,7 @@ cdef class KV(object):
 
     @staticmethod
     def create(uri, KVSchema schema, key=None, Ctx ctx=default_ctx()):
-        """Creates a persistent KV at the given URI, returns a KV class instance
+        """Creates a persistent KV at the given URI
         """
         cdef tiledb_ctx_t* ctx_ptr = ctx.ptr
         cdef bytes buri = unicode_path(uri)
@@ -2404,7 +2404,7 @@ cdef class KV(object):
         if rc != TILEDB_OK:
             _raise_ctx_err(ctx_ptr, rc)
 
-        return KV(uri, key=key, ctx=ctx)
+        return
 
     def __init__(self, uri, mode='r', key=None, timestamp=None, Ctx ctx=default_ctx()):
         cdef tiledb_ctx_t* ctx_ptr = ctx.ptr

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3405,6 +3405,7 @@ cdef class Array(object):
         cdef uint64_t _timestamp = 0
         if timestamp is not None:
             _timestamp = <uint64_t> timestamp
+
         # allocate and then open the array
         cdef tiledb_array_t* array_ptr = NULL
         cdef int rc = TILEDB_OK
@@ -3431,9 +3432,12 @@ cdef class Array(object):
 
         # view on a single attribute
         if attr and not any(attr == schema.attr(i).name for i in range(schema.nattr)):
+            tiledb_array_close(ctx_ptr, array_ptr)
+            tiledb_array_free(&array_ptr)
             raise KeyError("No attribute matching '{}'".format(attr))
         else:
             self.view_attr = unicode(attr) if (attr is not None) else None
+
         self.ctx = ctx
         self.uri = unicode(uri)
         self.mode = unicode(mode)

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -4,9 +4,11 @@ import glob
 import os
 import shutil
 import tempfile
+import traceback
 from unittest import TestCase
 
 class DiskTestCase(TestCase):
+    pathmap = dict()
 
     def setUp(self):
         prefix = 'tiledb-' + self.__class__.__name__
@@ -20,8 +22,14 @@ class DiskTestCase(TestCase):
             except OSError as exc:
                 print("test '{}' error deleting '{}'".format(self.__class__.__name__,
                                                              dirpath))
-                raise
+                print("registered paths and originating functions:")
+                for path,frame in self.pathmap.items():
+                    print("  '{}' <- '{}'".format(path,frame))
+                raise exc
 
     def path(self, path):
-        return os.path.abspath(os.path.join(self.rootdir, path))
+        out = os.path.abspath(os.path.join(self.rootdir, path))
+        frame = traceback.extract_stack(limit=2)[-2][2]
+        self.pathmap[out] = frame
+        return out
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1046,14 +1046,13 @@ class DenseVarlen(DiskTestCase):
         att = tiledb.Attr(dtype=np.float64, var=True, ctx=ctx)
 
         schema = tiledb.ArraySchema(dom, (att,), ctx=ctx)
-
         tiledb.DenseArray.create(self.path("foo"), schema)
         with tiledb.DenseArray(self.path("foo"), mode='w', ctx=ctx) as T:
             T[:] = A
 
         with tiledb.DenseArray(self.path("foo"), mode='r', ctx=ctx) as T:
             T_ = T[:]
-            self.assertEqual(len(A), len(T))
+            self.assertEqual(len(A), len(T_))
             # can't use assert_array_equal w/ np.object array
             self.assertTrue(all(np.array_equal(x,A[i]) for i,x in enumerate(T_)))
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1749,8 +1749,7 @@ class KVArray(DiskTestCase):
         a1 = tiledb.Attr("value", dtype=bytes, ctx=ctx)
         schema = tiledb.KVSchema(ctx, attrs=(a1,))
         # persist kv schema
-        kv = tiledb.KV.create(self.path("foo"), schema, ctx=ctx)
-        self.assertNotEqual(kv, None)
+        tiledb.KV.create(self.path("foo"), schema, ctx=ctx)
         self.assertEqual(tiledb.KVSchema.load(self.path("foo"), ctx=ctx), schema)
 
     def test_kv_contains(self):
@@ -1798,8 +1797,7 @@ class KVArray(DiskTestCase):
         schema = tiledb.KVSchema(attrs=(a1,), ctx=ctx)
 
         # persist kv schema
-        kv = tiledb.KV.create(self.path("foo1"), schema, ctx=ctx)
-        kv.close()
+        tiledb.KV.create(self.path("foo1"), schema, ctx=ctx)
 
         def append_kv(path, k, v):
             kv = tiledb.KV(path, mode='w', ctx=ctx)
@@ -1850,18 +1848,19 @@ class KVArray(DiskTestCase):
 
     def test_kv_update_reload(self):
         # create a kv array
-        ctx = tiledb.Ctx()
-        a1 = tiledb.Attr("val", ctx=ctx, dtype=bytes)
+        ctx1 = tiledb.Ctx()
+        ctx2 = tiledb.Ctx()
+        a1 = tiledb.Attr("val", ctx=ctx1, dtype=bytes)
         # persist kv schema
-        schema = tiledb.KVSchema(attrs=(a1,), ctx=ctx)
-        tiledb.KV.create(self.path("foo"), schema, ctx=ctx)
+        schema = tiledb.KVSchema(attrs=(a1,), ctx=ctx1)
+        tiledb.KV.create(self.path("foo"), schema, ctx=ctx1)
 
         # load kv array
-        with tiledb.KV(self.path("foo"), mode='w', ctx=ctx) as kv1:
+        with tiledb.KV(self.path("foo"), mode='w', ctx=ctx1) as kv1:
             kv1['foo'] = 'bar'
             kv1.flush()
 
-            with tiledb.KV(self.path("foo"), mode='r', ctx=ctx) as kv2:
+            with tiledb.KV(self.path("foo"), mode='r', ctx=ctx2) as kv2:
                 self.assertTrue('foo' in kv2)
                 kv1['bar'] = 'baz'
                 kv1.flush()

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1610,7 +1610,7 @@ class ArrayViewTest(DiskTestCase):
             T[:] = {'': anon_ar, 'named': named_ar}
 
         with self.assertRaises(KeyError):
-            T = tiledb.DenseArray(uri, 'r', attr="foo111")
+            T = tiledb.DenseArray(uri, 'r', attr="foo111", ctx=ctx)
 
         with tiledb.DenseArray(uri, 'r', attr="named", ctx=ctx) as T:
             assert_array_equal(T, named_ar)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1606,13 +1606,13 @@ class ArrayViewTest(DiskTestCase):
         anon_ar = np.random.rand(3, 3)
         named_ar = np.random.rand(3, 3)
 
-        with tiledb.DenseArray(uri, 'w') as T:
+        with tiledb.DenseArray(uri, 'w', ctx=ctx) as T:
             T[:] = {'': anon_ar, 'named': named_ar}
 
         with self.assertRaises(KeyError):
             T = tiledb.DenseArray(uri, 'r', attr="foo111")
 
-        with tiledb.DenseArray(uri, 'r', attr="named") as T:
+        with tiledb.DenseArray(uri, 'r', attr="named", ctx=ctx) as T:
             assert_array_equal(T, named_ar)
             # make sure each attr view can pickle and round-trip
             with io.BytesIO() as buf:
@@ -1621,7 +1621,7 @@ class ArrayViewTest(DiskTestCase):
                 with pickle.load(buf) as T_rt:
                     assert_array_equal(T, T_rt)
 
-        with tiledb.DenseArray(uri, 'r', attr="") as T:
+        with tiledb.DenseArray(uri, 'r', attr="", ctx=ctx) as T:
             assert_array_equal(T, anon_ar)
 
             with io.BytesIO() as buf:
@@ -1632,10 +1632,10 @@ class ArrayViewTest(DiskTestCase):
 
         # set subarray on multi-attribute
         range_ar = np.arange(0,9).reshape(3,3)
-        with tiledb.DenseArray(uri, 'w', attr='named') as V_named:
+        with tiledb.DenseArray(uri, 'w', attr='named', ctx=ctx) as V_named:
             V_named[1:3,1:3] = range_ar[1:3,1:3]
 
-        with tiledb.DenseArray(uri, 'r', attr='named') as V_named:
+        with tiledb.DenseArray(uri, 'r', attr='named', ctx=ctx) as V_named:
             assert_array_equal(V_named[1:3,1:3], range_ar[1:3,1:3])
 
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1559,9 +1559,9 @@ class PickleTest(DiskTestCase):
             with io.BytesIO() as buf, tiledb.DenseArray(uri) as V:
                 pickle.dump(V, buf)
                 buf.seek(0)
-                V2 = pickle.load(buf)
-                # make sure anonymous view pickles and round-trips
-                assert_array_equal(V, V2)
+                with pickle.load(buf) as V2:
+                    # make sure anonymous view pickles and round-trips
+                    assert_array_equal(V, V2)
 
     def test_pickle_with_config(self):
         import io, pickle


### PR DESCRIPTION
`PyArray_NewFromDescr` ignores the `NPY_ARRAY_OWNDATA` flag, so we
need to set it manually so that NumPy frees the memory.

Fixes #150