### PR TITLE
Wrap new fragment info API functions

### DIFF
--- a/tiledb/common.pxi
+++ b/tiledb/common.pxi
@@ -10,7 +10,7 @@ from libc.stdio cimport (FILE, stdout)
 from libc.stdio cimport stdout
 from libc.stdlib cimport malloc, calloc, free
 from libc.string cimport memcpy
-from libc.stdint cimport (uint8_t, uint32_t, uint64_t, int64_t, uintptr_t)
+from libc.stdint cimport (uint8_t, uint32_t, uint64_t, int64_t, uintptr_t, int32_t)
 from libc cimport limits
 from libcpp.vector cimport vector
 

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -624,6 +624,24 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_query_t* query,
         int* has_results)
 
+    int tiledb_query_get_fragment_num(
+        tiledb_ctx_t* ctx,
+        const tiledb_query_t* query,
+        uint32_t* num)
+
+    int tiledb_query_get_fragment_uri(
+        tiledb_ctx_t* ctx,
+        const tiledb_query_t* query,
+        uint64_t idx,
+        const char** uri)
+
+    int tiledb_query_get_fragment_timestamp_range(
+        tiledb_ctx_t* ctx,
+        const tiledb_query_t* query,
+        uint64_t idx,
+        uint64_t* t1,
+        uint64_t* t2)
+
     # Array
     int tiledb_array_alloc(
         tiledb_ctx_t* ctx,
@@ -1132,13 +1150,18 @@ cdef extern from "tiledb/tiledb.h":
         char* path_out,
         unsigned* path_length) nogil
 
+
+###############################################################################
+#                                                                             #
+#   TileDB-Py API declaration                                                 #
+#                                                                             #
+###############################################################################
+
 cdef class Config(object):
     cdef tiledb_config_t* ptr
 
     @staticmethod
     cdef from_ptr(tiledb_config_t* ptr)
-
-
 
 cdef class ConfigKeys(object):
     cdef ConfigItems config_items
@@ -1235,13 +1258,14 @@ cdef class ArraySchema(object):
 
 cdef class Array(object):
     cdef Ctx ctx
+    cdef tiledb_array_t* ptr
     cdef unicode uri
     cdef unicode mode
     cdef object view_attr # can be None
     cdef object key # can be None
     cdef object schema
-    cdef tiledb_array_t* ptr
     cdef DomainIndexer domain_index
+    cdef object last_fragment_info
 
     cdef _ndarray_is_varlen(self, np.ndarray array)
     cdef _unpack_varlen_query(self, ReadQuery read, unicode name)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1149,6 +1149,25 @@ class DenseArrayTest(DiskTestCase):
         with tiledb.DenseArray(uri) as T:
             assert_array_equal(A, T)
 
+    def test_written_fragment_info(self):
+        uri = self.path("test_written_fragment_info")
+
+        ctx = tiledb.Ctx()
+        dom = tiledb.Domain(tiledb.Dim(domain=(0, 9), tile=10, dtype=np.int64, ctx=ctx), ctx=ctx)
+        att = tiledb.Attr(ctx=ctx, dtype=np.int64)
+        schema = tiledb.ArraySchema(ctx=ctx, domain=dom, attrs=(att,))
+        tiledb.DenseArray.create(uri, schema)
+
+        with tiledb.DenseArray(uri, mode='w', ctx=ctx) as T:
+            T[:] = np.arange(0, 10, dtype=np.int64)
+
+            self.assertTrue(T.last_write_info is not None)
+            self.assertTrue(len(T.last_write_info.keys()) == 1)
+            print(T.last_write_info.values())
+            t_w1, t_w2 = list(T.last_write_info.values())[0]
+            self.assertTrue(t_w1 > 0)
+            self.assertTrue(t_w2 > 0)
+
 class DenseVarlen(DiskTestCase):
     def test_varlen_write_bytes(self):
         A = np.array(['aa','bbb','ccccc','ddddddddddddddddddddd','ee','ffffff','g','hhhhhhhhhh'], dtype=bytes)


### PR DESCRIPTION
Add support for retrieving fragment information (URI, timestamp range) for the most recent write operation on a given `Array` object, via the `Array:last_write_info` method.

---
depends on https://github.com/TileDB-Inc/TileDB/pull/1396