### PR TITLE
Add wheel builder scripts for macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-jobs:
+stages:
   - template: ./misc/azure-ci.yml
-  #- template: ./misc/azure-release.yml
+  - template: ./misc/azure-release.yml
   #- template: ./misc/azure-publish.yml

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -1,78 +1,78 @@
-  #  template: ./misc/azure-ci.yml
-
-jobs:
-- job:
-  pool:
-    vmImage: $(imageName)
+stages:
+- stage: CI
   condition: not(or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), contains(variables['Build.SourceBranchName'], 'release-')))
-  strategy:
-    matrix:
-      mac:
-        imageName: 'macOS-10.14'
-        python.version: '3.x'
-        SDKROOT: '/Applications/Xcode_10.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'
-      windows:
-        imageName: 'vs2017-win2016'
-        python.version: '3.x'
-      linux_py2:
-        imageName: 'ubuntu-16.04'
-        python.version: '2.7'
-      linux_py3:
-        imageName: 'ubuntu-16.04'
-        python.version: '3.x'
-    maxParallel: 4
+  jobs:
+  - job:
+    pool:
+      vmImage: $(imageName)
+    strategy:
+      matrix:
+        mac:
+          imageName: 'macOS-10.14'
+          python.version: '3.x'
+          SDKROOT: '/Applications/Xcode_10.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'
+        windows:
+          imageName: 'vs2017-win2016'
+          python.version: '3.x'
+        linux_py2:
+          imageName: 'ubuntu-16.04'
+          python.version: '2.7'
+        linux_py3:
+          imageName: 'ubuntu-16.04'
+          python.version: '3.x'
+      maxParallel: 4
 
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-      architecture: 'x64'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python.version)'
+        architecture: 'x64'
 
-  - script: |
-      printenv
-    displayName: 'Print env'
+    - script: |
+        printenv
+      displayName: 'Print env'
 
-  - script: |
-      python -m pip install --upgrade setuptools wheel numpy tox setuptools-scm cython psutil dask
-    displayName: 'Install dependencies'
+    - script: |
+        python -m pip install --upgrade setuptools wheel numpy tox setuptools-scm cython psutil dask
+      displayName: 'Install dependencies'
 
-  - script: |
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-      python setup.py build_ext --inplace
-      python setup.py install
-    displayName: 'Build TileDB and TileDB-Py extension (Windows)'
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    - script: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        python setup.py build_ext --inplace
+        python setup.py install
+      displayName: 'Build TileDB and TileDB-Py extension (Windows)'
+      condition: eq(variables['Agent.OS'], 'Windows_NT')
 
-  - bash: |
-      set -xeo pipefail
-      python setup.py build_ext --inplace
-      python setup.py install
-    displayName: 'Build TileDB and TileDB-Py extension (POSIX)'
-    condition: ne(variables['Agent.OS'], 'Windows_NT')
+    - bash: |
+        set -xeo pipefail
+        python setup.py build_ext --inplace
+        python setup.py install
+      displayName: 'Build TileDB and TileDB-Py extension (POSIX)'
+      condition: ne(variables['Agent.OS'], 'Windows_NT')
 
-  - bash: |
-      set -xeo pipefail
-      python -m unittest tiledb.tests.all.suite_test
+    - bash: |
+        set -xeo pipefail
+        python -m unittest tiledb.tests.all.suite_test
 
-      # Test wheel build, install, and run
-      python setup.py bdist_wheel
-      whl_file=`pwd`/dist/`ls dist/*.whl`
-      pushd /tmp
-      echo "Installing wheel file: '$whl_file'"
-      pip install $whl_file
-      python -c "import tiledb ; tiledb.libtiledb.version()"
-    displayName: 'Run tests'
+        # Test wheel build, install, and run
+        python setup.py bdist_wheel
+        whl_file=`pwd`/dist/`ls dist/*.whl`
+        pushd /tmp
+        echo "Installing wheel file: '$whl_file'"
+        pip install $whl_file
+        python -c "import tiledb ; tiledb.libtiledb.version()"
+      displayName: 'Run tests'
 
