### PR TITLE
Fix and test tiledb.open KeyError path for non-existent attribute

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,9 +9,11 @@
 - Added support for `read_csv` to read the input file from a TileDB VFS [#275](https://github.com/TileDB-Inc/TileDB-Py/pull/275)
 
 ## Bug fixes
+- Fixed accessing domain dimension by name (`domain.dim('dim name')`) [#271](https://github.com/TileDB-Inc/TileDB-Py/pull/271)
 - Fixed a number of bugs in the FileIO class, to allow using as input to other libraries which accept
   a file-like object (e.g. pandas readers) [#273](https://github.com/TileDB-Inc/TileDB-Py/pull/273)
-- Fixed accessing domain dimension by name (`domain.dim('dim name')`) [#271](https://github.com/TileDB-Inc/TileDB-Py/pull/271)
+- Fixed bug in tiledb.open path when attribute name does not exist [#277](https://github.com/TileDB-Inc/TileDB-Py/pull/277)
+
 
 # TileDB-Py 0.5.6 Release Notes
 

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3227,9 +3227,9 @@ cdef class Array(object):
             else:
                 new_array_typed = SparseArray.__new__(SparseArray)
 
-        except TileDBError as exc:
+        except:
             tiledb_array_free(&array_ptr)
-            raise exc
+            raise
 
         # *** this assignment must happen outside the try block ***
         # *** because the array destructor will free array_ptr  ***

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2526,6 +2526,11 @@ class HighlevelTests(DiskTestCase):
         with tiledb.open(uri, config=config) as A:
             self.assertEqual(A._ctx_().config(), config)
 
+        with self.assertRaises(KeyError):
+            # This path must test `tiledb.open` specifically
+            # https://github.com/TileDB-Inc/TileDB-Py/issues/277
+            tiledb.open(uri, 'r', attr='the-missing-attr')
+
     @unittest.skipIf(platform.system() == 'Windows' or \
                      sys.version_info < (3,2), "")
     def test_ctx_thread_cleanup(self):

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1220,6 +1220,23 @@ class DenseArrayTest(DiskTestCase):
             self.assertTrue(t_w1 > 0)
             self.assertTrue(t_w2 > 0)
 
+    def test_missing_schema_error(self):
+        uri = self.path("test_missing_schema_error")
+
+        ctx = tiledb.Ctx()
+        dom = tiledb.Domain(tiledb.Dim(domain=(0, 9), tile=10, dtype=np.int64, ctx=ctx), ctx=ctx)
+        att = tiledb.Attr(ctx=ctx, dtype=np.int64)
+        schema = tiledb.ArraySchema(ctx=ctx, domain=dom, attrs=(att,))
+        tiledb.DenseArray.create(uri, schema)
+
+        with tiledb.DenseArray(uri, mode='w', ctx=ctx) as T:
+            T[:] = np.arange(0, 10, dtype=np.int64)
+
+        tiledb.VFS().remove_file(os.path.join(uri, "__array_schema.tdb"))
+
+        with self.assertRaises(tiledb.TileDBError):
+            tiledb.DenseArray(uri)
+
 
 class DenseVarlen(DiskTestCase):
     def test_varlen_write_bytes(self):


### PR DESCRIPTION
Fixes crash when the name of a non-existent attribute is passed to `tiledb.open` (via https://github.com/dask/dask/issues/5915).

Also reduce specificity for a schema load `try..catch` block because the array should be freed for any exception, and add a test for the schema load failure condition.