### PR TITLE
WIP Support running unit tests against different VFS

### DIFF
--- a/tiledb/highlevel.py
+++ b/tiledb/highlevel.py
@@ -23,7 +23,7 @@ def open(uri, mode='r', key=None, attr=None, config=None, ctx=None):
         ctx = tiledb.Ctx(cfg)
 
     if ctx is None:
-        ctx = default_ctx()
+        ctx = tiledb.default_ctx()
 
     return tiledb.Array.load_typed(uri, mode, key, None, attr, ctx)
 
@@ -43,7 +43,7 @@ def save(uri, array, config=None, **kw):
         cfg = Config(config)
         ctx = tiledb.Ctx(cfg)
     else:
-        ctx = default_ctx()
+        ctx = tiledb.default_ctx()
 
     return tiledb.from_numpy(uri, array, ctx=ctx)
 
@@ -66,7 +66,7 @@ def empty_like(uri, arr, config=None, key=None, tile=None, ctx=None):
         cfg = tiledb.Config(config)
         ctx = tiledb.Ctx(cfg)
     elif ctx is None:
-        ctx = default_ctx()
+        ctx = tiledb.default_ctx()
 
     if arr is ArraySchema:
         schema = arr
@@ -83,7 +83,7 @@ def from_numpy(uri, array, ctx=None, **kw):
     See documentation of :func:`tiledb.DenseArray.from_numpy`.
     """
     if not ctx:
-        ctx = default_ctx()
+        ctx = tiledb.default_ctx()
     if not isinstance(array, np.ndarray):
         raise Exception("from_numpy is only currently supported for numpy.ndarray")
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1877,7 +1877,8 @@ class SparseArray(DiskTestCase):
             ],
             cell_order='row-major',
             tile_order='row-major',
-            sparse=True)
+            sparse=True,
+            ctx=ctx)
 
         tiledb.SparseArray.create(uri, schema)
 
@@ -2787,10 +2788,15 @@ class VFS(DiskTestCase):
     def test_ls(self):
         import os
         basepath = self.path("test_vfs_ls")
-        os.mkdir(basepath)
+
+        # TMP
+        if basepath.startswith("azure") or basepath.startswith("s3"):
+            return
+
+        self.vfs.create_dir(basepath)
         for id in (1,2,3):
             dir = os.path.join(basepath, "dir"+str(id))
-            os.mkdir(dir)
+            self.vfs.create_dir(dir)
             fname =os.path.join(basepath, "file_"+str(id))
             os.close(os.open(fname, os.O_CREAT | os.O_EXCL))
 

--- a/tiledb/tests/test_metadata.py
+++ b/tiledb/tests/test_metadata.py
@@ -178,7 +178,7 @@ class MetadataTest(DiskTestCase):
 
         # test expected number of fragments before consolidating
         self.assertEqual(
-            len( vfs.ls(os.path.join(path, "__meta")) ),
+            len( self.vfs.ls(os.path.join(path, "__meta")) ),
             302
             )
 
@@ -195,7 +195,7 @@ class MetadataTest(DiskTestCase):
 
         # should only have one fragment+'.ok' after vacuuming
         self.assertEqual(
-            len( vfs.ls(os.path.join(path, "__meta")) ),
+            len( self.vfs.ls(os.path.join(path, "__meta")) ),
             1
             )
 

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -26,7 +26,7 @@ def make_1d_dense(ctx, path, attr_name=''):
     schema = tiledb.ArraySchema(domain=dom, attrs=(att,), sparse=False, ctx=ctx)
     tiledb.DenseArray.create(path, schema)
 
-    with tiledb.DenseArray(path, 'w') as A:
+    with tiledb.DenseArray(path, 'w', ctx=ctx) as A:
         A[:] = a_orig
 
 
@@ -40,7 +40,7 @@ def make_2d_dense(ctx, path, attr_name=''):
     schema = tiledb.ArraySchema(domain=dom, attrs=(att,), sparse=False, ctx=ctx)
     tiledb.DenseArray.create(path, schema)
 
-    with tiledb.DenseArray(path, 'w') as A:
+    with tiledb.DenseArray(path, 'w', ctx=ctx) as A:
         A[:] = a_orig
 
 class TestMultiRange(DiskTestCase):
@@ -56,7 +56,7 @@ class TestMultiRange(DiskTestCase):
                              dtype=np.uint64)
 
 
-        with tiledb.DenseArray(path) as A:
+        with tiledb.DenseArray(path, ctx=ctx) as A:
             ranges = ( ((0, 0),), )
             expected = np.array([0], dtype=np.int64)
             a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
@@ -89,7 +89,7 @@ class TestMultiRange(DiskTestCase):
             ( (0, 0), (5,8), ),
         )
 
-        with tiledb.DenseArray(path) as A:
+        with tiledb.DenseArray(path, ctx=ctx) as A:
             a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
 
             assert_array_equal(a, expected)
@@ -112,7 +112,7 @@ class TestMultiRange(DiskTestCase):
             ( (0,3), )
         )
 
-        with tiledb.DenseArray(path) as A:
+        with tiledb.DenseArray(path, ctx=ctx) as A:
             a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
             assert_array_equal(a, expected)
 
@@ -293,10 +293,10 @@ class TestMultiRange(DiskTestCase):
         tiledb.DenseArray.create(path, schema)
 
         orig_array = np.random.rand(schema.domain.dim(0).size).astype(np.float32)
-        with tiledb.open(path, 'w') as A:
+        with tiledb.open(path, 'w', ctx=ctx) as A:
             A[:] = orig_array
 
-        with tiledb.open(path) as A:
+        with tiledb.open(path, ctx=ctx) as A:
             # stepped ranges are not supported
             with self.assertRaises(ValueError):
                 A.query(coords=True).multi_index[ 1::2 ]
@@ -342,10 +342,10 @@ class TestMultiRange(DiskTestCase):
         coords = np.linspace(0,30, num=31)
         orig_array = np.random.rand(coords.size)
 
-        with tiledb.open(path, 'w') as A:
+        with tiledb.open(path, 'w', ctx=ctx) as A:
             A[coords] = orig_array
 
-        with tiledb.open(path) as A:
+        with tiledb.open(path, ctx=ctx) as A:
             assert_array_equal(
                 orig_array[ [0] ],
                 A.multi_index[ [0] ][attr_name]
@@ -394,10 +394,10 @@ class TestMultiRange(DiskTestCase):
 
             coords = intspace(min, max, num=100, dtype=dtype)
 
-            with tiledb.open(path, 'w') as A:
+            with tiledb.open(path, 'w', ctx=ctx) as A:
                 A[coords] = coords
 
-            with tiledb.open(path) as A:
+            with tiledb.open(path, ctx=ctx) as A:
 
                 res = A.multi_index[slice(coords[0], coords[-1])]
                 assert_array_equal(
@@ -460,10 +460,10 @@ class TestMultiRange(DiskTestCase):
         d2 = np.linspace(0, 10, num=11, dtype=np.float32)
         coords_d1,coords_d2 = np.meshgrid(d1,d2,indexing='ij')
 
-        with tiledb.open(path, 'w') as A:
+        with tiledb.open(path, 'w', ctx=ctx) as A:
             A[coords_d1.flatten(),coords_d2.flatten()] = orig_array
 
-        with tiledb.open(path) as A:
+        with tiledb.open(path, ctx=ctx) as A:
             res = A.multi_index[[0], :]
             assert_array_equal(
                 orig_array[[0], :].squeeze(),
@@ -544,7 +544,7 @@ class TestMultiRange(DiskTestCase):
         data = {'U':  U,
                 'V':  V}
 
-        with tiledb.open(path, 'w') as A:
+        with tiledb.open(path, 'w', ctx=ctx) as A:
             A[coords] = data
 
         with tiledb.open(path) as A:
@@ -576,7 +576,7 @@ class TestMultiRange(DiskTestCase):
                     res[k]
                 )
 
-        with tiledb.open(path) as A:
+        with tiledb.open(path, ctx=ctx) as A:
             Q = A.query(coords=False, attrs=["U"])
             res = Q.multi_index[:]
             self.assertTrue("U" in res)
@@ -597,13 +597,13 @@ class TestMultiRange(DiskTestCase):
         tiledb.DenseArray.create(path, schema)
 
         data = np.random.rand(1000)
-        with tiledb.DenseArray(path, 'w') as A:
+        with tiledb.DenseArray(path, 'w', ctx=ctx) as A:
             A[0] = data[0]
             A[-1] = data[-1]
             A[:] = data
 
         for _ in range(0,50):
-            with tiledb.DenseArray(path) as A:
+            with tiledb.DenseArray(path, ctx=ctx) as A:
                 idxs = random.sample(range(0, 999), k=100)
                 res = A.multi_index[idxs]
                 assert_array_equal(
@@ -627,10 +627,10 @@ class TestMultiRange(DiskTestCase):
 
         orig_array = np.random.rand(11,11)
 
-        with tiledb.open(path, 'w') as A:
+        with tiledb.open(path, 'w', ctx=ctx) as A:
             A[:] = orig_array
 
-        with tiledb.open(path) as A:
+        with tiledb.open(path, ctx=ctx) as A:
             assert_array_equal(
                 orig_array[[0], :],
                 A.multi_index[[0], :][attr_name]

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -103,7 +103,6 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             super(PandasDataFrameRoundtrip, self).setUp()
 
     def test_dataframe_basic_rt1_manual(self):
-
         uri = self.path("dataframe_basic_rt1_manual")
 
         ctx = tiledb.Ctx()
@@ -185,14 +184,13 @@ class PandasDataFrameRoundtrip(DiskTestCase):
 
     def test_dataframe_csv_rt1(self):
         def rand_dtype(dtype, size):
-            import os
             nbytes = size * np.dtype(dtype).itemsize
 
             randbytes = os.urandom(nbytes)
             return np.frombuffer(randbytes, dtype=dtype)
 
         uri = self.path("dataframe_csv_rt1")
-        os.mkdir(uri)
+        self.vfs.create_dir(uri)
         col_size=15
         data_dict = {
             'dates': np.array(


### PR DESCRIPTION
@Shelnutt2 this is roughly what we need to do in order to run the TileDB-Py unit tests against a VFS rather than a local filesystem. Currently it is hard-coded against S3/minio, but can refactor to environment variables or something else depending on how we decide to target the REST system. 

(currently a couple failures against S3 that I haven't tracked down; some missing `ctx=` arguments, and a couple of multipart upload failures when flushing that I believe are spurious and related to minio, but haven't tracked down yet)