-  - bash: |
-      set -xeo pipefail
-      # Display log files if the build failed
-      echo "Dumping log files for failed build"
-      echo "----------------------------------"
-      for f in $(find $BUILD_REPOSITORY_LOCALPATH/build -name *.log);
-        do echo "------"
-           echo $f
-           echo "======"
-           cat $f
-        done;
-    condition: failed() # only run this job if the build step failed
-    displayName: "Print log files (failed build only)"
+    - bash: |
+        set -xeo pipefail
+        # Display log files if the build failed
+        echo "Dumping log files for failed build"
+        echo "----------------------------------"
+        for f in $(find $BUILD_REPOSITORY_LOCALPATH/build -name *.log);
+          do echo "------"
+             echo $f
+             echo "======"
+             cat $f
+          done;
+      condition: failed() # only run this job if the build step failed
+      displayName: "Print log files (failed build only)"

--- a/misc/azure-libtiledb-darwin.yml
+++ b/misc/azure-libtiledb-darwin.yml
@@ -1,0 +1,50 @@
+steps:
+- task: Cache@2
+  inputs:
+    key: 'libtiledb | "$(Agent.OS)" | "$(LIBTILEDB_SHA)" | v3'
+    path: $(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)
+    cacheHitVar: LIBTILEDB_CACHE_RESTORED
+
+- bash: |
+    find $PIPELINE_WORKSPACE/.libtiledb_dist/${LIBTILEDB_SHA}
+  condition: eq(variables.LIBTILEDB_CACHE_RESTORED, 'true')
+  displayName: "Print files restored from cache"
+
+- bash: |
+    set -xe pipefail
+
+    unset SYSTEM
+
+    # Darwin
+    INSTALL=$PIPELINE_WORKSPACE/.libtiledb_dist/${LIBTILEDB_SHA}
+    SRC=$BUILD_REPOSITORY_LOCALPATH/tiledb_src
+
+    git clone https://github.com/TileDB-Inc/TileDB $SRC
+    git -C $SRC checkout $LIBTILEDB_VERSION
+
+    libtiledb_sha_actual=$(git -C $SRC show-ref -s $LIBTILEDB_VERSION)
+    if [[ "$libtiledb_sha_actual" -ne "$(LIBTILEDB_SHA)" ]]; then
+      echo "variable LIBTILEDB_SHA ('$LIBTILEDB_SHA') does not match SHA of LIBTILEDB_VERSION checkout ('$libtiledb_sha_actual')";
+      exit 1;
+    fi
+
+    mkdir -p $BUILD_REPOSITORY_LOCALPATH/tiledb-build
+    cd $BUILD_REPOSITORY_LOCALPATH/tiledb-build
+
+    $SRC/bootstrap --force-build-all-deps --enable=s3,serialization --enable-static-tiledb --disable-avx2 --disable-cpp-api --disable-tests --prefix=$INSTALL
+    make -j4
+    make -C tiledb install
+
+    cp $BUILD_REPOSITORY_LOCALPATH/tiledb-build/externals/install/lib/libz.1.dylib $PIPELINE_WORKSPACE/.libtiledb_dist/${LIBTILEDB_SHA}/lib
+
+    echo "--- listing files"
+    ls $BUILD_REPOSITORY_LOCALPATH
+    find $INSTALL
+
+    otool -L ${INSTALL}/lib/libtiledb.dylib;
+  condition: ne(variables.LIBTILEDB_CACHE_RESTORED, 'true')
+  displayName: "Build libtiledb"
+
+- bash: |
+    cp  $PIPELINE_WORKSPACE/.libtiledb_dist/${LIBTILEDB_SHA}/lib/libz.1.dylib $BUILD_REPOSITORY_LOCALPATH
+  displayName: "Copy libz (tmp work-around for delocate)"

