### PR TITLE
Support Dim(domain=(None,None)) to use full dtype domain

### DIFF
--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -124,14 +124,16 @@ def rand_datetime64_array(size, start=None, stop=None, dtype=None):
     if not dtype:
         dtype = np.dtype('M8[ns]')
 
-    # generate randint inbounds on the range of M8[ns]
-    # (TODO this will give weird results for ps/fs/as scale but those are uncommon)
+    # generate randint inbounds on the range of the dtype
+    units = np.datetime_data(dtype)[0]
+    intmin, intmax = np.iinfo(np.int64).min, np.iinfo(np.int64).max
+
     if start is None:
-        start = np.datetime64('1678-01-01')
+        start = np.datetime64(intmin + 1, units)
     else:
         start = np.datetime64(start)
     if stop is None:
-        stop = np.datetime64('2202-01-01')
+        stop = np.datetime64(intmax, units)
     else:
         stop = np.datetime64(stop)
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2324,9 +2324,8 @@ class DatetimeSlicing(DiskTestCase):
             tile = np.timedelta64(1, res)
 
             dim = tiledb.Dim(name="d1", ctx=ctx,
-                             domain=(np.datetime64(0, res), np.datetime64(tmax, res)),
+                             domain=(None,None),
                              tile=tile, dtype=np.datetime64('', res).dtype)
-
             dom = tiledb.Domain(dim, ctx=ctx)
             schema = tiledb.ArraySchema(ctx=ctx, domain=dom, sparse=True,
                                         attrs=(tiledb.Attr('a1', dtype=np.float64),))


### PR DESCRIPTION
- Passing Ddomain=(None,None) will use the full dtype domain, except for
  representations which must fit the domain range in uint64 (add +1 to
  INTMIN for this case)
- Also adjust rand_datetime64 test helper to use cleaner typemin/max
  generation for datetime64.