### PR TITLE
Add `Array.df[]` indexer: directly return dataframe from indexing query

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,16 +1,21 @@
 # TileDB-Py 0.7.0 Release Notes
 
 ## TileDB Embedded updates:
-* TileDB-Py 0.7.0 includes [TileDB Embedded 2.1.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.0.6)
+* TileDB-Py 0.7.0 includes [TileDB Embedded 2.1.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.1.0)
+  featuring a number of significant improvements, with major highlights including:
+  - no longer uses Intel TBB for parallelization by default. Along with many benefits to TileDB Embedded, this
+    significantly reduces complications and bugs with python multiprocessing fork mode.
+  - Support coalescing subarray ranges to give major performance boosts.
 
 ## Packaging  Notes
-* TileDB-Py 0.7 packages on PyPI support macOS 10.13+ and manylinux10 compatible systems only.
+* TileDB-Py 0.7 packages on PyPI support macOS 10.13+ and manylinux10-compatible Linux distributions only.
+  For now, wheels could be produced supporting older systems but without Google Cloud Support; if needed,
+  please contact us to discuss.
 
 ## Improvements
 * Added ".df[]" indexer tiledb.Array: directly returns a Pandas dataframe from a query (uses `multi_index` indexing behavior) [#390](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
 * Added wrapping and support for TileDB checksumming filters: `ChecksumMD5Filter` and `ChecksumSHA256Filter` [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
-
-* Removed TBB from default setup.py, corresponding to TileDB Embedded changes [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
+* Removed TBB install from default setup.py, corresponding to TileDB Embedded changes [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
 
 ## Misc Updates
 * Added round-trip tests for all filter `repr` objects [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * TileDB-Py 0.7 packages on PyPI support macOS 10.13+ and manylinux10 compatible systems only.
 
 ## Improvements
+* Added ".df[]" indexer tiledb.Array: directly returns a Pandas dataframe from a query (uses `multi_index` indexing behavior) [#390](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
 * Added wrapping and support for TileDB checksumming filters: `ChecksumMD5Filter` and `ChecksumSHA256Filter` [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
 
 * Removed TBB from default setup.py, corresponding to TileDB Embedded changes [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,19 @@
+# TileDB-Py 0.7.0 Release Notes
+
+## TileDB Embedded updates:
+* TileDB-Py 0.7.0 includes [TileDB Embedded 2.1.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.0.6)
+
+## Packaging  Notes
+* TileDB-Py 0.7 packages on PyPI support macOS 10.13+ and manylinux10 compatible systems only.
+
+## Improvements
+* Added wrapping and support for TileDB checksumming filters: `ChecksumMD5Filter` and `ChecksumSHA256Filter` [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
+
+* Removed TBB from default setup.py, corresponding to TileDB Embedded changes [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
+
+## Misc Updates
+* Added round-trip tests for all filter `repr` objects [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
+
 # TileDB-Py 0.6.6 Release Notes
 
 **Note that we will be removing wheel support for macOS 10.9-10.12 in TileDB-Py 0.7 (planned for release in August 2020).** This change is due to upstream (AWS SDK) minimum version requirements. The minimum supported version for macOS wheels on PyPI will be macOS 10.13.

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -490,9 +490,6 @@ def open_dataframe(uri, ctx=None):
     >>> tiledb.objec_type("iris.tldb")
     'array'
     """
-    warnings.warn("open_dataframe is deprecated and will be removed in the next release",
-                  DeprecationWarning)
-
     if ctx is None:
         ctx = tiledb.default_ctx()
 

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -445,17 +445,13 @@ def from_pandas(uri, dataframe, **kwargs):
 
 def _tiledb_result_as_dataframe(readable_array, result_dict):
     import pandas as pd
-    #if not '__pandas_attribute_repr' in A.meta \
-    #    and not '__pandas_repr' in A.meta:
-    #    raise ValueError("Missing required keys to reload overloaded dataframe dtypes")
-
-    # TODO missing key should only be a warning, return best-effort?
+    # TODO missing key in the rep map should only be a warning, return best-effort?
     # TODO this should be generalized for round-tripping overloadable types
     #      for any array (e.g. np.uint8 <> bool)
     repr_meta = None
     index_dims = None
     if '__pandas_attribute_repr' in readable_array.meta:
-        # backwards compatibility... unsure if necessary at this point
+        # backwards compatibility
         repr_meta = json.loads(readable_array.meta['__pandas_attribute_repr'])
     if '__pandas_index_dims' in readable_array.meta:
         index_dims = json.loads(readable_array.meta['__pandas_index_dims'])

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1195,6 +1195,7 @@ cdef class Array(object):
 
     cdef DomainIndexer domain_index
     cdef object multi_index
+    cdef object df
     cdef Metadata meta
     cdef object last_fragment_info
 

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -168,3 +168,15 @@ class MultiRangeIndexer(object):
                 # TODO check/test layout
                 arr.shape = result_shape
             return result_dict
+
+class DataFrameIndexer(MultiRangeIndexer):
+    """
+    Implements `.df[]` indexing to directly return a dataframe
+    [] operator uses multi_index semantics.
+    """
+
+    def __getitem__(self, idx):
+        from .dataframe_ import _tiledb_result_as_dataframe
+
+        result_dict = super(DataFrameIndexer, self).__getitem__(idx)
+        return _tiledb_result_as_dataframe(self.array, result_dict)

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -263,7 +263,6 @@ class PandasDataFrameRoundtrip(DiskTestCase):
                 nonempty = A.nonempty_domain()[0]
                 res = A.multi_index[nonempty[0]:nonempty[1]]
 
-                # TODO use tiledb.open_dataframe here
                 res_df = pd.DataFrame(res, index=res.pop(col))
                 tm.assert_frame_equal(new_df, res_df, check_like=True)
 
@@ -291,6 +290,11 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             assert_array_equal(
                 res['int_vals'], df.int_vals.values
             )
+
+            # test .df[] indexing
+            df_idx_res = A.df[slice(*ned_time), :]
+            tm.assert_frame_equal(df_idx_res, df)
+
 
     def test_csv_dense(self):
         col_size = 10
@@ -473,6 +477,10 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             df_bk = pd.DataFrame(res)
 
             tm.assert_frame_equal(df_bk, df)
+
+            # test .df[] indexing
+            df_idx_res = A.df[int(ned[0]):int(ned[1])]
+            tm.assert_frame_equal(df_idx_res, df)
 
     def test_csv_fillna(self):
         col_size = 10


### PR DESCRIPTION
Adds a new indexing operation to `tiledb.Array` which returns query results directly as a Pandas dataframe.

Example:

```
In [1]: import tiledb, pandas as pd, numpy as np
   ...: uri = "/tmp/dfx"
   ...:
   ...: d = {'abc': np.random.rand(4),
   ...:      'xyz': np.random.randint(4)}
   ...:
   ...: tiledb.from_pandas(uri, pd.DataFrame.from_dict(d))
   ...:
   ...: a = tiledb.open(uri)
   ...: a.df[0:3]

Out[1]:
   rows       abc  xyz
0     0  0.014653    2
1     1  0.205917    2
2     2  0.092197    2
3     3  0.216491    2
```