--- a/misc/azure-print-logs.yml
+++ b/misc/azure-print-logs.yml
@@ -1,0 +1,14 @@
+steps:
+- bash: |
+    set -e pipefail
+    # Display log files if the build failed
+    echo "Dumping log files for failed build"
+    echo "----------------------------------"
+    for f in $(find $BUILD_REPOSITORY_LOCALPATH -name *.log);
+      do echo "------"
+         echo $f
+         echo "======"
+         cat $f
+    done;
+  condition: failed() # only run this job if the build step failed
+  displayName: "Print log files (failed build only)"

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -10,18 +10,18 @@ stages:
     pool:
       vmImage: 'macOS-10.13'
     variables:
-      cibw_test_command: "cd {project}/tiledb/tests && pytest"
+      #cibw_test_command: "cd {project}/tiledb/tests && pytest"
       cibw_test_requires: "pytest"
     steps:
     - template: azure-libtiledb-darwin.yml
     - task: UsePythonVersion@0
     - bash: |
         set -xe pipefail
-        python setup.py sdist --dist-dir {output_dir}
+        python setup.py sdist --dist-dir wheelhouse
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.1.0 pytest
         export CIBW_ENVIRONMENT="TILEDB_PATH=${HOSTPREFIX}/${PIPELINE_WORKSPACE}/.libtiledb_dist/${LIBTILEDB_SHA}"
-        cibuildwheel --output-dir wheelhouse .
+        cibuildwheel --output-dir wheelhouse `ls wheelhouse/tiledb-*.tar.gz`
       displayName: "Build and test wheels"
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -9,13 +9,15 @@ stages:
   - job:
     pool:
       vmImage: 'macOS-10.13'
-    #variables:
-    #cibw_test_command: "pytest {project}/tiledb/tests"
+    variables:
+      cibw_test_command: "cd {project}/tiledb/tests && pytest"
+      cibw_test_requires: "pytest"
     steps:
     - template: azure-libtiledb-darwin.yml
     - task: UsePythonVersion@0
     - bash: |
         set -xe pipefail
+        python setup.py sdist --dist-dir {output_dir}
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.1.0 pytest
         export CIBW_ENVIRONMENT="TILEDB_PATH=${HOSTPREFIX}/${PIPELINE_WORKSPACE}/.libtiledb_dist/${LIBTILEDB_SHA}"

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -1,11 +1,14 @@
 stages:
 - stage: Release
   variables:
-    LIBTILEDB_VERSION: release-1.7.3
-    LIBTILEDB_SHA: c4e938bdb155e88767c9f7dbd76f80ce0c30ec22
+    TILEDBPY_VERSION: 0.5.4
+    LIBTILEDB_VERSION: 1.7.3
+    LIBTILEDB_SHA: 86071783c209db936e6d870550583610e9594818
     CIBW_SKIP: cp35-*
   condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), contains(variables['Build.SourceBranchName'], 'release-'))
+
   jobs:
+
   - job:
     pool:
       vmImage: 'macOS-10.13'
@@ -20,12 +23,26 @@ stages:
         python setup.py sdist --dist-dir wheelhouse
         python -m pip install --upgrade pip
         pip install cibuildwheel==1.1.0 pytest
-        export CIBW_ENVIRONMENT="TILEDB_PATH=${HOSTPREFIX}/${PIPELINE_WORKSPACE}/.libtiledb_dist/${LIBTILEDB_SHA}"
-        cibuildwheel --output-dir wheelhouse `ls wheelhouse/tiledb-*.tar.gz`
+        export CIBW_ENVIRONMENT="TILEDB_PATH=${HOSTPREFIX}/${PIPELINE_WORKSPACE}/.libtiledb_dist/${LIBTILEDB_SHA} SETUPTOOLS_SCM_PRETEND_VERSION=${TILEDBPY_VERSION}"
+        cibuildwheel --output-dir wheelhouse .
       displayName: "Build and test wheels"
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}
     - template: azure-print-logs.yml
