### PR TITLE
WIP: statically linked cython extension

### DIFF
--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -15,16 +15,16 @@ else:
 # On Windows and whl builds, we may have a shared library already linked, or
 # adjacent to, the cython .pyd shared object. In this case, we can import directly
 # from .libtiledb
-try:
-    import tiledb
-    from .libtiledb import Ctx
-except:
-    try:
-        lib_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "native")
-        ctypes.CDLL(os.path.join(lib_dir, lib_name))
-    except OSError as e:
-        # Otherwise try loading by name only.
-        ctypes.CDLL(lib_name)
+#try:
+#    import tiledb
+#    from .libtiledb import Ctx
+#except:
+#    try:
+#        lib_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "native")
+#        ctypes.CDLL(os.path.join(lib_dir, lib_name))
+#    except OSError as e:
+#        # Otherwise try loading by name only.
+#        ctypes.CDLL(lib_name)
 
 from .libtiledb import (
      Array,


### PR DESCRIPTION
This works with a static TileDB build as long as TBB is disabled:

```
~/git/TileDB-Py$ ldd /home/ubuntu/miniconda3/envs/tiledb/lib/python3.7/site-packages/tiledb-0.4.4.dev1+dirty-py3.7-linux-x86_64.egg/tiledb/libtiledb.cpython-37m-x86_64-linux-gnu.so
        linux-vdso.so.1 (0x00007ffdeb9ac000)
        libstdc++.so.6 => /home/ubuntu/miniconda3/envs/tiledb/lib/libstdc++.so.6 (0x00007f5bff462000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f5bfe3a2000)
        libgcc_s.so.1 => /home/ubuntu/miniconda3/envs/tiledb/lib/libgcc_s.so.1 (0x00007f5bff445000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f5bfe183000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f5bfdd92000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f5bff37e000)
```

Building against libtiledb w/ TBB fails due to a missing symbol `_ZTIN3tbb4taskE`. That symbol only seems to be exported from the debug version of TBB .a files (our static builds otherwise seem to work, so I'm not sure exactly what the issue is).

---

note: if/when this is needed, will need to do the same thing as https://github.com/TileDB-Inc/TileDB/pull/1461 with the extra objects, to prevent symbol conflicts.