### PR TITLE
Fix PyPI wheel build for TileDB 1.6

### DIFF
--- a/misc/pypi_linux/Dockerfile
+++ b/misc/pypi_linux/Dockerfile
@@ -21,9 +21,14 @@ ENV CMAKE /opt/python/cp27-cp27mu/bin/cmake
 
 ###############################################
 # settings (B)
-ENV TILEDB_VERSION 1.5.0
-ENV TILEDB_PY_VERSION 0.4.0
+ENV TILEDB_VERSION dev
+ENV TILEDB_PY_VERSION dev
 ###############################################
+# 1) Nothing builds under GCC 4.8 due to default constructor unused-parameter warnings
+# 2) adding -lrt as a work-around for now because python2.7 doesn't link it, but it
+#    ends up as an unlinked dependency.
+ENV CXXFLAGS -Wno-unused-parameter -lrt
+ENV CFLAGS -Wno-unused-parameter -lrt
 
 # build libtiledb (core)
 # notes:
@@ -40,10 +45,10 @@ RUN cd /home/tiledb/ && \
   git -C TileDB checkout $TILEDB_VERSION && \
   mkdir build && \
   cd build && \
-  $CMAKE -DTILEDB_S3=ON -DTILEDB_HDFS=ON -DTILEDB_TESTS=OFF \
+  $CMAKE -DTILEDB_S3=ON -DTILEDB_CPP_API=OFF -DTILEDB_HDFS=ON -DTILEDB_TESTS=OFF \
          -DTILEDB_FORCE_ALL_DEPS:BOOL=ON -DSANITIZER="OFF;-DCOMPILER_SUPPORTS_AVX2:BOOL=FALSE" \
          ../TileDB && \
-  make -j2 && \
+  make -j8 && \
   make install-tiledb
 
 ADD misc/pypi_linux/build.sh /usr/bin/build.sh

--- a/misc/pypi_linux/build.sh
+++ b/misc/pypi_linux/build.sh
@@ -5,7 +5,7 @@
 # 0) cd TileDB-Py (NOTE: root directory!)
 # 1) docker build -f misc/pypi_linux/Dockerfile .
 # - copy resulting IMAGE_HASH
-# 2) docker run -v wheels:/wheels -ti IMAGE_HASH build.sh
+# 2) docker run -v misc/pypi_linux/wheels:/wheels -ti IMAGE_HASH build.sh
 #
 # testing (e.g. using the official python docker images)
 # - $ docker run -v `pwd`/wheels:/wheels --rm -ti python bash
@@ -13,7 +13,6 @@
 # -- python3.7 -c "import tiledb; print(tiledb.libtiledb.version())"
 set -ex
 
-export TILEDB_PY_VERSION="0.4.2"
 export TILEDB_PY_REPO="/opt/TileDB-Py"
 
 # build python27 wheel

--- a/misc/pypi_linux/build.sh
+++ b/misc/pypi_linux/build.sh
@@ -22,9 +22,7 @@ git clone $TILEDB_PY_REPO TileDB-Py27
 git -C TileDB-Py27 checkout $TILEDB_PY_VERSION
 
 cd /home/tiledb/TileDB-Py27
-# adding -lrt as a work-around for now because python2.7 doesn't link it, but it
-# ends up as an unlinked dependency.
-CFLAGS="-lrt" /opt/python/cp27-cp27mu/bin/python2.7 setup.py build_ext bdist_wheel --tiledb=/usr/local
+/opt/python/cp27-cp27mu/bin/python2.7 setup.py build_ext bdist_wheel --tiledb=/usr/local
 auditwheel repair dist/*.whl
 
 # build python35 wheel

--- a/setup.py
+++ b/setup.py
@@ -393,10 +393,10 @@ def cmake_available():
     except:
         return False
 
-
+numpy_required_version = 'numpy<=1.16' if sys.hexversion <0x3050000 else 'numpy>=1.7'
 def setup_requires():
     req = ['cython>=0.27',
-           'numpy>=1.7',
+           numpy_required_version,
            'setuptools>=18.0',
            'setuptools_scm>=1.5.4',
            'wheel>=0.30']
@@ -497,7 +497,7 @@ setup(
     ],
     setup_requires=setup_requires(),
     install_requires=[
-        'numpy>=1.7',
+        numpy_required_version,
         'wheel>=0.30'
     ],
     tests_require=TESTS_REQUIRE,
@@ -517,8 +517,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )


### PR DESCRIPTION
- AWS SDK and TileDB core have a number of default constructors which cause
  'unused parameter' warnings under GCC 4.8. I have manually run unit tests
  against Minio with a GCC 4.8 build, and all tests passed.

- ~~disable ~~HDFS and CPP_API, which don't make sense to build for the wheel.~~ 