### PR TITLE
Fix #260 and add test for all numpy time units

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4598,10 +4598,6 @@ cdef class SparseArrayImpl(Array):
         cdef np.npy_intp dims[1]
         cdef Py_ssize_t nattr = len(attr_names)
 
-        cdef tuple shape = \
-            tuple(int(subarray[r, 1]) - int(subarray[r, 0]) + 1
-                  for r in range(self.schema.ndim))
-
         read = ReadQuery(self, subarray, attr_names, layout)
 
         # collect a list of dtypes for resulting to construct array


### PR DESCRIPTION
Remove unused code which caused a failure when reading time
ranges with 'ms' units. Existing tests only covered 'ns' units
in this case, and the unused code failed with 'ms' units due to
a difference in NumPy (?) conversion rules, despite having the
same underlying representation:

```
>>> import numpy as np
>>> start = np.datetime64(0, 'ns')
>>> int(start)
0

>>> start = np.datetime64(0, 'ms')
>>> int(start)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: int() argument must be a string, a bytes-like object or a number, not 'datetime.datetime'

int() argument must be a string, a bytes-like object or a number, not 'datetime.datetime'

>>> start = np.datetime64(1000, 'ns')
>>> start.astype(int)
1000

>>> start = np.datetime64(1000, 'ms')
>>> start.astype(int)
1000
```