### PR TITLE
Add dataframe and CSV i/o helper functions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 # In progress
 
 ## Improvements
+- Added dataframe and CSV helper functions [#TDB](...)
+    `tiledb.{from_dataframe, from_csv, open_dataframe}`
 - Added repr for ArraySchema [#267](https://github.com/TileDB-Inc/TileDB-Py/pull/267)
 - Added repr for Attr [#266](https://github.com/TileDB-Inc/TileDB-Py/pull/266)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,9 @@
 - Added repr for ArraySchema [#267](https://github.com/TileDB-Inc/TileDB-Py/pull/267)
 - Added repr for Attr [#266](https://github.com/TileDB-Inc/TileDB-Py/pull/266)
 
+## Bug fixes
+- Fixed accessing domain dimension by name (`domain.dim('dim name')`) [#271](https://github.com/TileDB-Inc/TileDB-Py/pull/271)
+
 # TileDB-Py 0.5.6 Release Notes
 
 * Bump release target to [TileDB 1.7.5](https://github.com/TileDB-Inc/TileDB/releases/tag/1.7.5)

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.6
   - numpy=1.14.*
   - cython=0.28.*
+  - pandas>=1.0
   - pip:
     - tox==3.0.0
     - setuptools-scm==2.1.0

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -33,7 +33,7 @@ stages:
       displayName: 'Print env'
 
     - script: |
-        python -m pip install --upgrade setuptools wheel numpy tox setuptools-scm cython psutil dask
+        python -m pip install --upgrade setuptools wheel numpy tox setuptools-scm cython psutil dask pandas
       displayName: 'Install dependencies'
 
     - script: |

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -33,7 +33,7 @@ stages:
       displayName: 'Print env'
 
     - script: |
-        python -m pip install --upgrade setuptools wheel numpy tox setuptools-scm cython psutil dask pandas
+        python -m pip install --upgrade -r requirements.txt
       displayName: 'Install dependencies'
 
     - script: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ tox
 setuptools-scm
 cython
 dask
-pandas
+pandas ; python_version > '3.5'
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ setuptools>=18.0.1
 setuptools-scm>=1.5.4
 wheel>=0.30
 psutil
+pandas>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-cmake>=3.11.0
-cython>=0.29
+setuptools
+wheel
 numpy==1.16.*
-setuptools>=18.0.1
-setuptools-scm>=1.5.4
-wheel>=0.30
+tox
+setuptools-scm
+cython
+dask
+pandas
 psutil
-pandas>=1.0

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -73,6 +73,9 @@ from .highlevel import (
      array_exists
 )
 
+# TODO restricted imports
+from .dataframe_ import from_dataframe, from_csv, open_dataframe
+
 from .version import version as __version__
 
 # Note: we use a modified namespace packaging to allow continuity of existing TileDB-Py imports.

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -1,0 +1,191 @@
+import tiledb, numpy as np
+import json
+import sys
+
+if sys.version_info >= (3,3):
+    unicode_type = str
+else:
+    unicode_type = unicode
+
+# TODO
+# - handle missing values
+# - handle extended datatypes
+# - implement distributed CSV import
+# - implement support for read CSV via TileDB VFS from any supported FS
+
+TILEDB_KWARG_DEFAULTS = {
+    'ctx': tiledb.default_ctx(),
+    'cell_order': 'row-major',
+    'tile_order': 'row-major',
+    'sparse': False
+}
+
+class ColumnInfo:
+    def __init__(self, dtype, repr=None):
+        self.dtype = dtype
+        self.repr = repr
+
+def attr_dtype_from_column(col):
+    import pandas as pd
+
+    col_dtype = col.dtype
+    # TODO add more basic types here
+    if col_dtype in (np.int32, np.int64, np.uint32, np.uint64, np.float, np.double,
+                     np.uint8):
+        return ColumnInfo(col_dtype)
+
+    # TODO this seems kind of brittle
+    if col_dtype.base == np.dtype('M8[ns]'):
+        if col_dtype == np.dtype('datetime64[ns]'):
+            return ColumnInfo(col_dtype)
+        elif hasattr(col_dtype, 'tz'):
+            raise ValueError("datetime with tz not yet supported")
+        else:
+            raise ValueError("unsupported datetime subtype ({})".format(type(col_dtype)))
+
+    # Pandas 1.0 has StringDtype extension type
+    if col_dtype.name == 'string':
+        return ColumnInfo(unicode_type)
+
+    if col_dtype == 'bool':
+        return ColumnInfo(np.uint8, repr=np.dtype('bool'))
+
+    if col_dtype == np.dtype("O"):
+        # Note: this does a full scan of the column... not sure what else to do here
+        #       because Pandas allows mixed string column types (and actually has
+        #       problems w/ allowing non-string types in object columns)
+        inferred_dtype = pd.api.types.infer_dtype(col)
+
+        if inferred_dtype == 'bytes':
+            return ColumnInfo(bytes)
+        elif inferred_dtype == 'string':
+            return ColumnInfo(unicode_type)
+
+        elif inferred_dtype == 'mixed':
+            raise ValueError(
+                "Column '{}' has mixed value dtype and cannot yet be stored as a TileDB attribute"
+            )
+
+    raise ValueError(
+        "Unhandled column type: '{}'".format(
+            col_dtype
+        )
+    )
+
+
+# TODO make this a staticmethod on Attr?
+def attrs_from_df(df, ctx=None):
+    attr_reprs = dict()
+
+    if ctx is None:
+        ctx = tiledb.default_ctx()
+    attrs = list()
+    for name, col in df.items():
+        attr_info = attr_dtype_from_column(col)
+        attrs.append(tiledb.Attr(name=name, dtype=attr_info.dtype))
+
+        if attr_info.repr is not None:
+            attr_reprs[name] = attr_info.repr
+
+    return attrs, attr_reprs
+
+
+def from_csv(uri, csv_file, distributed=False, **kwargs):
+
+    try:
+        import pandas
+    except ImportError as exc:
+        raise ImportError("tiledb.from_csv requires pandas") from exc
+
+    tiledb_args = kwargs.pop('tiledb_args', None)
+
+    df = pandas.read_csv(csv_file, **kwargs)
+    from_dataframe(uri, df, tiledb_args=tiledb_args, **kwargs)
+
+
+def write_attr_metadata(array, metadata):
+    """
+
+    :param array: open, writable TileDB array
+    :param metadata: dict
+    :return:
+    """
+
+    md_dict = {n: str(t) for n,t in metadata.items()}
+
+    array.meta['__pandas_attribute_repr'] = json.dumps(md_dict)
+
+
+def from_dataframe(uri, dataframe, **kwargs):
+
+    args = TILEDB_KWARG_DEFAULTS
+    tiledb_args = kwargs.pop('tiledb_args', None)
+    if tiledb_args is not None:
+        args.update(tiledb_args)
+
+    ctx = args['ctx']
+    tile_order = args['tile_order']
+    cell_order = args['cell_order']
+    sparse = args['sparse']
+
+    nrows = len(dataframe)
+    tiling = np.min((nrows % 200, nrows))
+
+    # create the domain and attributes
+    dim = tiledb.Dim(
+        name="rows",
+        domain=(0, nrows-1),
+        dtype=np.uint64,
+        tile=tiling,
+    )
+    domain = tiledb.Domain(
+       dim,
+       ctx = ctx
+    )
+    attrs, attr_metadata = attrs_from_df(dataframe)
+
+    # now create the ArraySchema
+    schema = tiledb.ArraySchema(
+        domain=domain,
+        attrs=attrs,
+        cell_order=cell_order,
+        tile_order=tile_order,
+        sparse=sparse
+    )
+
+    tiledb.Array.create(uri, schema, ctx=ctx)
+
+    # TODO remove
+    global df
+    df = dataframe
+
+    with tiledb.DenseArray(uri, 'w') as A:
+        write_dict =  {k: v.values for k,v in dataframe.to_dict(orient='series').items()}
+        A[0:nrows] = write_dict
+
+        if attr_metadata is not None:
+            write_attr_metadata(A, attr_metadata)
+
+
+def open_dataframe(uri):
+    """
+
+    :param uri:
+    :return: dataframe constructed from given TileDB array URI
+    """
+
+    import pandas as pd
+
+    with tiledb.open(uri) as A:
+        if not '__pandas_attribute_repr' in A.meta:
+            raise ValueError("Missing key '__pandas_attribute_repr'")
+        repr_meta = json.loads(A.meta['__pandas_attribute_repr'])
+
+        data = A[:]
+
+        for col_name, col_val in data.items():
+            if col_name in repr_meta:
+                new_col = pd.Series(col_val, dtype=repr_meta[col_name])
+                data[col_name] = new_col
+
+    return pd.DataFrame.from_dict(data)

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -219,7 +219,8 @@ def from_csv(uri, csv_file, distributed=False, **kwargs):
     try:
         import pandas
     except ImportError as exc:
-        raise ImportError("tiledb.from_csv requires pandas") from exc
+        print("tiledb.from_csv requires pandas")
+        raise
 
     tiledb_args = kwargs.pop('tiledb_args', None)
 

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -14,7 +14,7 @@ else:
 # - implement support for read CSV via TileDB VFS from any supported FS
 
 TILEDB_KWARG_DEFAULTS = {
-    'ctx': tiledb.default_ctx(),
+    'ctx': None,
     'cell_order': 'row-major',
     'tile_order': 'row-major',
     'sparse': False
@@ -118,9 +118,12 @@ def write_attr_metadata(array, metadata):
 def from_dataframe(uri, dataframe, **kwargs):
 
     args = TILEDB_KWARG_DEFAULTS
+
     tiledb_args = kwargs.pop('tiledb_args', None)
     if tiledb_args is not None:
         args.update(tiledb_args)
+    if not args.get('ctx', None):
+        args['ctx'] = tiledb.default_ctx()
 
     ctx = args['ctx']
     tile_order = args['tile_order']

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -105,7 +105,6 @@ def from_csv(uri, csv_file, distributed=False, **kwargs):
 
 def write_attr_metadata(array, metadata):
     """
-
     :param array: open, writable TileDB array
     :param metadata: dict
     :return:
@@ -154,10 +153,6 @@ def from_dataframe(uri, dataframe, **kwargs):
     )
 
     tiledb.Array.create(uri, schema, ctx=ctx)
-
-    # TODO remove
-    global df
-    df = dataframe
 
     with tiledb.DenseArray(uri, 'w') as A:
         write_dict =  {k: v.values for k,v in dataframe.to_dict(orient='series').items()}

--- a/tiledb/tests/check_csv_dir.py
+++ b/tiledb/tests/check_csv_dir.py
@@ -1,0 +1,43 @@
+# This is a helper function to run tests on an external
+# directory, for example the contents of the Pandas
+# CSV tests:
+#   https://github.com/pandas-dev/pandas/tree/master/pandas/tests/io/data/csv
+# It takes one argument, the test directory, and checks that all
+# .csv files contained within are correctly round-tripped via
+# `tiledb.from_csv` and `tiledb.open_dataframe`
+
+import tiledb
+import os
+import sys
+import tempfile
+import pandas as pd
+import pandas._testing as tm
+from glob import glob
+
+
+def check_csv_roundtrip(input_csv):
+    basename = os.path.basename(input_csv)
+    tmp = tempfile.mktemp(prefix="csvtest-"+basename)
+    os.mkdir(tmp)
+
+    array_uri = os.path.join(tmp, "tiledb_from_csv")
+    tiledb.from_csv(array_uri, input_csv)
+
+    df_csv = pd.read_csv(input_csv)
+    df_back = tiledb.open_dataframe(array_uri)
+
+    tm.assert_frame_equal(df_csv, df_back)
+    return True
+
+
+def check_csv_dir(path):
+    files = glob(os.path.join(path, "*.csv"))
+    res = [check_csv_roundtrip(f) for f in files]
+
+    assert len(res) == len(files), "Failed to check all files!"
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print("expected one argument: path to CSV directory")
+
+    check_csv_dir(sys.argv[1])

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -79,14 +79,30 @@ def rand_ascii_bytes(size=5):
 def dtype_max(dtype):
     if not np.issubdtype(dtype, np.generic):
         raise TypeError("expected numpy dtype!")
-    iinfo = np.iinfo(dtype)
-    return int(iinfo.max)
+
+    if np.issubdtype(dtype, np.floating):
+        finfo = np.finfo(dtype)
+        return finfo.max
+
+    elif np.issubdtype(dtype, np.integer):
+        iinfo = np.iinfo(dtype)
+        return int(iinfo.max)
+
+    raise "Unknown dtype for dtype_max '{dtype}'".format(str(dtype))
 
 def dtype_min(dtype):
     if not np.issubdtype(dtype, np.generic):
         raise TypeError("expected numpy dtype!")
-    iinfo = np.iinfo(dtype)
-    return int(iinfo.min)
+
+    if np.issubdtype(dtype, np.floating):
+        finfo = np.finfo(dtype)
+        return finfo.min
+
+    elif np.issubdtype(dtype, np.integer):
+        iinfo = np.iinfo(dtype)
+        return int(iinfo.min)
+
+    raise "Unknown dtype for dtype_min '{dtype}'".format(str(dtype))
 
 def rand_int_sequential(size, dtype=np.uint64):
     arr = np.random.randint(dtype_max(dtype), size=size, dtype=dtype)

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 try:
     import pandas as pd
+    import pandas._testing as tm
+
     import_failed = False
 except ImportError:
     import_failed = True
@@ -14,7 +16,7 @@ from numpy.testing import assert_array_equal
 import tiledb
 from tiledb.tests.common import *
 
-def make_dataframe_ex1(col_size=10):
+def make_dataframe_basic1(col_size=10):
     data_dict = {
         'time': rand_int_sequential(col_size, dtype=np.uint64),
         'x': np.array([rand_ascii(4) for _ in range(col_size)]),
@@ -37,6 +39,38 @@ def make_dataframe_ex1(col_size=10):
     df = pd.DataFrame.from_dict(data_dict)
     return df
 
+def make_dataframe_basic2():
+    # This code is from Pandas feather i/o tests "test_basic" function:
+    #   https://github.com/pandas-dev/pandas/blob/master/pandas/tests/io/test_feather.py
+    # (available under BSD 3-clause license
+    #   https://github.com/pandas-dev/pandas/blob/master/LICENSE
+
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "string": list("abc"),
+            "int": list(range(1, 4)),
+            "uint": np.arange(3, 6).astype("u1"),
+            "float": np.arange(4.0, 7.0, dtype="float64"),
+            # TODO "float_with_null": [1.0, np.nan, 3],
+            "bool": [True, False, True],
+            # TODO "bool_with_null": [True, np.nan, False],
+            #"cat": pd.Categorical(list("abc")),
+            "dt": pd.date_range("20130101", periods=3),
+            #"dttz": pd.date_range("20130101", periods=3, tz="US/Eastern"),
+            #"dt_with_null": [
+            #    pd.Timestamp("20130101"),
+            #    pd.NaT,
+            #    pd.Timestamp("20130103"),
+            #],
+            "dtns": pd.date_range("20130101", periods=3, freq="ns"),
+        }
+    )
+
+    return df
+
+
 class PandasDataFrameRoundtrip(DiskTestCase):
     def setUp(self):
         if import_failed:
@@ -44,11 +78,10 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         else:
             super(PandasDataFrameRoundtrip, self).setUp()
 
-    def test_manual_dataframe_rt(self):
+    def test_dataframe_basic_rt1_manual(self):
 
-        uri = self.path("df_roundtrip")
+        uri = self.path("dataframe_basic_rt1_manual")
 
-        print(uri)
         ctx = tiledb.Ctx()
         dom = tiledb.Domain(tiledb.Dim(name="i_chars",
                                        domain=(0, 10000),
@@ -67,7 +100,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         compression = tiledb.FilterList([tiledb.ZstdFilter(level=-1)])
         attrs = [
             tiledb.Attr(name="x", dtype='U', filters=compression, ctx=ctx),
-            tiledb.Attr(name="chars", dtype='S', filters=compression, ctx=ctx),
+            tiledb.Attr(name="chars", dtype='|S2', filters=compression, ctx=ctx),
 
             tiledb.Attr(name="q", dtype='U', filters=compression, ctx=ctx),
             tiledb.Attr(name="r", dtype='S', filters=compression, ctx=ctx),
@@ -83,7 +116,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
                                     ctx=ctx)
         tiledb.SparseArray.create(uri, schema)
 
-        df = make_dataframe_ex1()
+        df = make_dataframe_basic1()
         incr = 0
         with tiledb.SparseArray(uri, 'w') as A:
             s_ichars = []
@@ -101,3 +134,58 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             df1 = pd.DataFrame.from_dict(A[:])
             for col in df.columns:
                 assert_array_equal(df[col], df1[col])
+
+    def test_dataframe_basic1(self):
+        uri = self.path("dataframe_basic_rt1")
+        df = make_dataframe_basic1()
+
+        tiledb.from_dataframe(uri, df)
+
+        # TODO tiledb.read_dataframe
+        with tiledb.open(uri) as B:
+            df_readback = pd.DataFrame.from_dict(B[:])
+            tm.assert_frame_equal(df, df_readback)
+
+    def test_dataframe_basic2(self):
+        uri = self.path("dataframe_basic_rt2")
+
+        df = make_dataframe_basic2()
+
+        tiledb.from_dataframe(uri, df)
+
+        with tiledb.open(uri) as B:
+            df_readback = tiledb.open_dataframe(uri)
+            tm.assert_frame_equal(df, df_readback)
+
+    def test_dataframe_csv_rt1(self):
+        def rand_dtype(dtype, size):
+            import os
+            nbytes = size * np.dtype(dtype).itemsize
+
+            randbytes = os.urandom(nbytes)
+            return np.frombuffer(randbytes, dtype=dtype)
+
+        uri = self.path("dataframe_csv_rt1")
+        os.mkdir(uri)
+        col_size=15
+        data_dict = {
+            'dates': np.array(
+                rand_dtype(np.uint64, col_size), dtype=np.dtype('datetime64[ns]')
+            ),
+            'float64s': rand_dtype(np.float64, col_size),
+            'ints': rand_dtype(np.int64, col_size),
+            'strings': [rand_utf8(5) for _ in range(col_size)],
+        }
+
+        df_orig = pd.DataFrame.from_dict(data_dict)
+
+        csv_uri = os.path.join(uri, "test.csv")
+        # note: encoding must be specified to avoid printing the b'' bytes
+        #       prefix, see https://github.com/pandas-dev/pandas/issues/9712
+        df_orig.to_csv(csv_uri, mode='w')
+
+        csv_array_uri = os.path.join(uri, "tiledb_csv")
+        tiledb.from_csv(csv_array_uri, csv_uri, index_col = 0, parse_dates=[1])
+
+        df_from_array = tiledb.open_dataframe(csv_array_uri)
+        tm.assert_frame_equal(df_orig, df_from_array)


### PR DESCRIPTION
Adds functions to create a TileDB array from dataframes and CSV files,
  with schema created automatically (if possible, or else error)
  - tiledb.from_dataframe accepting a Pandas dataframe
  - tiledb.from_csv

Adds function to load a TileDB array as a pandas dataframe, using
  metadata for non-primitive type representations when available.
  - tiledb.open_dataframe

CSV functionality is manually tested against the [pandas CSV test files](https://github.com/pandas-dev/pandas/tree/master/pandas/tests/io/data/csv) using the included `check_csv_dir.py` file.