### PR TITLE
Add support for 'capacity' as kwarg and 'tile' as dict of extents (from_csv/pandas)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@
 * Added ".df[]" indexer tiledb.Array: directly returns a Pandas dataframe from a query (uses `multi_index` indexing behavior) [#390](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
 * Added wrapping and support for TileDB checksumming filters: `ChecksumMD5Filter` and `ChecksumSHA256Filter` [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
 * Removed TBB install from default setup.py, corresponding to TileDB Embedded changes [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
+* Add support for 'capacity' kwarg to `from_csv`/`from_pandas` [#391](https://github.com/TileDB-Inc/TileDB-Py/pull/391)
 
 ## Misc Updates
 * Added round-trip tests for all filter `repr` objects [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,7 @@
     significantly reduces complications and bugs with python multiprocessing fork mode.
   - Support coalescing subarray ranges to give major performance boosts.
 
-## Packaging  Notes
+## Packaging Notes
 * TileDB-Py 0.7 packages on PyPI support macOS 10.13+ and manylinux10-compatible Linux distributions only.
   For now, wheels could be produced supporting older systems but without Google Cloud Support; if needed,
   please contact us to discuss.
@@ -17,6 +17,8 @@
 * Added wrapping and support for TileDB checksumming filters: `ChecksumMD5Filter` and `ChecksumSHA256Filter` [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
 * Removed TBB install from default setup.py, corresponding to TileDB Embedded changes [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)
 * Add support for 'capacity' kwarg to `from_csv`/`from_pandas` [#391](https://github.com/TileDB-Inc/TileDB-Py/pull/391)
+* Add support for 'tile' kwarg to `from_csv`/`from_pandas` to customize Dim tile extent [#391](https://github.com/TileDB-Inc/TileDB-Py/pull/391)
+
 
 ## Misc Updates
 * Added round-trip tests for all filter `repr` objects [#389](https://github.com/TileDB-Inc/TileDB-Py/pull/389)

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -33,6 +33,7 @@ TILEDB_KWARG_DEFAULTS = {
     'row_start_idx': None,
     'fillna': None,
     'column_types': None,
+    'capacity': None,
     'date_spec': None,
     'cell_order': 'row-major',
     'tile_order': 'row-major',
@@ -342,6 +343,7 @@ def from_pandas(uri, dataframe, **kwargs):
     attrs_filters = args.get('attrs_filters', None)
     coords_filters = args.get('coords_filters', None)
     full_domain = args.get('full_domain', False)
+    capacity = args.get('capacity', False)
     tile = args.get('tile', None)
     nrows = args.get('nrows', None)
     row_start_idx = args.get('row_start_idx', None)
@@ -358,6 +360,9 @@ def from_pandas(uri, dataframe, **kwargs):
             create_array = False
         elif mode != 'ingest':
             raise TileDBError("Invalid mode specified ('{}')".format(mode))
+
+    if capacity is None:
+        capacity = 0 # this will use the libtiledb internal default
 
     if ctx is None:
         ctx = tiledb.default_ctx()
@@ -398,6 +403,7 @@ def from_pandas(uri, dataframe, **kwargs):
             tile_order=tile_order,
             coords_filters=coords_filters,
             allows_duplicates=allows_duplicates,
+            capacity=capacity,
             sparse=sparse
         )
 
@@ -523,7 +529,7 @@ def from_csv(uri, csv_file, **kwargs):
             * ``attrs_filters``: FilterList to apply to all Attributes
             * ``coords_filters``: FilterList to apply to all coordinates (Dimensions)
             * ``sparse``: (default True) Create sparse schema
-            * ``tile``: Schema tiling (capacity)
+            * ``capacity``: Schema tiling (capacity)
             * ``date_spec``: Dictionary of {``column_name``: format_spec} to apply to date/time
               columns which are not correctly inferred by pandas 'parse_dates'.
               Format must be specified using the Python format codes:

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -249,7 +249,7 @@ def create_dims(ctx, dataframe, index_dims,
 
         # input check, can't do until after per_dim_tile
         if (per_dim_tile and not all(map(lambda x: isinstance(x,(int,float)), tile.values()))) or \
-           (per_dim_tile is False and not isinstance(tile, int)):
+           (per_dim_tile is False and not isinstance(tile, (int,float))):
             raise ValueError("Invalid tile kwarg: expected int or tuple of ints "
                              "got '{}'".format(tile))
 

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -382,6 +382,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
                         index_col=['time', 'double_range'],
                         parse_dates=['time'],
                         mode='schema_only',
+                        capacity=1001,
                         coords_filters=coords_filters)
 
         t0, t1 = df.time.min(), df.time.max()
@@ -399,6 +400,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
                         coords_filters=coords_filters,
                         cell_order='row-major',
                         tile_order='row-major',
+                        capacity=1001,
                         sparse=True,
                         allows_duplicates=False)
                         # note: filters omitted

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -361,7 +361,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             assert_array_equal(res['int_vals'], df.int_vals.values)
             assert_array_almost_equal(res['double_range'], df.double_range.values)
 
-    def test_csv_schema_only(self):
+    def test_dataframe_csv_schema_only(self):
         col_size = 10
         df = make_dataframe_basic3(col_size)
 
@@ -380,7 +380,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         tmp_assert_dir = os.path.join(tmp_dir, "array")
         # this should raise an error
         with self.assertRaises(ValueError):
-            tiledb.from_csv(tmp_assert_dir, tmp_csv, tile=1.0)
+            tiledb.from_csv(tmp_assert_dir, tmp_csv, tile='abc')
 
         with self.assertRaises(ValueError):
             tiledb.from_csv(tmp_assert_dir, tmp_csv, tile=(3,1.0))

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -377,12 +377,21 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         #   the arg is correctly parsed/passed
         coords_filters = tiledb.FilterList([tiledb.ZstdFilter(7)])
 
+        tmp_assert_dir = os.path.join(tmp_dir, "array")
+        # this should raise an error
+        with self.assertRaises(ValueError):
+            tiledb.from_csv(tmp_assert_dir, tmp_csv, tile=1.0)
+
+        with self.assertRaises(ValueError):
+            tiledb.from_csv(tmp_assert_dir, tmp_csv, tile=(3,1.0))
+
         tmp_array = os.path.join(tmp_dir, "array")
         tiledb.from_csv(tmp_array, tmp_csv,
                         index_col=['time', 'double_range'],
                         parse_dates=['time'],
                         mode='schema_only',
                         capacity=1001,
+                        tile={'time': 5},
                         coords_filters=coords_filters)
 
         t0, t1 = df.time.min(), df.time.max()
@@ -391,7 +400,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         ref_schema = tiledb.ArraySchema(
                         domain=tiledb.Domain(*[
                           tiledb.Dim(name='time', domain=(t0.to_datetime64(), t1.to_datetime64()),
-                                     tile=1000, dtype='datetime64[ns]'),
+                                     tile=5, dtype='datetime64[ns]'),
                           tiledb.Dim(name='double_range', domain=(-1000.0, 1000.0), tile=1000, dtype='float64'),
                         ]),
                         attrs=[


### PR DESCRIPTION
This PR implements the following for from_csv and from_pandas
- 'capacity' kwarg to apply to schema
- 'tile' as dict kwarg (in addition to existing scalar usage) optionally specifying per-dimension tile extents by `{name: extent}` pairs