### PR TITLE
Add `domain_index` operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,6 @@ install:
 script:
   # Build and test extension module
   - python setup.py build_ext --inplace
-  # Run doctests
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then (LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/tiledb:$LD_LIBRARY_PATH" python -m doctest -o NORMALIZE_WHITESPACE -f tiledb/libtiledb.pyx); fi
-  # Run unittests
-  - export LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/tiledb:$LD_LIBRARY_PATH"
-  - python -m unittest tiledb.tests.all.suite_test
   # Check wheel build
   - python setup.py bdist_wheel
   - whl_file=`pwd`/dist/`ls dist`
@@ -28,23 +23,9 @@ script:
   - echo "Installing wheel file from $whl_file..."
   - pip install $whl_file
   - python -c "import tiledb ; tiledb.libtiledb.version()"
-  - mkdir -p $TRAVIS_BUILD_DIR/test_examples && cd $TRAVIS_BUILD_DIR/test_examples
-  - python ../examples/quickstart_dense.py
-  - python ../examples/quickstart_sparse.py
-  - python ../examples/quickstart_kv.py
-  - python ../examples/reading_dense_layouts.py
-  - python ../examples/reading_sparse_layouts.py
-  - python ../examples/writing_dense_multiple.py
-  - python ../examples/writing_dense_padding.py
-  - python ../examples/writing_sparse_multiple.py
-  - python ../examples/config.py
-  - python ../examples/fragments_consolidation.py
-  - python ../examples/kv.py
-  - python ../examples/multi_attribute.py
-  - python ../examples/errors.py
-  - rm -rf my_group
-  - python ../examples/object.py
-  - python ../examples/vfs.py
-  - python ../examples/using_tiledb_stats.py
-  - cd ..
-  - rm -rf test_examples
+  - popd
+  # Run unittests
+  - export LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/tiledb:$LD_LIBRARY_PATH"
+  - python -m unittest tiledb.tests.all.suite_test
+  # Run doctests
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then (LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/tiledb:$LD_LIBRARY_PATH" python -m doctest -o NORMALIZE_WHITESPACE -f tiledb/libtiledb.pyx); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 language: python
 python:
   - "2.7"
-  - "3.5"
   - "3.6"
 
 notifications:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,12 +42,14 @@ steps:
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - script: |
+    set -xeo pipefail
     python setup.py build_ext --inplace
     python setup.py install
   displayName: 'Build TileDB and TileDB-Py extension (POSIX)'
   condition: ne(variables['Agent.OS'], 'Windows_NT')
 
 - bash: |
+    set -xeo pipefail
     python -m unittest tiledb.tests.all.suite_test
 
     # Test wheel build, install, and run
@@ -60,7 +62,7 @@ steps:
   displayName: 'Run tests'
 
 - bash: |
-    set -e pipefail
+    set -xeo pipefail
     # Display log files if the build failed
     echo "Dumping log files for failed build"
     echo "----------------------------------"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ steps:
   displayName: 'Build TileDB and TileDB-Py extension (Windows)'
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 
-- script: |
+- bash: |
     set -xeo pipefail
     python setup.py build_ext --inplace
     python setup.py install
@@ -54,9 +54,9 @@ steps:
 
     # Test wheel build, install, and run
     python setup.py bdist_wheel
-    whl_file=`pwd`/dist/`ls dist`
+    whl_file=`pwd`/dist/`ls dist/*.whl`
     pushd /tmp
-    echo "Installing wheel file from $whl_file..."
+    echo "Installing wheel file: '$whl_file'"
     pip install $whl_file
     python -c "import tiledb ; tiledb.libtiledb.version()"
   displayName: 'Run tests'

--- a/examples/errors.py
+++ b/examples/errors.py
@@ -41,4 +41,8 @@ try:
 except tiledb.TileDBError as e:
     print("TileDB exception: %s" % e.message)
 
+# clean up
+if tiledb.VFS().is_dir("my_group"):
+    tiledb.remove("my_group")
+
 # Setting a different error handler for the context is not yet supported.

--- a/examples/object.py
+++ b/examples/object.py
@@ -51,6 +51,7 @@ from __future__ import print_function
 
 import numpy as np
 import tiledb
+import os
 
 
 def create_array(array_name, sparse):
@@ -71,22 +72,23 @@ def create_kv(array_name):
     schema = tiledb.KVSchema(attrs=[tiledb.Attr(name="a", dtype=bytes)])
     tiledb.KV.create(array_name, schema)
 
+def path(p):
+    return os.path.join(os.getcwd(), p)
 
 def create_hierarchy():
-
     # Create groups
-    tiledb.group_create("my_group")
-    tiledb.group_create("my_group/dense_arrays")
-    tiledb.group_create("my_group/sparse_arrays")
+    tiledb.group_create(path("my_group"))
+    tiledb.group_create(path("my_group/dense_arrays"))
+    tiledb.group_create(path("my_group/sparse_arrays"))
 
     # Create arrays
-    create_array("my_group/dense_arrays/array_A", False)
-    create_array("my_group/dense_arrays/array_B", False)
-    create_array("my_group/sparse_arrays/array_C", True)
-    create_array("my_group/sparse_arrays/array_D", True)
+    create_array(path("my_group/dense_arrays/array_A"), False)
+    create_array(path("my_group/dense_arrays/array_B"), False)
+    create_array(path("my_group/sparse_arrays/array_C"), True)
+    create_array(path("my_group/sparse_arrays/array_D"), True)
 
     # Create key-value store
-    create_kv("my_group/dense_arrays/kv")
+    create_kv(path("my_group/dense_arrays/kv"))
 
 
 def list_obj(path):
@@ -104,12 +106,15 @@ def list_obj(path):
 
 
 def move_remove_obj():
-    tiledb.move("my_group", "my_group_2")
-    tiledb.remove("my_group_2/dense_arrays")
-    tiledb.remove("my_group_2/sparse_arrays/array_C")
+    tiledb.move(path("my_group"), path("my_group_2"))
+    tiledb.remove(path("my_group_2/dense_arrays"))
+    tiledb.remove(path("my_group_2/sparse_arrays/array_C"))
 
 
 create_hierarchy()
 list_obj("my_group")
 move_remove_obj()  # Renames 'my_group' to 'my_group_2'
 list_obj("my_group_2")
+
+# clean up
+tiledb.remove("my_group_2")

--- a/examples/variable_length.py
+++ b/examples/variable_length.py
@@ -42,7 +42,7 @@ def generate_data():
 
     a2_data = np.array(
                 list(map(
-                    lambda v: np.repeat(v[0], v[1]),
+                    lambda v: np.repeat(v[0], v[1]).astype(np.int64),
                     [
                     (1,1), (2,2), (3,1), (4,1),
                     (5,1), (6,2), (7,2), (8,3),

--- a/examples/vfs.py
+++ b/examples/vfs.py
@@ -34,7 +34,10 @@
 
 import struct
 import tiledb
+import os
 
+def path(p):
+    return os.path.join(os.getcwd(), p)
 
 def dirs_files():
     # Create TileDB VFS
@@ -42,29 +45,29 @@ def dirs_files():
 
     # Create directory
     if not vfs.is_dir("dir_A"):
-        vfs.create_dir("dir_A")
+        vfs.create_dir(path("dir_A"))
         print("Created 'dir_A'")
     else:
         print("'dir_A' already exists")
 
     # Creating an (empty) file
     if not vfs.is_file("dir_A/file_A"):
-        vfs.touch("dir_A/file_A")
+        vfs.touch(path("dir_A/file_A"))
         print("Created empty file 'dir_A/file_A'")
     else:
         print("'dir_A/file_A' already exists")
 
     # Getting the file size
-    print("Size of file 'dir_A/file_A': {}".format(vfs.file_size("dir_A/file_A")))
+    print("Size of file 'dir_A/file_A': {}".format(vfs.file_size(path("dir_A/file_A"))))
 
     # Moving files (moving directories is similar)
     print("Moving file 'dir_A/file_A' to 'dir_A/file_B'")
-    vfs.move_file("dir_A/file_A", "dir_A/file_B")
+    vfs.move_file(path("dir_A/file_A"), path("dir_A/file_B"))
 
     # Deleting files and directories
     print("Deleting 'dir_A/file_B' and 'dir_A'")
-    vfs.remove_file("dir_A/file_B")
-    vfs.remove_dir("dir_A")
+    vfs.remove_file(path("dir_A/file_B"))
+    vfs.remove_dir(path("dir_A"))
 
 
 def write():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cmake>=3.11.0
 cython>=0.27.3
-numpy>=1.7.2
+numpy==1.16.*
 setuptools>=18.0.1
 setuptools-scm>=1.5.4
 wheel>=0.30.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,8 @@
 # pinned dependencies for the development and CI
-cmake==3.13
+# note: cmake 3.13 is the last manylinux1 release on pypi
+cmake==3.13.*
 cython==0.27.3
-numpy==1.7.2
+numpy==1.16.*
 setuptools==40.8.0
 setuptools-scm==1.5.4
 wheel==0.30.0

--- a/setup.py
+++ b/setup.py
@@ -468,7 +468,6 @@ if TILEDB_PATH != '':
 with open('README.rst') as f:
     README_RST = f.read()
 
-
 __extensions = [
   Extension(
     "tiledb.libtiledb",
@@ -482,7 +481,6 @@ __extensions = [
     language="c++"
     )
 ]
-
 
 MODULAR_SOURCES = [
   'tiledb/np2buf.pyx',

--- a/setup.py
+++ b/setup.py
@@ -483,8 +483,10 @@ __extensions = [
     )
 ]
 
+
 MODULAR_SOURCES = [
-  'tiledb/np2buf.pyx'
+  'tiledb/np2buf.pyx',
+  'tiledb/indexing.pyx',
   ]
 
 if TILEDBPY_MODULAR:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ import sys
 from sys import version_info as ver
 
 # Target branch
-TILEDB_VERSION = "1.6.0"
+TILEDB_VERSION = "dev"
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION
 

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -75,6 +75,8 @@ from .highlevel import (
      array_exists
 )
 
+from .version import version as __version__
+
 # Note: we use a modified namespace packaging to allow continuity of existing TileDB-Py imports.
 #       Therefore, 'tiledb/__init__.py' must *only* exist in this package.
 #       Furthermore, in sub-packages, the `find_packages` helper will not work at the

--- a/tiledb/common.pxi
+++ b/tiledb/common.pxi
@@ -1,5 +1,3 @@
-from libtiledb cimport *
-
 from cpython.bytes cimport (PyBytes_GET_SIZE,
                             PyBytes_AS_STRING,
                             PyBytes_Size,
@@ -47,3 +45,14 @@ cdef extern from "numpy/arrayobject.h":
     void* PyDataMem_NEW(size_t nbytes)
     void* PyDataMem_RENEW(void* data, size_t nbytes)
     void PyDataMem_FREE(void* data)
+
+
+import sys
+
+# Integer types supported by Python / System
+if sys.version_info >= (3, 0):
+    _MAXINT = 2 ** 31 - 1
+    _inttypes = (int, np.integer)
+else:
+    _MAXINT = sys.maxint
+    _inttypes = (int, long, np.integer)

--- a/tiledb/indexing.pxd
+++ b/tiledb/indexing.pxd
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from .libtiledb cimport *
+from .libtiledb cimport SparseArray, ArraySchema
 
 cdef class DomainIndexer:
     cdef SparseArray array

--- a/tiledb/indexing.pxd
+++ b/tiledb/indexing.pxd
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+
+from .libtiledb cimport *
+
+cdef class DomainIndexer:
+    cdef SparseArray array
+    cdef ArraySchema schema

--- a/tiledb/indexing.pyx
+++ b/tiledb/indexing.pyx
@@ -1,0 +1,76 @@
+from __future__ import absolute_import
+
+include "common.pxi"
+
+# ref
+#   https://github.com/TileDB-Inc/TileDB-Py/issues/102
+#   https://github.com/TileDB-Inc/TileDB-Py/issues/201
+
+def _index_as_tuple(idx):
+    """Forces scalar index objects to a tuple representation"""
+    if isinstance(idx, tuple):
+        return idx
+    return (idx,)
+
+
+cdef class DomainIndexer(object):
+
+    @staticmethod
+    def with_schema(ArraySchema schema):
+        cdef DomainIndexer indexer = DomainIndexer.__new__(DomainIndexer)
+        indexer.array = None
+        indexer.schema = schema
+        return indexer
+
+    def __init__(self, SparseArray array):
+        self.array = array
+        self.schema = array.schema
+
+    def __getitem__(self, object idx):
+        # implements domain-based indexing: slice by domain coordinates, not 0-based python indexing
+
+        cdef Domain dom = self.schema.domain
+        cdef ndim = dom.ndim
+
+        idx = _index_as_tuple(idx)
+
+        if len(idx) < dom.ndim:
+            raise IndexError("number of indices does not match domain rank: "
+                             "(got {!r}, expected: {!r})".format(len(idx), ndim))
+
+        new_idx = []
+        for i in range(dom.ndim):
+            dim = dom.dim(i)
+            dim_idx = idx[i]
+            if np.isscalar(dim_idx):
+                start = dim_idx
+                stop = dim_idx
+                new_idx.append(slice(start, stop, None))
+            else:
+                new_idx.append(dim_idx)
+
+        subarray = np.zeros(shape=(ndim, 2), dtype=dom.dtype)
+
+        for i, subidx in enumerate(new_idx):
+            assert isinstance(subidx, slice)
+            subarray[i] = subidx.start, subidx.stop
+
+        # TODO...
+        order = None
+        if order is None or order == 'C':
+            layout = TILEDB_ROW_MAJOR
+        elif order == 'F':
+            layout = TILEDB_COL_MAJOR
+        elif order == 'G':
+            layout = TILEDB_GLOBAL_ORDER
+        else:
+            raise ValueError("order must be 'C' (TILEDB_ROW_MAJOR), 'F' (TILEDB_COL_MAJOR), or 'G' (TILEDB_GLOBAL_ORDER)")
+
+        # TODO make coords optional. there are no kwargs in slicing[], so
+        #      one way to do this would be to overload __call__ and return a new
+        #      object with a flag set. not ideal.
+        attr_names = list()
+        attr_names.append("coords")
+        attr_names.extend(self.schema.attr(i).name for i in range(self.schema.nattr))
+
+        return self.array._read_sparse_subarray(subarray, attr_names, layout)

--- a/tiledb/indexing.pyx
+++ b/tiledb/indexing.pyx
@@ -1,6 +1,8 @@
-from __future__ import absolute_import
+IF TILEDBPY_MODULAR:
+  include "common.pxi"
+  from .libtiledb cimport *
 
-include "common.pxi"
+import numpy as np
 
 # ref
 #   https://github.com/TileDB-Inc/TileDB-Py/issues/102

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1,8 +1,8 @@
-from __future__ import absolute_import
-
 from libc.stdio cimport FILE
 from libc.stdint cimport uint64_t
-from tiledb.indexing cimport DomainIndexer
+
+IF TILEDBPY_MODULAR:
+    from .indexing cimport DomainIndexer
 
 include "common.pxi"
 
@@ -1268,3 +1268,7 @@ cdef class Query(object):
 cdef class ReadQuery(object):
     cdef object _buffers
     cdef object _offsets
+
+IF (not TILEDBPY_MODULAR):
+    include "indexing.pxd"
+

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4,12 +4,9 @@
 
 from __future__ import absolute_import
 
-include "common.pxi"
-
-
-
 from cpython.version cimport PY_MAJOR_VERSION
 
+include "common.pxi"
 
 import sys
 from os.path import abspath
@@ -37,12 +34,15 @@ def default_ctx():
 #    MODULAR IMPORTS                                                          #
 ###############################################################################
 
-# np2buf.pyx
 IF TILEDBPY_MODULAR:
     from .np2buf import array_to_buffer, array_type_ncells, dtype_to_tiledb
+    from .indexing import DomainIndexer
 ELSE:
+    include "indexing.pyx"
     include "np2buf.pyx"
 
+#from .np2buf import array_to_buffer, array_type_ncells, dtype_to_tiledb
+#from .indexing import DomainIndexer
 
 ###############################################################################
 #    Utility/setup                                                            #

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4453,6 +4453,9 @@ cdef class SparseArray(Array):
         super().__init__(*args, **kw)
         if not self.schema.sparse:
             raise ValueError("Array at '{}' is not a sparse array".format(self.uri))
+
+        cdef domain_index = DomainIndexer(self)
+        self.domain_index = domain_index
         return
 
     def __len__(self):
@@ -4725,6 +4728,14 @@ cdef class SparseArray(Array):
                     out[name] = arr
 
         return out
+
+    @property
+    def domain_index(self):
+        return self.domain_index
+
+    @property
+    def dindex(self):
+        return self.domain_index
 
 def consolidate(uri=None, Config config=None, key=None, Ctx ctx=default_ctx()):
     """Consolidates a TileDB Array updates for improved read performance

--- a/tiledb/np2buf.pyx
+++ b/tiledb/np2buf.pyx
@@ -3,6 +3,8 @@ IF TILEDBPY_MODULAR:
     include "common.pxi"
     from cpython.version cimport PY_MAJOR_VERSION
 
+from .libtiledb cimport *
+
 from collections import deque
 
 cdef _varlen_dtype_itemsize(object item):

--- a/tiledb/np2buf.pyx
+++ b/tiledb/np2buf.pyx
@@ -1,9 +1,8 @@
 # Set true to enable modular compilation
 IF TILEDBPY_MODULAR:
     include "common.pxi"
-    from cpython.version cimport PY_MAJOR_VERSION
-
-from .libtiledb cimport *
+    from .libtiledb import *
+    from .libtiledb cimport *
 
 from collections import deque
 

--- a/tiledb/tests/test_domain_index.py
+++ b/tiledb/tests/test_domain_index.py
@@ -1,0 +1,92 @@
+#%%
+
+import numpy as np
+import tiledb
+
+from tiledb.tests.common import *
+
+class DomainIndexingTest(DiskTestCase):
+
+    def test_fp_domain_indexing(self):
+        array_path = self.path("test_domain_idx")
+
+
+        # test case from https://github.com/TileDB-Inc/TileDB-Py/issues/201
+        tile = 1
+        dom = tiledb.Domain(tiledb.Dim(name="x", domain=(-89.75, 89.75), tile=tile, dtype=np.float64),
+                            tiledb.Dim(name="y", domain=(-179.75, 179.75), tile=tile, dtype=np.float64),
+                            tiledb.Dim(name="z", domain=(157498, 157863), tile=tile, dtype=np.float64)
+                            )
+        schema = tiledb.ArraySchema(domain=dom, sparse=True,
+                                    attrs=[tiledb.Attr(name="data", dtype=np.float64)])
+
+        tiledb.SparseArray.create(array_path, schema)
+
+        # fake data
+        X = np.linspace(*(-89.75, 89.75), 359)
+        Y = np.linspace(*(-179.75, 179.75), 359)
+        Z = np.linspace(*(157498, 157857), 359)
+
+        #data = np.random.rand(*map(lambda x: x[0], (X.shape, Y.shape, Z.shape)))
+        data = np.random.rand(X.shape[0])
+
+        with tiledb.SparseArray(array_path, mode='w') as A:
+            A[X, Y, Z] = data
+
+        with tiledb.SparseArray(array_path) as A:
+
+            # check direct slicing
+            assert_array_equal(
+                A.domain_index[ X[0], Y[0], Z[0] ]['data'],
+                data[0])
+
+            # check small slice ranges
+            tmp = A.domain_index[
+                X[0] : np.nextafter(X[0], 0), Y[0] : np.nextafter(Y[0], 0), Z[0] : np.nextafter(Z[0], Z[0] + 1)
+                ]
+            assert_array_equal(
+                tmp['data'],
+                data[0]
+            )
+
+            # check slicing last element
+            tmp = A.domain_index[ X[-1], Y[-1], Z[-1] ]
+            assert_array_equal(
+                tmp['data'],
+                data[ -1 ]
+            )
+
+            # check slice range multiple components
+            tmp = A.domain_index[ X[1]:X[2], Y[1]:Y[2], Z[1]:Z[2] ]
+            assert_array_equal(
+                tmp['data'],
+                data[1:3]
+            )
+
+            # check an interior point
+            coords = X[145], Y[145], Z[145]
+            tmp = A.domain_index[coords]
+            assert_array_equal(
+                tmp['coords'].view(np.float64),
+                np.array(coords)
+            )
+            assert_array_equal(
+                tmp['data'],
+                data[145]
+            )
+
+            # check entire domain
+            tmp = A.domain_index[X[0]:X[-1], Y[0]:Y[-1], Z[0]:Z[-1]]
+            assert_array_equal(
+                tmp['data'],
+                data[:]
+            )
+
+            # check entire domain
+            # TODO uncomment if vectorized indexing is available
+            #coords = np.array([X,Y,Z]).transpose().flatten()
+            #tmp = A.domain_index[coords]
+            #assert_array_equal(
+            #    tmp['data'],
+            #    data[:]
+            #)

--- a/tiledb/tests/test_domain_index.py
+++ b/tiledb/tests/test_domain_index.py
@@ -7,6 +7,28 @@ from tiledb.tests.common import *
 
 class DomainIndexingTest(DiskTestCase):
 
+    def test_int_domain_indexing(self):
+        path = self.path("int_domain_indexing")
+
+        dom = tiledb.Domain(tiledb.Dim(name="x", domain=(-10,10), tile=1, dtype=np.int64))
+        schema = tiledb.ArraySchema(domain=dom, sparse=True,
+                                    attrs=[tiledb.Attr(name="a", dtype=np.float64)])
+
+        tiledb.SparseArray.create(path, schema)
+
+        X = np.arange(-10,11,step=1)
+        val = np.random.rand(len(X))
+
+        with tiledb.SparseArray(path, mode='w') as A:
+            A[X] = val
+
+        with tiledb.SparseArray(path) as A:
+            assert_array_equal(A.domain_index[ X[0]]['a'], val[0])
+            assert_array_equal(A.domain_index[ X[-1]]['a'], val[-1])
+            assert_array_equal(A.domain_index[ X[0]:X[-1] ]['a'], val[:])
+            # sanity check
+            assert_array_equal(A.domain_index[ X[0]:X[-1] ]['coords'].view(np.int64), X[:])
+
     def test_fp_domain_indexing(self):
         array_path = self.path("test_domain_idx")
 

--- a/tiledb/tests/test_domain_index.py
+++ b/tiledb/tests/test_domain_index.py
@@ -45,9 +45,9 @@ class DomainIndexingTest(DiskTestCase):
         tiledb.SparseArray.create(array_path, schema)
 
         # fake data
-        X = np.linspace(*(-89.75, 89.75), 359)
-        Y = np.linspace(*(-179.75, 179.75), 359)
-        Z = np.linspace(*(157498, 157857), 359)
+        X = np.linspace(-89.75, 89.75, 359)
+        Y = np.linspace(-179.75, 179.75, 359)
+        Z = np.linspace(157498, 157857, 359)
 
         #data = np.random.rand(*map(lambda x: x[0], (X.shape, Y.shape, Z.shape)))
         data = np.random.rand(X.shape[0])

--- a/tiledb/tests/test_examples.py
+++ b/tiledb/tests/test_examples.py
@@ -1,4 +1,4 @@
-import os, sys, glob, unittest, tempfile, shutil
+import os, sys, glob, unittest, tempfile, shutil, platform
 import subprocess
 
 def run_checked(args):
@@ -27,6 +27,9 @@ class ExamplesTest(unittest.TestCase):
       args = [ex]
       run_checked(args)
 
+  # some of the doctests are missing a clean-up step on windows
+  @unittest.skipIf(platform.system() is 'Windows', "")
+  def test_docs(self):
     if sys.version_info >= (3,6):
       doctest_args = ['-m', 'doctest', '-o', 'NORMALIZE_WHITESPACE', '-f',
                       os.path.abspath(os.path.join(__file__, '../../', 'libtiledb.pyx'))]

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1177,7 +1177,7 @@ class DenseVarlen(DiskTestCase):
             self.assertTrue(np.all([np.array_equal(A.flat[i], T[:].flat[i]) for i in np.arange(0, 9)]))
 
     def test_varlen_write_int_subarray(self):
-        A = np.array(list(map(np.array,
+        A = np.array(list(map(lambda x: np.array(x, dtype=np.uint64),
                         [np.arange(i, 2 * i + 1) for i in np.arange(0, 16)])
                         ),
                      dtype='O').reshape(4,4)
@@ -1196,7 +1196,7 @@ class DenseVarlen(DiskTestCase):
         # NumPy forces single-element object arrays into a contiguous layout
         #       so we alternate the size to get a consistent baseline array.
         A_onestwos = np.array(
-            list(map(np.array,
+            list(map(lambda x: np.array(x, dtype=np.uint64),
                      list([(1,) if x % 2 == 0 else (1, 2) for x in range(16)]))),
             dtype=np.dtype('O')).reshape(4,4)
 


### PR DESCRIPTION
Add `Array.domain_index` operator, which supports slicing over any range within the domain bounds, including negative slices (previously limited for the Array[] operator by NumPy wrap-around semantics). Slice ranges are passed down to libtiledb core for range and point queries.

Fixes #102
Fixes #201