### PR TITLE
Check for resizing offset buffers independently

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -670,15 +670,16 @@ public:
 
       update_read_elem_num();
 
-      for (auto bp : buffers_) {
+      for (auto &bp : buffers_) {
         auto buf = bp.second;
 
-        if ((int64_t)(buf.data_vals_read * buf.elem_nbytes) > (buf.data.nbytes() + 1) / 2) {
+        // Check if values buffer should be resized
+        if ((int64_t)(buf.data_vals_read * buf.elem_nbytes) > (buf.data.nbytes() + 1) / 2)
           buf.data.resize({buf.data.size() * 2}, false);
 
-          if (buf.isvar)
-            buf.offsets.resize({buf.offsets.size() * 2}, false);
-        }
+        // Check if offset buffer should be resized
+        if (buf.isvar && (int64_t)(buf.offsets_read * sizeof(uint64_t)) > (buf.offsets.nbytes() + 1) / 2)
+          buf.offsets.resize({buf.offsets.size() * 2}, false);
       }
 
       set_buffers();


### PR DESCRIPTION
The resize algorithm to increase the capacity of buffers was tied to checking the remaining capacity of the data buffer. For variable
length fields, the offset buffer needs to be checked independently.

We encountered an array in which a string field which has a single character. Since this is 1 byte in length, but offsets are 4
bytes in length, we ran out of offset room in the buffer before we had enough data to force a resize.