### PR TITLE
Fix mac CI: switch to macOS-10.14 image and set SDKROOT

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,8 +4,9 @@ trigger:
 strategy:
   matrix:
     mac:
-      imageName: 'macOS-10.13'
+      imageName: 'macOS-10.14'
       python.version: '3.x'
+      SDKROOT: '/Applications/Xcode_10.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'
     windows:
       imageName: 'vs2017-win2016'
       python.version: '3.x'


### PR DESCRIPTION
Azure pipelines python, activated via `UsePythonVersion@0`, in the `macOS-10.13` image seems to have been broken in an update. Details in https://github.com/microsoft/azure-pipelines-image-generation/issues/1342

This PR switches to the `macOS-10.14` image, which requires setting `SDKROOT` in the environment in order for TBB (via CMake) and probably other build targets to find things like `stdlib.h`.