### PR TITLE
Release 0.6.5: add wheel support for GCS

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,15 @@
+# TileDB-Py 0.6.5 Release Notes
+
+We have added manylinux2010 wheels, corresponding to CentOS6 / glibc 2.12.
+
+We are deprecating support for manylinux1 (CentOS5 / glibc 2.0.7), which is not supported by
+the Google Cloud Storage SDK. We are planning to remove manylinux1 wheel support in the
+TileDB-Py 0.7 release.
+
+
+## Improvements
+* Enabled Google Cloud Storage support in macOS and linux (manylinux2010) wheels on PyPI ([#364](https://github.com/TileDB-Inc/TileDB-Py/pull/364))
+
 # TileDB-Py 0.6.4 Release Notes
 
 ## API notes

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,7 +27,7 @@ author = 'TileDB, Inc.'
 # The short X.Y version
 version = '0.6'
 # The full version, including alpha/beta/rc tags
-release = '0.6.4'
+release = '0.6.5'
 
 
 # -- General configuration ---------------------------------------------------

--- a/misc/azure-libtiledb-darwin.yml
+++ b/misc/azure-libtiledb-darwin.yml
@@ -1,7 +1,7 @@
 steps:
 - task: Cache@2
   inputs:
-    key: 'libtiledb | "$(Agent.OS)" | "$(imageName)" | "$(LIBTILEDB_SHA)" | v1'
+    key: 'libtiledb | "$(Agent.OS)" | "$(imageName)" | "$(LIBTILEDB_SHA)" | v2'
     path: $(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)
     cacheHitVar: LIBTILEDB_CACHE_RESTORED
 
@@ -20,7 +20,7 @@ steps:
     mkdir -p $TILEDB_BUILD
     cd $TILEDB_BUILD
 
-    $TILEDB_SRC/bootstrap --force-build-all-deps --enable=s3,azure,serialization --enable-static-tiledb --disable-avx2 --disable-tests --prefix=$TILEDB_INSTALL
+    $TILEDB_SRC/bootstrap --force-build-all-deps --enable=s3,gcs,azure,serialization --enable-static-tiledb --disable-avx2 --disable-tests --prefix=$TILEDB_INSTALL
 
     cmake --build $TILEDB_BUILD --config Release -j3
     cmake --build $TILEDB_BUILD --target install-tiledb --config Release

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -142,3 +142,19 @@ stages:
         docker run -v `pwd`/wheelhouse:/wheels -t wheel_builder build.sh
     - task: PublishBuildArtifacts@1
       inputs: {pathtoPublish: 'wheelhouse'}
+
+  - job: build1_linux_wheels_2010
+    strategy:
+      matrix:
+        wheels:
+          imageName: 'ubuntu-16.04'
+    pool:
+      vmImage: $(imageName)
+
+    steps:
+    - script: git tag $(TILEDBPY_VERSION)
+    - bash: |
+        docker build -f misc/pypi_linux/Dockerfile2010 . -t wheel_builder_2010
+        docker run -v `pwd`/wheelhouse:/wheels -t wheel_builder_2010 build.sh
+    - task: PublishBuildArtifacts@1
+      inputs: {pathtoPublish: 'wheelhouse'}

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -1,7 +1,7 @@
 stages:
 - stage: Release
   variables:
-    TILEDBPY_VERSION: 0.6.4
+    TILEDBPY_VERSION: 0.6.5
     LIBTILEDB_VERSION: 2.0.6
     LIBTILEDB_SHA: d6cdfe65f70d077ca0cc50767010353fb25591d3
     SDKROOT: '/Applications/Xcode_10.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'

--- a/misc/pypi_linux/Dockerfile
+++ b/misc/pypi_linux/Dockerfile
@@ -23,7 +23,7 @@ ENV CMAKE /opt/python/cp27-cp27mu/bin/cmake
 # settings (B)
 ENV LIBTILEDB_VERSION 2.0.6
 ENV LIBTILEDB_SHA d6cdfe65f70d077ca0cc50767010353fb25591d3
-ENV TILEDBPY_VERSION 0.6.4
+ENV TILEDBPY_VERSION 0.6.5
 ###############################################
 # 1) Nothing builds under GCC 4.8 due to default constructor unused-parameter warnings
 # 2) adding -lrt as a work-around for now because python2.7 doesn't link it, but it

--- a/misc/pypi_linux/Dockerfile2010
+++ b/misc/pypi_linux/Dockerfile2010
@@ -19,7 +19,7 @@ ENV CMAKE /opt/python/cp27-cp27mu/bin/cmake
 # settings (B)
 ENV LIBTILEDB_VERSION 2.0.6
 ENV LIBTILEDB_SHA d6cdfe65f70d077ca0cc50767010353fb25591d3
-ENV TILEDBPY_VERSION 0.6.4
+ENV TILEDBPY_VERSION 0.6.5
 ###############################################
 # 1) Nothing builds under GCC 4.8 due to default constructor unused-parameter warnings
 # 2) adding -lrt as a work-around for now because python2.7 doesn't link it, but it

--- a/misc/pypi_linux/Dockerfile2010
+++ b/misc/pypi_linux/Dockerfile2010
@@ -1,0 +1,58 @@
+FROM quay.io/pypa/manylinux2010_x86_64
+
+###############################################
+# settings (A)
+# NOTE: MUST USE the 'mu' variant here to be compatible
+#       with "most" linux distros (see manylinux README)
+ENV PYTHON_BASE /opt/python/cp27-cp27mu/bin/
+
+RUN useradd tiledb
+ENV HOME /home/tiledb
+
+# dependencies:
+# - cmake (need recent) and auditwheel from pip
+RUN  $PYTHON_BASE/pip install cmake==3.17.3 auditwheel
+
+ENV CMAKE /opt/python/cp27-cp27mu/bin/cmake
+
+###############################################
+# settings (B)
+ENV LIBTILEDB_VERSION 2.0.6
+ENV LIBTILEDB_SHA d6cdfe65f70d077ca0cc50767010353fb25591d3
+ENV TILEDBPY_VERSION 0.6.4
+###############################################
+# 1) Nothing builds under GCC 4.8 due to default constructor unused-parameter warnings
+# 2) adding -lrt as a work-around for now because python2.7 doesn't link it, but it
+#    ends up as an unlinked dependency.
+# 3) Capnproto (TileDB Serialization) requeries -DKJ_USE_EPOLL=0 -D__BIONIC__=1 per
+#    https://github.com/capnproto/capnproto/issues/350#issuecomment-270930594
+
+ENV CXXFLAGS -Wno-unused-parameter -lrt -DKJ_USE_EPOLL=0 -D__BIONIC__=1
+ENV CFLAGS -Wno-unused-parameter -lrt -DKJ_USE_EPOLL=0 -D__BIONIC__=1
+
+# build libtiledb (core)
+# notes:
+#    1) we are using auditwheel from https://github.com/pypa/auditwheel
+#       this verifies and tags wheel products with the manylinux1 label,
+#       and allows us to build libtiledb once, install it to a normal
+#       system path, and then use it to build wheels for all of the python
+#       versions.
+RUN cd /home/tiledb/ && \
+  git clone https://github.com/TileDB-Inc/TileDB && \
+  git -C TileDB checkout $LIBTILEDB_SHA && \
+  mkdir build && \
+  cd build && \
+  $CMAKE -DTILEDB_S3=ON -DTILEDB_AZURE=ON -DTILEDB_GCS=ON \
+         -DTILEDB_CPP_API=ON -DTILEDB_HDFS=ON -DTILEDB_TESTS=OFF \
+         -DTILEDB_SERIALIZATION=ON -DTILEDB_FORCE_ALL_DEPS:BOOL=ON \
+         -DTILEDB_LOG_OUTPUT_ON_FAILURE:BOOL=ON \
+         -DSANITIZER="OFF;-DCOMPILER_SUPPORTS_AVX2:BOOL=FALSE" \
+         ../TileDB && \
+  make -j8 && \
+  make install-tiledb
+
+ADD misc/pypi_linux/build.sh /usr/bin/build.sh
+RUN chmod +x /usr/bin/build.sh
+
+# add source directory as optional TILEDB_PY_REPO
+ADD . /opt/TileDB-Py

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -120,6 +120,8 @@ cdef extern from "tiledb/tiledb.h":
     ctypedef enum tiledb_filesystem_t:
         TILEDB_HDFS
         TILEDB_S3
+        TILEDB_AZURE
+        TILEDB_GCS
 
     ctypedef enum tiledb_vfs_mode_t:
         TILEDB_VFS_READ

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -5655,6 +5655,14 @@ cdef class VFS(object):
             check_error(self.ctx,
                         tiledb_ctx_is_supported_fs(self.ctx.ptr, TILEDB_S3, &supports))
             return bool(supports)
+        elif scheme == "azure":
+            check_error(self.ctx,
+                        tiledb_ctx_is_supported_fs(self.ctx.ptr, TILEDB_AZURE, &supports))
+            return bool(supports)
+        elif scheme == "gcs":
+            check_error(self.ctx,
+                        tiledb_ctx_is_supported_fs(self.ctx.ptr, TILEDB_GCS, &supports))
+            return bool(supports)
         elif scheme == "hdfs":
             check_error(self.ctx,
                         tiledb_ctx_is_supported_fs(self.ctx.ptr, TILEDB_HDFS, &supports))

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2567,6 +2567,8 @@ class VFS(DiskTestCase):
         self.assertTrue(vfs.supports("file"))
         self.assertIsInstance(vfs.supports("s3"), bool)
         self.assertIsInstance(vfs.supports("hdfs"), bool)
+        self.assertIsInstance(vfs.supports("gcs"), bool)
+        self.assertIsInstance(vfs.supports("azure"), bool)
 
         with self.assertRaises(ValueError):
             vfs.supports("invalid")


### PR DESCRIPTION
Adds manylinux2010 wheel release target, with Google Cloud Storage enabled.

Addresses #361.