### PR TITLE
allow Array.create() to take an optional ctx to override schema

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3339,11 +3339,14 @@ cdef class Array(object):
         return self.ctx
 
     @staticmethod
-    def create(uri, ArraySchema schema, key=None):
+    def create(uri, ArraySchema schema, key=None, Ctx ctx=None):
         """Creates a persistent TileDB Array at the given URI
 
         :param str uri: URI at which to create the new empty array.
         :param ArraySchema schema: Schema for the array
+        :param str key: (default None) Encryption key to use for array
+        :param ctx Ctx: (default None) Optional TileDB Ctx used when creating the array,
+                        by default uses the ArraySchema's associated context.
         """
         cdef tiledb_ctx_t* ctx_ptr = schema.ctx.ptr
         cdef bytes buri = unicode_path(uri)
@@ -3362,8 +3365,11 @@ cdef class Array(object):
                 bkey = bytes(key)
             key_type = TILEDB_AES_256_GCM
             key_ptr = <void *> PyBytes_AS_STRING(bkey)
-            #TODO: unsafe cast here ssize_t -> uint64_t;t
+            #TODO: unsafe cast here ssize_t -> uint64_t
             key_len = <unsigned int> PyBytes_GET_SIZE(bkey)
+        
+        if ctx is not None:
+            ctx_ptr = ctx.ptr
 
         cdef int rc = TILEDB_OK
         with nogil:

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -515,6 +515,19 @@ class ArrayTest(DiskTestCase):
             # cannot re-open a closed array
             array.reopen()
 
+    def test_array_create_with_ctx(self):
+        config = tiledb.Config()
+        config["sm.consolidation.step_min_frag"] = 0
+        config["sm.consolidation.steps"] = 1
+        ctx = tiledb.Ctx(config=config)
+        schema = self.create_array_schema(ctx)
+
+        with self.assertRaises(TypeError):
+            tiledb.libtiledb.Array.create(self.path("foo"), schema, ctx="foo")
+
+        # persist array schema
+        tiledb.libtiledb.Array.create(self.path("foo"), schema, ctx=tiledb.Ctx())
+
     def test_array_create_encrypted(self):
         config = tiledb.Config()
         config["sm.consolidation.step_min_frags"] = 0


### PR DESCRIPTION
closes #161 