### PR TITLE
Remove cmake pin in requirements_dev

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 # note: cmake 3.13 is the last manylinux1 release on pypi
-cmake==3.13.*
+cmake >= 3.13
 cython
 pybind11
 wheel


### PR DESCRIPTION
manylinux1 wheels are available again, and this allows wheel installation on other platforms where wheels were *not* available for 3.13.