### PR TITLE
Improve type check and error reporting for sparse assignment

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2076,7 +2076,7 @@ cdef class Attr(object):
 
 
     def __repr__(self):
-        return f"""Attr(name={repr(self.name)}, dtype={self.dtype!s})"""
+        return f"""Attr(name={repr(self.name)}, dtype='{self.dtype!s}')"""
 
 
 cdef class Dim(object):
@@ -2171,7 +2171,7 @@ cdef class Dim(object):
         self.ptr = dim_ptr
 
     def __repr__(self):
-        return 'Dim(name={0!r}, domain={1!s}, tile={2!s}, dtype={3!s})' \
+        return "Dim(name={0!r}, domain={1!s}, tile={2!s}, dtype='{3!s}')" \
             .format(self.name, self.domain, self.tile, self.dtype)
 
     def __len__(self):

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -119,8 +119,12 @@ def intspace(start, stop, num=50, dtype=np.int64):
     :return:
     """
     rval = np.zeros(num, dtype=dtype)
-    step = (stop-start)//num
+    step = (stop-start) // num
     nextval = start
+
+    if np.issubdtype(dtype, np.integer) and step < 1:
+      raise ValueError("Cannot use non-integral step value '{}' for integer dtype!".format(
+                      step))
 
     for i in range(num):
         rval[i] = nextval

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2632,7 +2632,7 @@ class ReprTest(unittest.TestCase):
     def test_attr_repr(self):
         attr = tiledb.Attr(name="itsanattr", dtype=np.float64)
         self.assertTrue(
-            re.match(r"Attr\(name=[u]?'itsanattr', dtype=float64\)",
+            re.match(r"Attr\(name=[u]?'itsanattr', dtype='float64'\)",
                      repr(attr))
         )
 
@@ -2655,8 +2655,7 @@ class ReprTest(unittest.TestCase):
         schema_repr = repr(orig_schema)
         g = dict()
         setup = ("from tiledb import ArraySchema, Domain, Attr, Dim\n"
-                 "import numpy as np\n"
-                 "from numpy import uint64, float64\n")
+                 "import numpy as np\n")
 
         exec(setup, g)
         new_schema = eval(schema_repr, g)


### PR DESCRIPTION
This change adds a printout of the attribute name if an input variable cannot be converted to NumPy when writing to a sparse array; previously it was difficult to determine which input was failing (e.g. when working with many attributes in a dataframe from `read_csv`).

plus two other small fixes
- print `dtype` repr as quoted string
- check calculated step in `tests.common.intspace` helper