### PR TITLE
Add default_ctx support for Config argument

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -59,6 +59,8 @@ def default_ctx(config = None):
 
 def initialize_ctx(config = None):
     """
+    (deprecated) Please use `tiledb.default_ctx(config)`.
+
     Initialize the TileDB-Py default Ctx. This function exists primarily to
     allow configuration overrides for global per-process parameters, such as
     the TBB thread count in particular.
@@ -66,10 +68,7 @@ def initialize_ctx(config = None):
     :param config: Config object or dictionary with config parameters.
     :return:  None
     """
-    global _global_ctx
-    if _global_ctx is not None:
-        raise TileDBError("Global context already initialized!")
-    _global_ctx = Ctx(config)
+    return default_ctx(config)
 
 ###############################################################################
 #    MODULAR IMPORTS                                                          #

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -36,11 +36,25 @@ cdef Ctx _global_ctx = None
 def _get_global_ctx():
     return _global_ctx
 
-def default_ctx():
-    """Returns the default tiledb.Ctx object"""
+def default_ctx(config = None):
+    """
+    Returns, and optionally initializes, the default tiledb.Ctx object
+
+    For initialization, this function must be called before any other
+    tiledb functions. Initialization allows to pass a `Config` object
+    overriding defaults for process-global parameters such as the TBB
+    thread count.
+
+    :param config (default None): Config object or dictionary with config parameters.
+    :return: Ctx
+    """
     global _global_ctx
-    if _global_ctx is None:
-        _global_ctx = Ctx()
+    if _global_ctx is not None:
+        if config is not None:
+            raise TileDBError("Global context already initialized!")
+    else:
+        _global_ctx = Ctx(config)
+
     return _global_ctx
 
 def initialize_ctx(config = None):


### PR DESCRIPTION
Adds optional argument to `default_ctx`, allowing to both retrieve and initialize (once) the global configuration via single function. Deprecates the previous functionality provided by `libtiledb.initialize_ctx`.