### PR TITLE
Support domain.dim('dim name')

### DIFF
--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -256,6 +256,10 @@ class DomainTest(unittest.TestCase):
         dim_names = [dim.name for dim in dom]
         self.assertEqual(["d1", "d2"], dim_names)
 
+        # check that we can access dim by name
+        dim_d1 = dom.dim("d1")
+        self.assertEqual(dim_d1, dom.dim(0))
+
     def test_domain_dims_not_same_type(self):
         with self.assertRaises(TypeError):
             tiledb.Domain(


### PR DESCRIPTION
This was implemented as a Cython method overload, which AFAICT only
works for Cython C++ classes.

```
%load_ext cython
```
```
%%cython

cdef class Foo(object):
    def p(self, int p):
        print("got int p: ", p)

    def p(self, str s):
        print("got str s: " , s)

f = Foo()
f.p(1)
f.p("abc") # error
```