### PR TITLE
Updates: `open_dataframe` ctx keyword arg; revert a56d919

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -35,7 +35,7 @@ using namespace pybind11::literals;
   throw TileDBPyError(std::string(m) + " (" + __FILE__ + ":" +                 \
                       std::to_string(__LINE__) + ")");
 
-const uint64_t DEFAULT_INIT_BUFFER_BYTES = 13107200 * 8;
+const uint64_t DEFAULT_INIT_BUFFER_BYTES = 1310720 * 8;
 const uint64_t DEFAULT_EXP_ALLOC_MAX_BYTES = uint64_t(4 * pow(2, 30));
 
 class TileDBPyError : std::runtime_error {

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -442,7 +442,7 @@ def from_pandas(uri, dataframe, **kwargs):
             A.close()
 
 
-def open_dataframe(uri):
+def open_dataframe(uri, ctx=None):
     """Open TileDB array at given URI as a Pandas dataframe
 
     If the array was saved using tiledb.from_dataframe, then columns
@@ -464,9 +464,12 @@ def open_dataframe(uri):
 
     import pandas as pd
 
+    if ctx is None:
+        ctx = tiledb.default_ctx()
+
     # TODO support `distributed=True` option?
 
-    with tiledb.open(uri) as A:
+    with tiledb.open(uri, ctx=ctx) as A:
         #if not '__pandas_attribute_repr' in A.meta \
         #    and not '__pandas_repr' in A.meta:
         #    raise ValueError("Missing required keys to reload overloaded dataframe dtypes")

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -212,7 +212,8 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         csv_array_uri = os.path.join(uri, "tiledb_csv")
         tiledb.from_csv(csv_array_uri, csv_uri, index_col = 0, parse_dates=[1], sparse=False)
 
-        df_from_array = tiledb.open_dataframe(csv_array_uri)
+        ctx = tiledb.default_ctx()
+        df_from_array = tiledb.open_dataframe(csv_array_uri, ctx=ctx)
         tm.assert_frame_equal(df_orig, df_from_array)
 
         # Test reading via TileDB VFS. The main goal is to support reading


### PR DESCRIPTION
- Revert "Bump default initial buffer allocation to 100 MB"
  100 MB is too large for smaller instance types when opening an array
with >10 columns. User will need manual config for now, and we will
revisit with a more sophisticated approach to account for available
memory at runtime.

- Allow open_dataframe to take a Ctx parameter [ch2767]