### PR TITLE
Core update/sync 1

### DIFF
--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -61,6 +61,7 @@ from .libtiledb import (
      stats_disable,
      stats_reset,
      stats_dump,
+     vacuum
 )
 
 from .array import DenseArray, SparseArray

--- a/tiledb/libmetadata.pyx
+++ b/tiledb/libmetadata.pyx
@@ -327,10 +327,15 @@ cdef object load_metadata(Array array, unpack=True):
         if not unpack:
             ret_val.append(key)
         else:
-            # TODO change this after TileDB 1.8 fix
             # in this case, the key might exist with empty value
-            if value_num == 0:
-                unpacked_val = array.meta[key]
+            if (value == NULL) and (value_num == 1):
+                   # in this case, the key exists with empty value
+                   if value_type == TILEDB_CHAR:
+                       unpacked_val = b''
+                   elif value_type == TILEDB_STRING_UTF8:
+                       unpacked_val = u''
+                   else:
+                       unpacked_val = ()
             else:
                 unpacked_val = unpack_metadata_val(value_type, value_num, value)
 

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -838,6 +838,11 @@ cdef extern from "tiledb/tiledb.h":
         uint64_t* buffer_off_size,
         uint64_t* buffer_val_size) nogil
 
+    int tiledb_array_vacuum(
+        tiledb_ctx_t* ctx,
+        const char* array_uri,
+        tiledb_config_t* config) nogil
+
     # Resource management
     int tiledb_object_type(
         tiledb_ctx_t* ctx,

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2397,11 +2397,6 @@ cdef class Domain(object):
         if ndim == 0:
             raise TileDBError("Domain must have ndim >= 1")
         cdef Dim dimension = dims[0]
-        cdef tiledb_datatype_t domain_type = dimension._get_type()
-        for i in range(1, ndim):
-            dimension = dims[i]
-            if dimension._get_type() != domain_type:
-                raise TypeError("all dimensions must have the same dtype")
 
         if (ndim > 1):
             if all(dim.name == '__dim_0' for dim in dims):
@@ -5646,3 +5641,17 @@ class FileIO(io.RawIOBase):
         self._nbytes += nbytes
         self._offset += nbytes
         return nbytes
+
+def vacuum(array_uri, Config config=None, Ctx ctx=None):
+    cdef tiledb_ctx_t* ctx_ptr = NULL
+    cdef tiledb_config_t* config_ptr = NULL
+
+    if not ctx:
+        ctx = default_ctx()
+
+    ctx_ptr = ctx.ptr
+    config_ptr = config.ptr if config is not None else NULL
+    cdef bytes buri = unicode_path(array_uri)
+    cdef const char* uri_ptr = PyBytes_AS_STRING(buri)
+
+    tiledb_array_vacuum(ctx_ptr, uri_ptr, config_ptr)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -188,7 +188,7 @@ class DimensionTest(unittest.TestCase):
     def test_minimal_dimension(self):
         ctx = tiledb.Ctx()
         dim = tiledb.Dim(domain=(0, 4), tile=5, ctx=ctx)
-        self.assertEqual(dim.name, "", "dimension name is empty")
+        self.assertEqual(dim.name, "__dim_0", "automatic dimension name is incorrect")
         self.assertEqual(dim.shape, (5,))
         self.assertEqual(dim.tile, 5)
 
@@ -273,6 +273,12 @@ class DomainTest(unittest.TestCase):
         dom = tiledb.Domain(dim)
         self.assertEqual(dom.dtype, np.datetime64('', 'D'))
 
+    def test_domain_mixed_names_error(self):
+        ctx = tiledb.Ctx()
+        with self.assertRaises(tiledb.TileDBError):
+            tiledb.Domain(
+                tiledb.Dim("d1", (1, 4), 2, dtype='u8'),
+                tiledb.Dim("__dim_0", (1, 4), 2, dtype='u8'))
 
 class AttributeTest(unittest.TestCase):
 
@@ -441,14 +447,14 @@ class ArraySchemaTest(unittest.TestCase):
         ctx = tiledb.Ctx()
 
         # create dimensions
-        d1 = tiledb.Dim("", domain=(1, 1000), tile=10, dtype="uint64", ctx=ctx)
+        d1 = tiledb.Dim("d1", domain=(1, 1000), tile=10, dtype="uint64", ctx=ctx)
         d2 = tiledb.Dim("d2", domain=(101, 10000), tile=100, dtype="uint64", ctx=ctx)
 
         # create domain
         domain = tiledb.Domain(d1, d2, ctx=ctx)
 
         # create attributes
-        a1 = tiledb.Attr("", dtype="int32,int32,int32", ctx=ctx)
+        a1 = tiledb.Attr("a1", dtype="int32,int32,int32", ctx=ctx)
         a2 = tiledb.Attr("a2",
                          filters=tiledb.FilterList([tiledb.GzipFilter(-1, ctx=ctx)], ctx=ctx),
                          dtype="float32", ctx=ctx)
@@ -502,14 +508,14 @@ class ArraySchemaTest(unittest.TestCase):
         ctx = tiledb.Ctx()
 
         # create dimensions
-        d1 = tiledb.Dim("", domain=(1, 1000), tile=10, dtype="uint64", ctx=ctx)
+        d1 = tiledb.Dim("d1", domain=(1, 1000), tile=10, dtype="uint64", ctx=ctx)
         d2 = tiledb.Dim("d2", domain=(101, 10000), tile=100, dtype="uint64", ctx=ctx)
 
         # create domain
         domain = tiledb.Domain(d1, d2, ctx=ctx)
 
         # create attributes
-        a1 = tiledb.Attr("", dtype="int32,int32,int32", ctx=ctx)
+        a1 = tiledb.Attr("a1", dtype="int32,int32,int32", ctx=ctx)
         #a2 = tiledb.Attr(ctx, "a2", compressor=("gzip", -1), dtype="float32")
         filter_list = tiledb.FilterList([tiledb.GzipFilter(ctx=ctx)], ctx=ctx)
         a2 = tiledb.Attr("a2", filters=filter_list, dtype="float32", ctx=ctx)


### PR DESCRIPTION
- Sync up metadata empty-val indicator with core libtiledb
- Avoid anonymous dim names in Domain constructor
  - automatically constructs sequentially-numbered `__dim_N` named dimensions when all dimension names are given as empty. This expands existing behavior for automatic `from_numpy` dimension naming.
- Add support for `tiledb_array_vacuum` and update related tests