### PR TITLE
Define Dense and Sparse Array in pure python

### DIFF
--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -34,8 +34,6 @@ from .libtiledb import (
      Domain,
      Attr,
      ArraySchema,
-     DenseArray,
-     SparseArray,
      TileDBError,
      VFS,
      FileIO,
@@ -64,6 +62,8 @@ from .libtiledb import (
      stats_reset,
      stats_dump,
 )
+
+from .array import DenseArray, SparseArray
 
 from .highlevel import (
      open,

--- a/tiledb/array.py
+++ b/tiledb/array.py
@@ -1,0 +1,33 @@
+from .libtiledb import DenseArrayImpl, SparseArrayImpl
+
+class DenseArray(DenseArrayImpl):
+    _mixin_init = False
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._mixin_init:
+            try:
+                from tiledb.cloud import cloudarray
+                DenseArray.__bases__ = DenseArray.__bases__ + (cloudarray.CloudArray,)
+            except ImportError:
+                pass
+            finally:
+                cls._mixin_init = True
+
+        obj = super(DenseArray, cls).__new__(cls, *args, **kwargs)
+        return obj
+
+class SparseArray(SparseArrayImpl):
+    _mixin_init = False
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._mixin_init:
+            try:
+                from tiledb.cloud import cloudarray
+                SparseArray.__bases__ = SparseArray.__bases__ + (cloudarray.CloudArray,)
+            except ImportError:
+                pass
+            finally:
+                cls._mixin_init = True
+
+        obj = super(SparseArray, cls).__new__(cls, *args, **kwargs)
+        return obj

--- a/tiledb/indexing.pyx
+++ b/tiledb/indexing.pyx
@@ -87,8 +87,8 @@ cdef class DomainIndexer(object):
 
 
         if isinstance(self.array, SparseArray):
-            return (<SparseArray>self.array)._read_sparse_subarray(subarray, attr_names, layout)
+            return (<SparseArrayImpl>self.array)._read_sparse_subarray(subarray, attr_names, layout)
         elif isinstance(self.array, DenseArray):
-            return (<DenseArray>self.array)._read_dense_subarray(subarray, attr_names, layout)
+            return (<DenseArrayImpl>self.array)._read_dense_subarray(subarray, attr_names, layout)
         else:
             raise Exception("No handler for Array type: " + str(type(self.array)))

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1070,10 +1070,10 @@ cdef class Array(object):
     cdef _ndarray_is_varlen(self, np.ndarray array)
     cdef _unpack_varlen_query(self, ReadQuery read, unicode name)
 
-cdef class SparseArray(Array):
+cdef class SparseArrayImpl(Array):
     cdef _read_sparse_subarray(self, np.ndarray subarray, list attr_names, tiledb_layout_t layout)
 
-cdef class DenseArray(Array):
+cdef class DenseArrayImpl(Array):
     cdef _read_dense_subarray(self, np.ndarray subarray, list attr_names, tiledb_layout_t layout)
 
 cdef class FileHandle(object):

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 from cpython.version cimport PY_MAJOR_VERSION
 
 include "common.pxi"
+from .array import DenseArray, SparseArray
 
 import sys
 from os.path import abspath
@@ -2948,9 +2949,9 @@ cdef class Array(object):
         :param ctx Ctx: (default None) Optional TileDB Ctx used when creating the array,
                         by default uses the ArraySchema's associated context.
         """
-        if issubclass(cls, DenseArray) and schema.sparse:
+        if issubclass(cls, DenseArrayImpl) and schema.sparse:
             raise ValueError("Array.create `schema` argument must be a dense schema for DenseArray and subclasses")
-        if issubclass(cls, SparseArray) and not schema.sparse:
+        if issubclass(cls, SparseArrayImpl) and not schema.sparse:
             raise ValueError("Array.create `schema` argument must be a sparse schema for SparseArray and subclasses")
 
         cdef tiledb_ctx_t* ctx_ptr = schema.ctx.ptr
@@ -3539,7 +3540,7 @@ def _create_densearray(cls, sta):
     rv.__setstate__(sta)
     return rv
 
-cdef class DenseArray(Array):
+cdef class DenseArrayImpl(Array):
     """Class representing a dense TileDB array.
 
     Inherits properties and methods of :py:class:`tiledb.Array`.
@@ -3898,7 +3899,7 @@ cdef class DenseArray(Array):
                 values.append(val)
             else:
                 dtype = self.schema.attr(self.view_attr).dtype
-                with DenseArray(self.uri, 'r', ctx=Ctx(self.ctx.config())) as readable:
+                with DenseArrayImpl(self.uri, 'r', ctx=Ctx(self.ctx.config())) as readable:
                     current = readable[selection]
                 current[self.view_attr] = \
                     np.ascontiguousarray(val, dtype=dtype)
@@ -4081,7 +4082,7 @@ def index_domain_coords(Domain dom, tuple idx):
     return np.column_stack(idx)
 
 
-cdef class SparseArray(Array):
+cdef class SparseArrayImpl(Array):
     """Class representing a sparse TileDB array.
 
     Inherits properties and methods of :py:class:`tiledb.Array`.


### PR DESCRIPTION
Adds support for mix-in functionality defined in tiledb.cloud when
installed.

Co-authored-by: Seth Shelnutt <seth@tiledb.io>