### PR TITLE
Improve multi_index query/coords behavior

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -566,6 +566,9 @@ public:
     // schema.attributes() is unordered, but we need to return ordered results
     for (size_t attr_idx = 0; attr_idx < schema.attribute_num(); attr_idx++) {
       auto attr = schema.attribute(attr_idx);
+      if (std::find(attrs_.begin(), attrs_.end(), attr.name()) == attrs_.end()) {
+        continue;
+      }
       alloc_buffer(attr.name());
     }
 

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -110,7 +110,7 @@ class MultiRangeIndexer(object):
 
         schema = self.schema
         dom = self.schema.domain
-        attr_names = tuple(self.schema.attr(i).name for i in range(self.schema.nattr))
+        attr_names = tuple(self.schema.attr(i)._internal_name for i in range(self.schema.nattr))
 
         coords = None
         order = 'C' # TILEDB_ROW_MAJOR

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -51,8 +51,7 @@ def sel_to_subranges(dim_sel):
 
 class MultiRangeIndexer(object):
     """
-    Implements multi-range / outer / orthogonal indexing.
-
+    Implements multi-range indexing.
     """
 
     def __init__(self, array, query = None):
@@ -111,7 +110,6 @@ class MultiRangeIndexer(object):
         schema = self.schema
         dom = self.schema.domain
         attr_names = tuple(self.schema.attr(i)._internal_name for i in range(self.schema.nattr))
-
         coords = None
         order = 'C' # TILEDB_ROW_MAJOR
         if self.query is not None:

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2853,7 +2853,9 @@ class RegTests(DiskTestCase):
             self.assertEqual(A[0], 1)
             mres = A.multi_index[0]
             self.assertEqual(mres[''], 1)
-            self.assertEqual(mres['d'], 0)
+
+            qres = A.query(coords=True).multi_index[0]
+            self.assertEqual(qres['d'], 0)
 
 class MemoryTest(DiskTestCase):
     # sanity check that memory usage doesn't increase more than 2x when reading 40MB 100x

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2754,7 +2754,7 @@ class VFS(DiskTestCase):
 
         path = self.path("test_vfs_dir_size")
         os.mkdir(path)
-        rand_sizes = [np.random.randint(100) for _ in range(4)]
+        rand_sizes = np.random.choice(100, size=4, replace=False)
         for size in rand_sizes:
             file_path = os.path.join(path, "f_" + str(size))
             with tiledb.FileIO(vfs, file_path, 'wb') as f:

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -583,7 +583,7 @@ class TestMultiRange(DiskTestCase):
         dom = tiledb.Domain(tiledb.Dim(domain=(0, 999), tile=1000,
                                        dtype=np.uint32, ctx=ctx),
                             ctx=ctx)
-        attrs = tiledb.Attr(name="U", dtype=np.float64, ctx=ctx)
+        attrs = tiledb.Attr(name='', dtype=np.float64, ctx=ctx)
 
         schema = tiledb.ArraySchema(domain=dom, attrs=(attrs,), sparse=False, ctx=ctx)
         tiledb.DenseArray.create(path, schema)
@@ -600,7 +600,7 @@ class TestMultiRange(DiskTestCase):
                 res = A.multi_index[idxs]
                 assert_array_equal(
                     data[idxs],
-                    res['U']
+                    res['']
                 )
 
     def test_multirange_2d_dense_float(self):

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -299,7 +299,7 @@ class TestMultiRange(DiskTestCase):
         with tiledb.open(path) as A:
             # stepped ranges are not supported
             with self.assertRaises(ValueError):
-                A.multi_index[ 1::2 ]
+                A.query(coords=True).multi_index[ 1::2 ]
 
             assert_array_equal(
                 orig_array[ [0,-1] ],
@@ -311,7 +311,7 @@ class TestMultiRange(DiskTestCase):
             )
             self.assertEqual(
                 -10,
-                A.multi_index[-10]['coords'].view('i8')
+                A.query(coords=True).multi_index[-10]['coords'].view('i8')
             )
             assert_array_equal(
                 orig_array[0:],
@@ -575,6 +575,14 @@ class TestMultiRange(DiskTestCase):
                     np.hstack([ d[0:3], d[-1] ]),
                     res[k]
                 )
+
+        with tiledb.open(path) as A:
+            Q = A.query(coords=False, attrs=["U"])
+            res = Q.multi_index[:]
+            self.assertTrue("U" in res)
+            self.assertTrue("V" not in res)
+            self.assertTrue("coords" not in res)
+            assert_array_equal(res["U"], data["U"])
 
     def test_multirange_1d_dense_vectorized(self):
         ctx = tiledb.Ctx()

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -467,7 +467,6 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             ned = A.nonempty_domain()[0]
             # TODO should support numpy scalar here
             res = A.multi_index[int(ned[0]):int(ned[1])]
-            res.pop('rows')
             df_bk = pd.DataFrame(res)
 
             tm.assert_frame_equal(df_bk, df)


### PR DESCRIPTION
- Improve multi_index query/coords behavior
  - Don't return coords for dense multi_index by default (#347) [ch2652]
  - Fix and test coords exclusion for sparse array queries [ch2650]

- Fix buffer exclusion when specifying attribute subset
