### PR TITLE
Eliminate reference cycles to improve Ctx cleanup

### DIFF
--- a/tiledb/indexing.pxd
+++ b/tiledb/indexing.pxd
@@ -1,6 +1,6 @@
 from .libtiledb cimport Array, ArraySchema, Query
 
 cdef class DomainIndexer:
-    cdef Array array
+    cdef object array_ref
     cdef ArraySchema schema
     cdef Query query

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1098,6 +1098,7 @@ cdef class ArraySchema(object):
     cdef _attr_idx(self, int idx)
 
 cdef class Array(object):
+    cdef object __weakref__
     cdef Ctx ctx
     cdef tiledb_array_t* ptr
     cdef unicode uri
@@ -1106,13 +1107,11 @@ cdef class Array(object):
     cdef object view_attr # can be None
     cdef object key # can be None
     cdef object schema
+
     cdef DomainIndexer domain_index
-
-    # TODO make this a cython type TBD
     cdef object multi_index
-
-    cdef object last_fragment_info
     cdef Metadata meta
+    cdef object last_fragment_info
 
     cdef _ndarray_is_varlen(self, np.ndarray array)
     cdef _unpack_varlen_query(self, ReadQuery read, unicode name)
@@ -1149,7 +1148,7 @@ cdef class ReadQuery(object):
     cdef object _offsets
 
 cdef class Metadata(object):
-    cdef Array array
+    cdef object array_ref
 
 cdef class TileDBError(Exception):
     pass

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -1,7 +1,7 @@
 import tiledb
 from tiledb import Array, ArraySchema
 import os, numpy as np
-import sys
+import sys, weakref
 
 try:
     from tiledb.libtiledb import multi_index
@@ -74,11 +74,15 @@ class MultiRangeIndexer(object):
     #def __init__(self, array: Array, query = None):
 
     def __init__(self, array, query = None):
-        self.array = array
-        # TODO remove
-        if hasattr(array, 'schema'):
-            self.schema = array.schema
+        self.array_ref = weakref.ref(array)
+        self.schema = array.schema
         self.query = query
+
+    @property
+    def array(self):
+        assert self.array_ref() is not None, \
+            "Internal error: invariant violation (indexing call w/ dead array_ref)"
+        return self.array_ref()
 
     def getitem_ranges(self, idx):
         dom = self.schema.domain


### PR DESCRIPTION
In #247 @bkmartinjr demonstrated thread-count oversubscription caused by delayed Array destruction (thus, Ctx deallocation), due to internal reference cycles. These cycles can eventually be freed by the Python GC, but the GC does not run sufficiently often to prevent the issue.