### PR TITLE
Bind ctx_set_tag API; set default tags in Ctx init.

### DIFF
--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -246,6 +246,11 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_filesystem_t fs,
         int* is_supported)
 
+    int tiledb_ctx_set_tag(
+        tiledb_ctx_t* ctx,
+        const char* key,
+        const char* value)
+
     # Error
     int tiledb_error_message(
         tiledb_error_t* err,

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -847,6 +847,7 @@ cdef class Ctx(object):
             # after the exception is raised
             _raise_ctx_err(ctx_ptr, rc)
         self.ptr = ctx_ptr
+        self._set_default_tags()
 
     def config(self):
         """Returns the Config instance associated with the Ctx
@@ -855,6 +856,22 @@ cdef class Ctx(object):
         check_error(self,
                     tiledb_ctx_get_config(self.ptr, &config_ptr))
         return Config.from_ptr(config_ptr)
+
+    def set_tag(self, key, value):
+        """Sets a string:string "tag" on the Ctx"""
+        cdef tiledb_ctx_t* ctx_ptr = self.ptr
+        bkey = key.encode('UTF-8')
+        bvalue = value.encode('UTF-8')
+        cdef int rc = TILEDB_OK
+        rc = tiledb_ctx_set_tag(ctx_ptr, bkey, bvalue)
+        if rc != TILEDB_OK:
+            _raise_ctx_err(ctx_ptr, rc)
+
+    def _set_default_tags(self):
+        """Sets all default tags on the Ctx"""
+        self.set_tag('x-tiledb-api-language', 'python')
+        self.set_tag('x-tiledb-api-language-version', '{}.{}.{}'.format(*sys.version_info))
+        self.set_tag('x-tiledb-api-sys-platform', sys.platform)
 
 
 def _tiledb_datetime_extent(begin, end):


### PR DESCRIPTION
Requires latest TileDB dev / TileDB 1.7