### PR TITLE
Add tiledb.Array.load_typed for typed open w/out separate schema check

### DIFF
--- a/tiledb/common.pxi
+++ b/tiledb/common.pxi
@@ -17,6 +17,8 @@ from libc.stdint cimport (uint8_t, int8_t,
                           uint32_t, int32_t,
                           uint64_t, int64_t,
                           uintptr_t)
+from libc.stddef cimport ptrdiff_t
+
 from libc cimport limits
 from libcpp.vector cimport vector
 

--- a/tiledb/highlevel.py
+++ b/tiledb/highlevel.py
@@ -24,17 +24,7 @@ def open(uri, mode='r', key=None, attr=None, config=None, ctx=None):
     if ctx is None:
         ctx = default_ctx()
 
-    schema = ArraySchema.load(uri, ctx=ctx)
-    if not schema:
-        raise Exception("Unable to load tiledb ArraySchema from URI: '{}'".format(uri))
-
-    if schema.sparse:
-        return tiledb.SparseArray(uri, mode=mode, key=key, attr=attr, ctx=ctx)
-    elif not schema.sparse:
-        return tiledb.DenseArray(uri, mode=mode, key=key, attr=attr, ctx=ctx)
-    else:
-        raise Exception("Unknown TileDB array type")
-
+    return tiledb.Array.load_typed(uri, mode, key, None, attr, ctx)
 
 def save(uri, array, config=None, **kw):
     """

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1102,6 +1102,7 @@ cdef class Array(object):
     cdef tiledb_array_t* ptr
     cdef unicode uri
     cdef unicode mode
+    cdef bint _isopen
     cdef object view_attr # can be None
     cdef object key # can be None
     cdef object schema
@@ -1111,7 +1112,6 @@ cdef class Array(object):
     cdef object multi_index
 
     cdef object last_fragment_info
-    # TODO make this Metadata
     cdef Metadata meta
 
     cdef _ndarray_is_varlen(self, np.ndarray array)

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -21,7 +21,7 @@ def mr_dense_result_shape(ranges, base_shape = None):
 
     new_shape = list()
     for i,rr in enumerate(ranges):
-        if rr is not ():
+        if rr != ():
             m = list(map(lambda y: abs(y[1] - y[0]) + 1, rr))
             new_shape.append(np.sum(m))
         else:

--- a/tiledb/tests/test_examples.py
+++ b/tiledb/tests/test_examples.py
@@ -28,7 +28,7 @@ class ExamplesTest(unittest.TestCase):
       run_checked(args)
 
   # some of the doctests are missing a clean-up step on windows
-  @unittest.skipIf(platform.system() is 'Windows', "")
+  @unittest.skipIf(platform.system() == 'Windows', "")
   def test_docs(self):
     if sys.version_info >= (3,6):
       doctest_args = ['-m', 'doctest', '-o', 'NORMALIZE_WHITESPACE', '-f',


### PR DESCRIPTION
Adds a factory-like static method, `Array.load_typed`, which returns
a DenseArray or SparseArray instance, depending on the type of the
underlying array. Eliminates the current schema check before class
allocation, which adds latency in non-local usage.