### PR TITLE
More CSV updates

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# TileDB-Py 0.6.3 Release Notes
+
+* Fix unnecessary implicit ordering requirement for multi-attribute assignment. [#328](https://github.com/TileDB-Inc/TileDB-Py/pull/328)
+
 # TileDB-Py 0.6.2 Release Notes
 
 ## Bug fixes

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -328,6 +328,9 @@ def open_dataframe(uri):
     >>> tiledb.objec_type("iris.tldb")
     'array'
     """
+    warnings.warn("open_dataframe is deprecated and will be removed in the next release",
+                  DeprecationWarning)
+
     import pandas as pd
 
     # TODO support `distributed=True` option?

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -4,6 +4,7 @@ import sys
 import os
 import io
 from collections import OrderedDict
+import warnings
 
 if sys.version_info >= (3,3):
     unicode_type = str
@@ -207,8 +208,14 @@ def create_dims(ctx, dataframe, index_dims):
 
     return dims
 
-
 def from_dataframe(uri, dataframe, **kwargs):
+    # deprecated in 0.6.3
+    warnings.warn("tiledb.from_dataframe is deprecated; please use .from_pandas",
+                  DeprecationWarning)
+
+    from_pandas(uri, dataframe, **kwargs)
+
+def from_pandas(uri, dataframe, **kwargs):
     """Create TileDB array at given URI from pandas dataframe
 
     :param uri: URI for new TileDB array
@@ -402,4 +409,4 @@ def from_csv(uri, csv_file, **kwargs):
     df = pandas.read_csv(csv_file, **kwargs)
 
     kwargs.update(tiledb_args)
-    from_dataframe(uri, df, **kwargs)
+    from_pandas(uri, df, **kwargs)

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4205,7 +4205,10 @@ cdef class DenseArrayImpl(Array):
         cdef list values = list()
 
         if isinstance(val, dict):
-            for (k, v) in val.items():
+            for attr_idx in range(self.schema.nattr):
+                attr = self.schema.attr(attr_idx)
+                k = attr.name
+                v = val[k]
                 attr = self.schema.attr(k)
                 attributes.append(attr._internal_name)
                 # object arrays are var-len and handled later

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1125,6 +1125,12 @@ class DenseArrayTest(DiskTestCase):
         with tiledb.DenseArray(self.path("foo"), mode='w', ctx=ctx) as T:
             T[:] = V
 
+        # check setting attribute in different order from Attr definition
+        #   https://github.com/TileDB-Inc/TileDB-Py/issues/299
+        V2 = {"floats": V_floats, "ints": V_ints}
+        with tiledb.DenseArray(self.path("foo"), mode='w', ctx=ctx) as T:
+            T[:] = V
+
         with tiledb.DenseArray(self.path("foo"), mode='r', ctx=ctx) as T:
             R = T[:]
             assert_array_equal(V["ints"], R["ints"])

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -316,7 +316,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         tmp_array2b = os.path.join(tmp_dir, "array2b")
 
         # create a duplicate value
-        df.int_vals[0] = df.int_vals[1]
+        df.loc[0, 'int_vals'] = df.int_vals[1]
         df.sort_values('int_vals', inplace=True)
 
         df.to_csv(tmp_csv2, index=False)


### PR DESCRIPTION
- Use attr and coords compression by default for from_csv
- Deprecate and rename tiledb.from_dataframe -> from_pandas
- Fix copy assignment warning from pandas
- Add deprecation warning for open_dataframe
- Remove implicit dict order requirement for multi-attr assignment