### PR TITLE
Add support for read_csv creation with mode=schema_only

### DIFF
--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1157,6 +1157,7 @@ cdef class Domain(object):
     cdef from_ptr(const tiledb_domain_t* ptr, Ctx ctx=*)
     cdef tiledb_datatype_t _get_type(Domain self) except? TILEDB_CHAR
     cdef _integer_domain(Domain self)
+    cdef _is_homogeneous(Domain self)
     cdef _shape(Domain self)
 
 cdef class ArraySchema(object):

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -578,7 +578,7 @@ class ArraySchemaTest(unittest.TestCase):
         self.assertFalse(schema.domain.dim("dpos").isvar)
         self.assertEqual(schema.domain.dim("dpos").dtype, np.double)
         self.assertEqual(schema.domain.dim("str_index").dtype, np.bytes_)
-        self.assertFalse(schema.domain.homogeneous())
+        self.assertFalse(schema.domain.homogeneous)
 
 class ArrayTest(DiskTestCase):
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -420,6 +420,7 @@ class ArraySchemaTest(unittest.TestCase):
         self.assertEqual(schema.ndim, 2)
         self.assertEqual(schema.shape, (8, 8))
         self.assertEqual(schema.nattr, 1)
+        self.assertEqual(schema.domain.homogeneous, True)
         self.assertEqual(schema.attr(0), a1)
         self.assertTrue(schema.has_attr("val"))
         self.assertFalse(schema.has_attr("nononoattr"))
@@ -577,6 +578,7 @@ class ArraySchemaTest(unittest.TestCase):
         self.assertFalse(schema.domain.dim("dpos").isvar)
         self.assertEqual(schema.domain.dim("dpos").dtype, np.double)
         self.assertEqual(schema.domain.dim("str_index").dtype, np.bytes_)
+        self.assertFalse(schema.domain.homogeneous())
 
 class ArrayTest(DiskTestCase):
 


### PR DESCRIPTION
This change adds support for `read_csv(..., mode='schema_only')`, which will read `nrows` rows and create a schema with matching dims/attributes *without* writing any data to the array.

[ch2471]