### PR TITLE
Add support for from_csv 'fillna' argument

### DIFF
--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -30,7 +30,8 @@ TILEDB_KWARG_DEFAULTS = {
     'coords_filters': None,
     'full_domain': False,
     'tile': None,
-    'row_start_idx': None
+    'row_start_idx': None,
+    'fillna': None
 }
 
 def parse_tiledb_kwargs(kwargs):
@@ -56,7 +57,8 @@ def parse_tiledb_kwargs(kwargs):
         args['tile'] = kwargs.pop('tile')
     if 'row_start_idx' in kwargs:
         args['row_start_idx'] = kwargs.pop('row_start_idx')
-
+    if 'fillna' in kwargs:
+        args['fillna'] = kwargs.pop('fillna')
 
     return args
 
@@ -341,6 +343,7 @@ def from_pandas(uri, dataframe, **kwargs):
     tile = args.get('tile', None)
     nrows = args.get('nrows', None)
     row_start_idx = args.get('row_start_idx', None)
+    fillna = args.pop('fillna', None)
 
     write = True
     create_array = True
@@ -393,6 +396,10 @@ def from_pandas(uri, dataframe, **kwargs):
         )
 
         tiledb.Array.create(uri, schema, ctx=ctx)
+
+    # apply fill replacements for NA values if specified
+    if fillna is not None:
+        dataframe.fillna(fillna, inplace=True)
 
     if write:
         write_dict = {k: v.values for k,v in dataframe.to_dict(orient='series').items()}

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -470,3 +470,26 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             df_bk = pd.DataFrame(res)
 
             tm.assert_frame_equal(df_bk, df)
+
+    def test_csv_fillna(self):
+        col_size = 10
+        data = np.random.rand(10)
+        data[4] = np.nan
+        df = pd.DataFrame({'v': data})
+
+        tmp_dir = self.path("csv_fillna")
+        os.mkdir(tmp_dir)
+        tmp_csv = os.path.join(tmp_dir, "generated.csv")
+
+        df.to_csv(tmp_csv, index=False)
+
+        tmp_array = os.path.join(tmp_dir, "array")
+        tiledb.from_csv(tmp_array, tmp_csv, fillna={'v': 0})
+
+        df['v'][4] = 0
+        with tiledb.open(tmp_array) as A:
+            res = A[:]
+            df_bk = pd.DataFrame(res)
+            df_bk.pop('rows')
+
+            tm.assert_frame_equal(df_bk, df)


### PR DESCRIPTION
The argument will be applied via pandas.DataFrame.fillna, before
any values are passed in to the TileDB writer. ([example](https://github.com/TileDB-Inc/TileDB-Py/compare/ihn/fillna?expand=1#diff-970d04aaca2ebc4aaa52a1eadbf53db9R488))