### PR TITLE
Fixes for sparse+varlen with empty result

### DIFF
--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -146,7 +146,7 @@ class MultiRangeIndexer(object):
                 arr = item[0]
                 final_dtype = schema.attr_or_dim_dtype(name)
                 if (len(arr) < 1 and
-                        (np.issubdtype(final_dtype, np.str_) or
+                        (np.issubdtype(final_dtype, np.bytes_) or
                          np.issubdtype(final_dtype, np.unicode_))):
                     # special handling to get correctly-typed empty array
                     # (expression below changes itemsize from 0 to 1)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1828,6 +1828,11 @@ class SparseArray(DiskTestCase):
             assert_array_equal(res[""], A[0:2])
             self.assertEqual(("coords" in res), False)
 
+            # empty sparse varlen result
+            res = T[1000]
+            assert_array_equal(res[''], np.array('', dtype='S1'))
+            assert_array_equal(res['x'], np.array([], dtype=np.int))
+
     def test_sparse_unicode(self):
         ctx = tiledb.Ctx()
         dom = tiledb.Domain(
@@ -1855,6 +1860,11 @@ class SparseArray(DiskTestCase):
             res = T.query(coords=False)[40:61]
             assert_array_equal(res[""], A[5:7])
             self.assertEqual(("coords" in res), False)
+
+            # empty sparse varlen result
+            res = T[1000]
+            assert_array_equal(res[''], np.array('', dtype='U1'))
+            assert_array_equal(res['x'], np.array([], dtype=np.int))
 
     def test_sparse_fixes(self):
         uri = self.path("test_sparse_fixes")


### PR DESCRIPTION
- add missing path for properly-typed, empty array return values for empty sparse
  varlen results
- fix np.str_ -> np.bytes_ to ensure typed empty array for np.bytes_
  data (np.str_ == np.unicode_)