### PR TITLE
Clean up FileIO for better compatibility with RawIOBase

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,13 +1,15 @@
 # In progress
 
 ## Improvements
-- Added dataframe and CSV helper functions [#TDB](...)
-    `tiledb.{from_dataframe, from_csv, open_dataframe}`
+- Added dataframe and CSV helper functions [#269](https://github.com/TileDB-Inc/TileDB-Py/pull/269)
+  - `tiledb.{from_dataframe, from_csv, open_dataframe}`
 - Added repr for ArraySchema [#267](https://github.com/TileDB-Inc/TileDB-Py/pull/267)
 - Added repr for Attr [#266](https://github.com/TileDB-Inc/TileDB-Py/pull/266)
-- Added `Array.dim` access for direct access to Dim by name or index (similar to `Array.attr`) [#272](https://github.com/TileDB-Inc/TileDB-Py/pull/266)
+- Added `Array.dim` access for direct access to Dim by name or index (similar to `Array.attr`) [#272](https://github.com/TileDB-Inc/TileDB-Py/pull/272)
 
 ## Bug fixes
+- Fixed a number of bugs in the FileIO class, to allow using as input to other libraries which accept
+  a file-like object (e.g. pandas readers) [#273](https://github.com/TileDB-Inc/TileDB-Py/pull/273)
 - Fixed accessing domain dimension by name (`domain.dim('dim name')`) [#271](https://github.com/TileDB-Inc/TileDB-Py/pull/271)
 
 # TileDB-Py 0.5.6 Release Notes

--- a/examples/vfs.py
+++ b/examples/vfs.py
@@ -75,7 +75,7 @@ def write():
     vfs = tiledb.VFS()
 
     # Create VFS file handle
-    f = vfs.open("tiledb_vfs.bin", "w")
+    f = vfs.open("tiledb_vfs.bin", "wb")
 
     # Write binary data
     vfs.write(f, struct.pack("f", 153.0))
@@ -83,13 +83,13 @@ def write():
     vfs.close(f)
 
     # Write binary data again - this will overwrite the previous file
-    f = vfs.open("tiledb_vfs.bin", "w")
+    f = vfs.open("tiledb_vfs.bin", "wb")
     vfs.write(f, struct.pack("f", 153.1))
     vfs.write(f, "abcdef".encode("utf-8"))
     vfs.close(f)
 
     # Append binary data to existing file (this will NOT work on S3)
-    f = vfs.open("tiledb_vfs.bin", "a")
+    f = vfs.open("tiledb_vfs.bin", "ab")
     vfs.write(f, "ghijkl".encode("utf-8"))
     vfs.close(f)
 
@@ -99,7 +99,7 @@ def read():
     vfs = tiledb.VFS()
 
     # Read binary data
-    f = vfs.open("tiledb_vfs.bin", "r")
+    f = vfs.open("tiledb_vfs.bin", "rb")
     f1 = struct.unpack("f", vfs.read(f, 0, 4))[0]
     s1 = bytes.decode(vfs.read(f, 4, 12), "utf-8")
     print("Binary read:\n{}\n{}".format(f1, s1))

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -5523,8 +5523,8 @@ class FileIO(io.RawIOBase):
         return self._readonly
 
     def seek(self, offset, whence=0):
-        if not isinstance(offset, int):
-            raise TypeError("offset must be an integer")
+        if not isinstance(offset, (int, long)):
+            raise TypeError(f"Offset must be an integer or None (got {safe_repr(offset)})")
         if whence == 0:
             if offset < 0:
                 raise ValueError("offset must be a positive or zero value when SEEK_SET")
@@ -5549,12 +5549,12 @@ class FileIO(io.RawIOBase):
         return not self._readonly
 
     def read(self, size=-1):
-        if not isinstance(size, int):
-            raise TypeError("offset must be an integer")
+        if not isinstance(size, (int, long)):
+            raise TypeError(f"size must be an integer or None (got {safe_repr(size)})")
         if self._mode == "wb":
-            raise IOError("cannot read from write-only FileIO handle")
+            raise IOError("Cannot read from write-only FileIO handle")
         if self.closed:
-            raise IOError("cannot read from closed FileIO handle")
+            raise IOError("Cannot read from closed FileIO handle")
         nbytes_remaining = self._nbytes - self._offset
         cdef Py_ssize_t nbytes
         if size < 0:
@@ -5571,6 +5571,9 @@ class FileIO(io.RawIOBase):
         self.vfs.readinto(self.fh, buff, self._offset, nbytes)
         self._offset += nbytes
         return buff
+
+    def read1(self, size=-1):
+        return self.read(size)
 
     def readall(self):
         if self._mode == "wb":

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -12,6 +12,7 @@ from .array import DenseArray, SparseArray
 import sys
 from os.path import abspath
 from collections import OrderedDict
+import io
 try:
     # Python 2
     from StringIO import StringIO
@@ -5288,11 +5289,11 @@ cdef class VFS(object):
 
         """
         cdef tiledb_vfs_mode_t vfs_mode
-        if mode == "r":
+        if mode == "rb":
             vfs_mode = TILEDB_VFS_READ
-        elif mode == "w":
+        elif mode == "wb":
             vfs_mode = TILEDB_VFS_WRITE
-        elif mode == "a":
+        elif mode == "ab":
             vfs_mode = TILEDB_VFS_APPEND
         else:
             raise ValueError("invalid mode {0!r}".format(mode))
@@ -5326,7 +5327,7 @@ cdef class VFS(object):
             _raise_ctx_err(ctx_ptr, rc)
         return fh
 
-    def readinto(self, FileHandle fh, bytes buffer, offset, nbytes):
+    def readinto(self, FileHandle fh, const unsigned char[:] buffer, offset, nbytes):
         """Read nbytes from an opened VFS FileHandle at a given offset into a preallocated bytes buffer
 
         :param FileHandle fh: An opened VFS FileHandle in 'r' mode
@@ -5348,13 +5349,14 @@ cdef class VFS(object):
         cdef tiledb_vfs_fh_t* fh_ptr = fh.ptr
         cdef uint64_t _offset = offset
         cdef uint64_t _nbytes = nbytes
-        cdef char* buffer_ptr = PyBytes_AS_STRING(buffer)
+        cdef const unsigned char* buffer_ptr = &buffer[0]
         cdef int rc = TILEDB_OK
         with nogil:
-            rc = tiledb_vfs_read(ctx_ptr, fh_ptr, _offset, <void*> buffer_ptr, _nbytes)
+            rc = tiledb_vfs_read(ctx_ptr, fh_ptr, _offset, <void*>buffer_ptr, _nbytes)
         if rc != TILEDB_OK:
             _raise_ctx_err(ctx_ptr, rc)
-        return buffer
+        # TileDB will error if the requested bytes are not read exactly
+        return nbytes
 
     def read(self, FileHandle fh, offset, nbytes):
         """Read nbytes from an opened VFS FileHandle at a given offset
@@ -5367,9 +5369,12 @@ cdef class VFS(object):
         :raises: :py:exc:`tiledb.TileDBError`
 
         """
+        if nbytes == 0:
+            return b''
         cdef Py_ssize_t _nbytes = nbytes
         cdef bytes buffer = PyBytes_FromStringAndSize(NULL, _nbytes)
-        return self.readinto(fh, buffer, offset, nbytes)
+        cdef Py_ssize_t res_nbytes = self.readinto(fh, buffer, offset, nbytes)
+        return buffer
 
     def write(self, FileHandle fh, buff):
         """Writes buffer to opened VFS FileHandle
@@ -5465,21 +5470,20 @@ cdef class VFS(object):
         return Config.from_ptr(config_ptr)
 
 
-class FileIO(object):
-
-    def __init__(self, VFS vfs, uri, mode="r"):
+class FileIO(io.RawIOBase):
+    def __init__(self, VFS vfs, uri, mode="rb"):
         self.fh = vfs.open(uri, mode=mode)
         self.vfs = vfs
         self._offset = 0
         self._closed = False
         self._readonly = True
-        if mode == "r":
+        if mode == "rb":
             try:
                 self._nbytes = vfs.file_size(uri)
             except:
                 raise IOError("URI {0!r} is not a valid file")
-            self._read_only = True
-        elif mode == "w":
+            self._readonly = True
+        elif mode == "wb":
             self._readonly = False
             self._nbytes = 0
         else:
@@ -5487,10 +5491,14 @@ class FileIO(object):
         self._mode = mode
         return
 
-    def __enter__(self):
-        pass
+    def __len__(self):
+        return self._nbytes
 
-    def __exit__(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.flush()
         self.close()
         return
 
@@ -5511,6 +5519,9 @@ class FileIO(object):
     def seekable(self):
         return True
 
+    def readable(self):
+        return self._readonly
+
     def seek(self, offset, whence=0):
         if not isinstance(offset, int):
             raise TypeError("offset must be an integer")
@@ -5529,16 +5540,18 @@ class FileIO(object):
         elif self._offset > self._nbytes:
             self._offset = self._nbytes
 
+        return self._offset
+
     def tell(self):
         return self._offset
 
-    def writeable(self):
+    def writable(self):
         return not self._readonly
 
     def read(self, size=-1):
         if not isinstance(size, int):
             raise TypeError("offset must be an integer")
-        if self._mode == "w":
+        if self._mode == "wb":
             raise IOError("cannot read from write-only FileIO handle")
         if self.closed:
             raise IOError("cannot read from closed FileIO handle")
@@ -5550,13 +5563,17 @@ class FileIO(object):
             nbytes = nbytes_remaining
         else:
             nbytes = size
+
+        if nbytes == 0:
+            return b''
+
         cdef bytes buff = PyBytes_FromStringAndSize(NULL, nbytes)
         self.vfs.readinto(self.fh, buff, self._offset, nbytes)
         self._offset += nbytes
         return buff
 
     def readall(self):
-        if self._mode == "w":
+        if self._mode == "wb":
             raise IOError("cannot read from a write-only FileIO handle")
         if self.closed:
             raise IOError("cannot read from closed FileIO handle")
@@ -5569,19 +5586,23 @@ class FileIO(object):
         return buff
 
     def readinto(self, buff):
-        if self._mode == "w":
+        if self._mode == "wb":
             raise IOError("cannot read from a write-only FileIO handle")
         if self.closed:
             raise IOError("cannot read from closed FileIO handle")
-        nbytes = self._nbytes - self._offset
+        nbytes = len(buff)
+        if nbytes > self._nbytes:
+            nbytes = self._nbytes
         if nbytes == 0:
-            return
+            return 0
         self.vfs.readinto(self.fh, buff, self._offset, nbytes)
         self._offset += nbytes
-        return
+
+        # RawIOBase contract is to return the number of bytes read
+        return nbytes
 
     def write(self, buff):
-        if not self.writeable():
+        if not self.writable():
             raise IOError("cannot write to read-only FileIO handle")
         nbytes = len(buff)
         self.vfs.write(self.fh, buff)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2404,12 +2404,12 @@ class VFS(DiskTestCase):
         lines = [rand_utf8(random.randint(0, 50))+'\n' for _ in range(10)]
         rand_uri = self.path("test_fio.rand")
         with tiledb.FileIO(vfs, rand_uri, 'wb') as f:
-            txtio = io.TextIOWrapper(f)
+            txtio = io.TextIOWrapper(f, encoding='utf-8')
             txtio.writelines(lines)
             txtio.flush()
 
         with tiledb.FileIO(vfs, rand_uri, 'rb') as f2:
-            txtio = io.TextIOWrapper(f2)
+            txtio = io.TextIOWrapper(f2, encoding='utf-8')
             self.assertEqual(txtio.readlines(), lines)
 
     def test_ls(self):


### PR DESCRIPTION
This PR fixes a number of problems with the FileIO wrapper class which prevented using it with other Python libraries expecting a file-like object for input. In particular, these changes make it possible to pass a FileIO object to pandas and successfully read the content (test added with a TextIOWrapper around a generated local file; manually tested against an S3 VFS).

---
- inherit from RawIOBase
- fix spelling of `writable` (this is checked by various io wrappers)
- fix spelling of `_read_only` -> `read_only` in internal assignment
- fix `readinto` to take any memoryview-like object instead of only `bytes`
- accept `rb`/`wb`/`ab` modes only (not sure if HL callers use this, but we should not lie about being usable as a text i/o)
- fix `readinto` to read up to the length of the given buffer rather than internal nbytes
- add `readable()`
- add __len__
- fix return value of read when EOF (must return empty string b’’)
- fix return value of seek (must return seek’d position)
- fix context manager for FileIO (__enter__ should return self, __exit__ should take self+3 args)
- add tests (esp. for r+w via TextIOWrapper, which is used by pandas read_csv)