### PR TITLE
Support attaching external result buffers to Array

### DIFF
--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1188,6 +1188,7 @@ cdef class Array(object):
     cdef object view_attr # can be None
     cdef object key # can be None
     cdef object schema
+    cdef object _buffers
 
     cdef DomainIndexer domain_index
     cdef object multi_index

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2149,7 +2149,7 @@ cdef class Attr(object):
 
         """
         internal_name = self._get_name()
-        # handle __attr names
+        # handle __attr names from arrays written with libtiledb < 2
         if internal_name == "__attr":
             return u""
         return internal_name
@@ -3935,6 +3935,13 @@ cdef class Array(object):
     @property
     def last_write_info(self):
         return self.last_fragment_info
+
+    @property
+    def _buffers(self):
+        return self._buffers
+
+    def _set_buffers(self, object buffers):
+        self._buffers = buffers
 
 cdef class Query(object):
     """

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3941,6 +3941,11 @@ cdef class Array(object):
         return self._buffers
 
     def _set_buffers(self, object buffers):
+        """
+        Helper function to set external buffers in the form of
+            {'attr_name': (data_array, offsets_array)}
+        Buffers will be used to satisfy the next index/query request.
+        """
         self._buffers = buffers
 
 cdef class Query(object):

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -136,7 +136,6 @@ class MultiRangeIndexer(object):
 
         q.set_ranges(ranges)
         q.submit()
-
         result_dict = OrderedDict(q.results())
 
         final_names = dict()


### PR DESCRIPTION
Buffer(s) will be used to satisfy any subsequent indexing/query request,
until `A._set_buffers(None)` is called.