+
+
+#  - job: sdist
+#    displayName: "Make sdist bundle"
+#    pool:
+#      vmImage: 'ubuntu-16.04'
+#    steps:
+#    - task: UsePythonVersion@0
+#    - bash: |
+#        python setup.py sdist
+#    - task: PublishBuildArtifacts@1
+#      inputs:
+#        pathtoPublish: dist
+#        artifactName: 'tiledb_py_sdist'
 
 #  - job:
 #    variables:

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -1,0 +1,61 @@
+stages:
+- stage: Release
+  variables:
+    LIBTILEDB_VERSION: release-1.7.3
+    LIBTILEDB_SHA: c4e938bdb155e88767c9f7dbd76f80ce0c30ec22
+    CIBW_SKIP: cp35-*
+  condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), contains(variables['Build.SourceBranchName'], 'release-'))
+  jobs:
+  - job:
+    pool:
+      vmImage: 'macOS-10.13'
+    #variables:
+    #cibw_test_command: "pytest {project}/tiledb/tests"
+    steps:
+    - template: azure-libtiledb-darwin.yml
+    - task: UsePythonVersion@0
+    - bash: |
+        set -xe pipefail
+        python -m pip install --upgrade pip
+        pip install cibuildwheel==1.1.0 pytest
+        export CIBW_ENVIRONMENT="TILEDB_PATH=${HOSTPREFIX}/${PIPELINE_WORKSPACE}/.libtiledb_dist/${LIBTILEDB_SHA}"
+        cibuildwheel --output-dir wheelhouse .
+      displayName: "Build and test wheels"
+    - task: PublishBuildArtifacts@1
+      inputs: {pathtoPublish: 'wheelhouse'}
+    - template: azure-print-logs.yml
+
+#  - job:
+#    variables:
+#      HOSTPREFIX: "/host/" # linux builds are run in docker w/ '-v/:/host'
+#      cibw_before_build:
+#        /host/${BUILD_REPOSITORY_LOCALPATH}/misc/azure-build-libtiledb-unix.sh
+#    pool:
+#      vmImage: 'ubuntu-16.04'
+#    resources:
+#      containers:
+#      - container: manylinux2010
+#        image: 'quay.io/pypa/manylinux2010_x86_64'
+#    container: manylinux2010
+#    steps:
+#    - task: UsePythonVersion@0
+#    - bash: |
+#        set -xe pipefail
+#        python -m pip install --upgrade pip
+#        pip install cibuildwheel==1.1.0
+#        export CIBW_ENVIRONMENT="TILEDB_PATH=${HOSTPREFIX}/${PIPELINE_WORKSPACE}/.libtiledb_dist/${LIBTILEDB_SHA} CXXFLAGS='-Wno-unused-parameter -lrt -DKJ_USE_EPOLL=0 -D__BIONIC__=1' CFLAGS='-Wno-unused-parameter -lrt -DKJ_USE_EPOLL=0 -D__BIONIC__=1'"
+#        cibuildwheel --output-dir wheelhouse .
+#    - template: azure-print-logs.yml
+
+#- job: windows
+#  pool: {vmImage: 'vs2017-win2016'}
+#  variables:
+#    CIBW_SKIP: cp27-win_amd64, cp35-win_amd64
+#  steps:
+#    - task: UsePythonVersion@0
+#    - script: choco install vcpython27 -f -y
+#      displayName: Install Visual C++ for Python 2.7
+#    - bash: |
+#        python -m pip install --upgrade pip
+#        pip install cibuildwheel==1.1.0
+#        cibuildwheel --output-dir wheelhouse .


### PR DESCRIPTION
Adds a wheel-build script running on azure pipelines and utilizing cibuildwheel. Currently this is run for macOS only, because the `misc/pypi_linux` Docker setup needs some reorganization before I can run it in a similar way.

Fixes #144 

macOS wheels for 0.5.4 were built with this method and uploaded to PyPI: https://pypi.org/project/tiledb/#files (uploaded manually for now, until the Linux side is added).