### PR TITLE
Incomplete query support for standard indexing

### DIFF
--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -447,27 +447,6 @@ class TestMultiRange(DiskTestCase):
                 res['coords'].view('f4').reshape(-1,2)
             )
 
-    def test_mr_incomplete_dense(self):
-        path = self.path("incomplete_dense")
-        # create 10 MB array
-        data = np.arange(1310720, dtype=np.int64)
-        # if `tile` is not set, it defaults to the full array and we
-        # only read 8 bytes at a time.
-        use_tile=131072
-        #use_tile = None
-        with tiledb.from_numpy(path, data, tile=use_tile) as A:
-            print("domain: " + str(A.schema.domain))
-            pass
-
-        # create context with 1 MB memory budget
-        config = tiledb.Config({'sm.memory_budget': 2 * 1024**2})
-        ctx = tiledb.Ctx(config=config)
-
-        # TODO would be good to check repeat count here. Not currently exposed by retry loop.
-        with tiledb.DenseArray(path, ctx=ctx) as A:
-            res = A.multi_index[ slice(0, len(data) - 1) ]
-            assert_array_equal(res[""], data)
-
     def test_mr_1d_sparse_query(self):
         ctx = tiledb.Ctx()
         path = self.path('mr_1d_sparse_query')


### PR DESCRIPTION
Retry incomplete queries as long as bytes are being returned, updating
buffers appropriately between query_submit calls.

- fixes #245
- follow up to #238