### PR TITLE
Update Readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,10 +5,13 @@ formats: []
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 
+sphinx:
+  configuration: doc/source/conf.py
+
 python:
   version: 3.7
   install:
     # this order is important: we need to get cmake
-    - requirements: requirements.txt
+    - requirements: requirements_dev.txt
     - method: setuptools
       path: .

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -33,7 +33,7 @@ stages:
       displayName: 'Print env'
 
     - script: |
-        python -m pip install --upgrade -r requirements.txt
+        python -m pip install --upgrade -r requirements_dev.txt
       displayName: 'Install dependencies'
 
     - script: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,2 @@
+numpy==1.16.* ; python_version < '3.6'
 setuptools
-wheel
-numpy==1.16.*
-tox
-setuptools-scm
-cython
-dask
-pandas ; python_version > '3.5'
-psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+numpy>=1.16.* ; python_version >= '3.6'
 numpy==1.16.* ; python_version < '3.6'
 setuptools

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,11 @@
-# pinned dependencies for the development and CI
 # note: cmake 3.13 is the last manylinux1 release on pypi
 cmake==3.13.*
-cython==0.29
-numpy==1.16.*
-setuptools==40.8.0
-setuptools-scm==1.5.4
-wheel>=0.30.0
-tox==3.0.0
+cython
+pybind11
+wheel
+setuptools-scm
+tox
+dask
+pandas ; python_version > '3.5'
 psutil
+-r requirements.txt


### PR DESCRIPTION
The RTD image seems to no longer provide cmake, so we need to pull it in from PyPI in order to build the docs. Also clean up the requirements/requirements_dev split.