### PR TITLE
Use std::invalid_argument -> ValueError for config errors

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -883,9 +883,8 @@ PYBIND11_MODULE(core, m) {
       PyErr_SetString(tiledb_py_error.ptr(), e.what());
     } catch (const tiledb::TileDBError &e) {
       PyErr_SetString(tiledb_py_error.ptr(), e.what());
-    } catch (std::exception &e) {
-      auto tmp_errstr = std::string("pybind untranslated std::exception: '") + std::string(e.what()) + "', '" + std::string(typeid(e).name()) + "'";
-      PyErr_SetString(tiledb_py_error.ptr(), tmp_errstr.c_str());
+    } catch (std::runtime_error &e) {
+      std::cout << "unexpected runtime_error: " << e.what() << std::endl;
     }
   });
 }

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -269,7 +269,7 @@ public:
           std::stoull(tmp_str);
       } catch (const std::invalid_argument &e) {
         (void)e;
-        throw TileDBError("Failed to convert 'py.init_buffer_bytes' to uint64_t ('" + tmp_str + "')");
+        throw std::invalid_argument("Failed to convert 'py.init_buffer_bytes' to uint64_t ('" + tmp_str + "')");
       }
     }
 
@@ -280,7 +280,7 @@ public:
           std::stoull(tmp_str);
       } catch (const std::invalid_argument &e) {
         (void)e;
-        throw TileDBError("Failed to convert 'py.exp_alloc_max_bytes' to uint64_t ('" + tmp_str + "')");
+        throw std::invalid_argument("Failed to convert 'py.exp_alloc_max_bytes' to uint64_t ('" + tmp_str + "')");
       }
     }
 
@@ -291,7 +291,7 @@ public:
       } else if (tmp_str == "false") {
         deduplicate_ = false;
       } else {
-        throw TileDBError("Failed to convert configuration 'py.deduplicate' to bool ('" + tmp_str + "')");
+        throw std::invalid_argument("Failed to convert configuration 'py.deduplicate' to bool ('" + tmp_str + "')");
       }
     }
 

--- a/tiledb/tests/test_core.py
+++ b/tiledb/tests/test_core.py
@@ -16,6 +16,10 @@ class CoreCCTest(DiskTestCase):
             pass
 
         with tiledb.open(uri) as a:
+            with self.assertRaises(ValueError):
+                testctx = tiledb.Ctx(config={'py.init_buffer_bytes': 'abcd'})
+                core.PyQuery(testctx, a, ("",), False, 0)
+
             q = core.PyQuery(ctx, a, ("",), False, 0)
 
             try:


### PR DESCRIPTION
Provides more Pythonic error rendering.