### PR TITLE
Improve tests and error messages for mixed-input slicing

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2636,8 +2636,10 @@ def index_domain_subarray(dom: Domain, idx: tuple):
                 raise IndexError('cannot index datetime dimension with non-datetime interval')
             # don't round / promote fp slices
             if np.issubdtype(dim.dtype, np.integer):
-                if not isinstance(stop, _inttypes):
+                if isinstance(start, (np.float32, np.float64)):
                     raise IndexError("cannot index integral domain dimension with floating point slice")
+                elif not isinstance(start, _inttypes):
+                    raise IndexError("cannot index integral domain dimension with non-integral slice (dtype: {})".format(type(start)))
             if not is_datetime and stop < 0:
                 stop += dim_ub
             if stop > dim_ub:

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -760,6 +760,10 @@ class DenseArrayTest(DiskTestCase):
             # mixed-type slicing
             # https://github.com/TileDB-Inc/TileDB-Py/issues/140
             self.assertEqual(A[0:1], T[0:np.uint16(1)])
+            self.assertEqual(A[0:1], T[np.int64(0):1])
+            with self.assertRaises(IndexError):
+                # this is a consequence of NumPy promotion rules
+                self.assertEqual(A[0:1], T[np.uint64(0):1])
 
             # basic step
             assert_array_equal(A[:50:2], T[:50:2])

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -321,6 +321,10 @@ class TestMultiRange(DiskTestCase):
                 orig_array[0:],
                 A.multi_index[ [slice(-10, 10),] ][attr_name]
             )
+            assert_array_equal(
+                orig_array[0:10],
+                A.multi_index[ -10:np.int64(-1) ][attr_name]
+            )
 
 
     def test_multirange_1d_sparse_double(self):


### PR DESCRIPTION
NumPy scalar slicing is supported (#253). However, there are still some cases
where the NumPy type promotion rules end up coercing the inputs to
float, such as `[np.uint64(0) : 1]` (whereas `np.int64(0):1` works
fine).

Fixes #253