### PR TITLE
Add support for multi-file CSV ingestion

### DIFF
--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -31,7 +31,8 @@ TILEDB_KWARG_DEFAULTS = {
     'full_domain': False,
     'tile': None,
     'row_start_idx': None,
-    'fillna': None
+    'fillna': None,
+    'debug': None
 }
 
 def parse_tiledb_kwargs(kwargs):
@@ -61,6 +62,8 @@ def parse_tiledb_kwargs(kwargs):
         args['fillna'] = kwargs.pop('fillna')
     if 'column_types' in kwargs:
         args['column_types'] = kwargs.pop('column_types')
+    if 'debug' in kwargs:
+        args['debug'] = kwargs.pop('debug')
 
     return args
 
@@ -542,6 +545,7 @@ def from_csv(uri, csv_file, **kwargs):
 
     tiledb_args = parse_tiledb_kwargs(kwargs)
     multi_file = False
+    debug = tiledb_args.get('debug', False)
 
     if isinstance(csv_file, str) and not os.path.isfile(csv_file):
         # for non-local files, use TileDB VFS i/o
@@ -622,6 +626,10 @@ def from_csv(uri, csv_file, **kwargs):
                 kwargs['mode'] = 'append'
             # after the first chunk, switch to append mode
             array_created = True
+
+            if debug:
+                print("`tiledb.read_csv` flushing '{}' rows ('{}' files)".format(
+                    len(df), csv_idx))
 
             # now flush
             from_pandas(uri, df, **kwargs)

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -559,7 +559,7 @@ def from_csv(uri, csv_file, **kwargs):
     mode = kwargs.pop('mode', None)
     if mode is not None:
         tiledb_args['mode'] = mode
-        # For schema-only mode we need to pass a max read count into
+        # For schema_only mode we need to pass a max read count into
         #   pandas.read_csv
         # Note that 'nrows' is a pandas arg!
         if mode == 'schema_only' and not 'nrows' in kwargs:
@@ -634,6 +634,9 @@ def from_csv(uri, csv_file, **kwargs):
             # now flush
             from_pandas(uri, df, **kwargs)
             rows_written += len(df)
+
+            if mode == 'schema_only':
+                break
 
     else:
         df = pandas.read_csv(csv_file, **kwargs)

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -32,38 +32,16 @@ TILEDB_KWARG_DEFAULTS = {
     'tile': None,
     'row_start_idx': None,
     'fillna': None,
+    'column_types': None,
     'debug': None
 }
 
 def parse_tiledb_kwargs(kwargs):
     args = dict(TILEDB_KWARG_DEFAULTS)
 
-    if 'ctx' in kwargs:
-        args['ctx'] = kwargs.pop('ctx')
-    if 'sparse' in kwargs:
-        args['sparse'] = kwargs.pop('sparse')
-    if 'index_dims' in kwargs:
-        args['index_dims'] = kwargs.pop('index_dims')
-    if 'allows_duplicates' in kwargs:
-        args['allows_duplicates'] = kwargs.pop('allows_duplicates')
-    if 'mode' in kwargs:
-        args['mode'] = kwargs.pop('mode')
-    if 'attrs_filters' in kwargs:
-        args['attrs_filters'] = kwargs.pop('attrs_filters')
-    if 'coords_filters' in kwargs:
-        args['coords_filters'] = kwargs.pop('coords_filters')
-    if 'full_domain' in kwargs:
-        args['full_domain'] = kwargs.pop('full_domain')
-    if 'tile' in kwargs:
-        args['tile'] = kwargs.pop('tile')
-    if 'row_start_idx' in kwargs:
-        args['row_start_idx'] = kwargs.pop('row_start_idx')
-    if 'fillna' in kwargs:
-        args['fillna'] = kwargs.pop('fillna')
-    if 'column_types' in kwargs:
-        args['column_types'] = kwargs.pop('column_types')
-    if 'debug' in kwargs:
-        args['debug'] = kwargs.pop('debug')
+    for key in TILEDB_KWARG_DEFAULTS.keys():
+        if key in kwargs:
+            args[key] = kwargs.pop(key)
 
     return args
 

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -443,16 +443,17 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         # Test sparse chunked
         tmp_array = os.path.join(tmp_dir, "array")
         tiledb.from_csv(tmp_array, tmp_csv,
-                        index_col=['time', 'double_range'],
+                        index_col=['double_range'],
                         parse_dates=['time'],
+                        date_spec={'time': "%Y-%m-%dT%H:%M:%S.%f"},
                         chunksize=10)
 
         with tiledb.open(tmp_array) as A:
             res = A[:]
             df_bk = pd.DataFrame(res)
-            df_bk.set_index(['time','double_range'], inplace=True)
+            df_bk.set_index(['double_range'], inplace=True)
 
-            df_ck = df.set_index(['time','double_range'])
+            df_ck = df.set_index(['double_range'])
             tm.assert_frame_equal(df_bk, df_ck)
 
         # Test dense chunked


### PR DESCRIPTION
This PR implements support for `tiledb.from_csv` to accept a list of CSV files as the first input argument, instead of a single filename. This ingestion mode requires the `chunksize` argument, which will determine the minimum number of rows to read before flushing to disk.