### PR TITLE
Add support for chunked CSV read into dense array

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -201,7 +201,7 @@ public:
   PyQuery() = delete;
 
   PyQuery(py::object ctx, py::object array, py::iterable attrs,
-          py::object coords) {
+          py::object coords, py::object py_layout) {
 
     tiledb_ctx_t *c_ctx_ = (py::capsule)ctx.attr("__capsule__")();
     if (c_ctx_ == nullptr)
@@ -218,10 +218,14 @@ public:
         new Query(ctx_, *array_, TILEDB_READ));
         //        [](Query* p){} /* note: no deleter*/);
 
-    if (coords.is(py::none()))
+    tiledb_layout_t layout = (tiledb_layout_t)py_layout.cast<int32_t>();
+    query_->set_layout(layout);
+
+    if (coords.is(py::none())) {
       include_coords_ = true;
-    else
+    } else {
       include_coords_ = coords.cast<bool>();
+    }
 
     for (auto a : attrs) {
       attrs_.push_back(a.cast<string>());
@@ -713,7 +717,7 @@ public:
 
 PYBIND11_MODULE(core, m) {
   py::class_<PyQuery>(m, "PyQuery")
-      .def(py::init<py::object, py::object, py::iterable, py::object>())
+      .def(py::init<py::object, py::object, py::iterable, py::object, py::object>())
       .def("set_ranges", &PyQuery::set_ranges)
       .def("set_subarray", &PyQuery::set_subarray)
       .def("submit", &PyQuery::submit)

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -486,9 +486,18 @@ def from_csv(uri, csv_file, **kwargs):
 
     :param uri: URI for new TileDB array
     :param csv_file: input CSV file
-    :param kwargs: optional keyword arguments for Pandas and TileDB.
-                TileDB context and configuration arguments
-                may be passed in a dictionary as `tiledb_args={...}`
+    :param kwargs:
+                - Any pandas.read_csv supported keyword argument.
+                - TileDB-specific arguments:
+                    'allows_duplicates': Generated schema should allow duplicates
+                    'cell_order': Schema cell order
+                    'tile_order': Schema tile order
+                    'mode': (default 'ingest'), Ingestion mode: 'ingest', 'schema_only', 'append'
+                    'full_domain': Dimensions should be created with full range of the dtype
+                    'attrs_filters': FilterList to apply to all Attributes
+                    'coords_filters': FilterList to apply to all coordinates (Dimensions)
+                    'sparse': (default True) Create sparse schema
+                    'tile': Schema tiling (capacity)
     :return: None
 
     **Example:**

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3947,6 +3947,10 @@ cdef class Query(object):
         return self.coords
 
     @property
+    def order(self):
+        return self.order
+
+    @property
     def domain_index(self):
         return self.domain_index
 
@@ -4188,7 +4192,7 @@ cdef class DenseArrayImpl(Array):
                               tiledb_layout_t layout, bint include_coords):
 
         from tiledb.core import PyQuery
-        q = PyQuery(self._ctx_(), self, tuple(attr_names), include_coords)
+        q = PyQuery(self._ctx_(), self, tuple(attr_names), include_coords, <int32_t>layout)
         q.set_ranges([list([x]) for x in subarray])
         q.submit()
 
@@ -4756,6 +4760,7 @@ cdef class SparseArrayImpl(Array):
 
         if not self.isopen or self.mode != 'r':
             raise TileDBError("SparseArray is not opened for reading")
+
         cdef tiledb_layout_t layout = TILEDB_UNORDERED
         if order is None or order == 'C':
             layout = TILEDB_ROW_MAJOR
@@ -4789,7 +4794,7 @@ cdef class SparseArrayImpl(Array):
         cdef Py_ssize_t nattr = len(attr_names)
 
         from tiledb.core import PyQuery
-        q = PyQuery(self._ctx_(), self, tuple(attr_names), True)
+        q = PyQuery(self._ctx_(), self, tuple(attr_names), True, <int32_t>layout)
         q.set_ranges([list([x]) for x in subarray])
         q.submit()
 

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4018,7 +4018,7 @@ cdef class DenseArrayImpl(Array):
         """Retrieve data cells for an item or region of the array.
 
         :param tuple selection: An int index, slice or tuple of integer/slice objects,
-            specifiying the selected subarray region for each dimension of the DenseArray.
+            specifying the selected subarray region for each dimension of the DenseArray.
         :rtype: :py:class:`numpy.ndarray` or :py:class:`collections.OrderedDict`
         :returns: If the dense array has a single attribute than a Numpy array of corresponding shape/dtype \
                 is returned for that attribute.  If the array has multiple attributes, a \

--- a/tiledb/tests/test_core.py
+++ b/tiledb/tests/test_core.py
@@ -16,7 +16,7 @@ class CoreCCTest(DiskTestCase):
             pass
 
         with tiledb.open(uri) as a:
-            q = core.PyQuery(ctx, a, ("",), False)
+            q = core.PyQuery(ctx, a, ("",), False, 0)
 
             try:
                 q._test_err("bad foo happened")
@@ -49,7 +49,7 @@ class CoreCCTest(DiskTestCase):
                     q.set_ranges([[("aa", "bbbb")]])
 
         with tiledb.open(uri) as a:
-            q2 = core.PyQuery(ctx, a, ("",), False)
+            q2 = core.PyQuery(ctx, a, ("",), False, 0)
 
             q2.set_ranges([[(0,3)]])
             q2.submit()
@@ -70,5 +70,5 @@ class CoreCCTest(DiskTestCase):
             pass
 
         with tiledb.open(uri) as a:
-            q = core.PyQuery(ctx, a, ("",), False)
+            q = core.PyQuery(ctx, a, ("",), False, 0)
             self.assertEqual(q._test_init_buffer_bytes, intmax)


### PR DESCRIPTION
Using `full_domain` support added in #338 and #342, `from_csv` now allows chunked ingestion into a dense array. The chunking dimension is along `rows` only, with unlimited domain, therefore reads must request the `nonempty_domain` or a subset rather than `[:]`. 