### PR TITLE
Modified stats_dump() To Return Internal Stats As String

### DIFF
--- a/examples/using_tiledb_stats.py
+++ b/examples/using_tiledb_stats.py
@@ -41,11 +41,18 @@ array_name = "stats_array"
 
 
 def create_array(row_tile_extent, col_tile_extent):
-    dom = tiledb.Domain(tiledb.Dim(name="rows", domain=(1, 12000), tile=row_tile_extent, dtype=np.int32),
-                        tiledb.Dim(name="cols", domain=(1, 12000), tile=col_tile_extent, dtype=np.int32))
+    dom = tiledb.Domain(
+        tiledb.Dim(
+            name="rows", domain=(1, 12000), tile=row_tile_extent, dtype=np.int32
+        ),
+        tiledb.Dim(
+            name="cols", domain=(1, 12000), tile=col_tile_extent, dtype=np.int32
+        ),
+    )
 
-    schema = tiledb.ArraySchema(domain=dom, sparse=False,
-                                attrs=[tiledb.Attr(name="a", dtype=np.int32)])
+    schema = tiledb.ArraySchema(
+        domain=dom, sparse=False, attrs=[tiledb.Attr(name="a", dtype=np.int32)]
+    )
 
     # Create the (empty) array on disk.
     tiledb.DenseArray.create(array_name, schema)
@@ -53,14 +60,14 @@ def create_array(row_tile_extent, col_tile_extent):
 
 def write_array():
     # Open the array and write to it.
-    with tiledb.DenseArray(array_name, mode='w') as A:
+    with tiledb.DenseArray(array_name, mode="w") as A:
         data = np.arange(12000 * 12000)
         A[:] = data
 
 
 def read_array():
     # Open the array and read from it.
-    with tiledb.DenseArray(array_name, mode='r') as A:
+    with tiledb.DenseArray(array_name, mode="r") as A:
         # Read a slice of 3,000 rows.
         # Enable the stats for the read query, and print the report.
         tiledb.stats_enable()

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -838,16 +838,19 @@ void init_stats() {
   stats_counters["py.unpack_results_time"] = TimerType();
 }
 
-void print_stats() {
+std::string python_internal_stats() {
   if (!g_stats) {
-    TPY_ERROR_LOC("Stats counters are not unitialized!")
+    TPY_ERROR_LOC("Stats counters are not uninitialized!")
   }
 
   auto counters = g_stats.get()->counters;
 
-  std::cout << "==== Python ====" << std::endl <<
-               "- Read query time: " << counters["py.read_query_time"].count() << std::endl <<
-               "- Buffer conversion time: " << counters["py.unpack_results_time"].count() << std::endl;
+  std::ostringstream os;
+  os << "==== Python ====" << std::endl <<
+      "- Read query time: " << counters["py.read_query_time"].count() << std::endl <<
+      "- Buffer conversion time: " << counters["py.unpack_results_time"].count();
+
+  return os.str();
 }
 
 PYBIND11_MODULE(core, m) {
@@ -866,7 +869,7 @@ PYBIND11_MODULE(core, m) {
       .def_property_readonly("_test_init_buffer_bytes", &PyQuery::_test_init_buffer_bytes);
 
   m.def("init_stats", &init_stats);
-  m.def("print_stats", &print_stats);
+  m.def("python_internal_stats", &python_internal_stats);
 
   /*
      We need to make sure C++ TileDBError is translated to a correctly-typed py

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -31,7 +31,9 @@ cdef extern from "tiledb/tiledb.h":
     void tiledb_stats_enable()
     void tiledb_stats_disable()
     void tiledb_stats_reset()
-    void tiledb_stats_dump(FILE* out)
+    int32_t tiledb_stats_dump(FILE* out)
+    int32_t tiledb_stats_dump_str(char** out)
+    int32_t tiledb_stats_free_str(char** out)
 
     # Enums
     ctypedef enum tiledb_object_t:

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -10,7 +10,6 @@ from cpython.pycapsule cimport PyCapsule_New, PyCapsule_IsValid, PyCapsule_GetPo
 include "common.pxi"
 from .array import DenseArray, SparseArray
 
-import sys
 from os.path import abspath
 from collections import OrderedDict
 import io
@@ -504,13 +503,23 @@ def stats_reset():
     tiledb.core.init_stats()
 
 def stats_dump():
-    """Print all TileDB internal statistics values to standard output."""
-    tiledb_stats_dump(stdout)
+    """Return TileDB internal statistics as a string."""
+    cdef char* stats_str_ptr = NULL;
+
+    if tiledb_stats_dump_str(&stats_str_ptr) == TILEDB_ERR:
+        raise TileDBError("Unable to dump stats to stats_str_ptr.")
+
+    stats_str = stats_str_ptr.decode("UTF-8", "strict")
+
+    if tiledb_stats_free_str(&stats_str_ptr) == TILEDB_ERR:
+        raise TileDBError("Unable to free stats_str_ptr.")
+
+    print(stats_str)
 
     import tiledb.core
-    tiledb.core.print_stats()
+    print(tiledb.core.python_internal_stats())
 
-
+        
 cpdef unicode ustring(object s):
     """Coerce a python object to a unicode string"""
 


### PR DESCRIPTION
Previously, tiledb_stats_dump() output to stdout. However, Jupyter notebooks
do not capture or redirect external stdout and thus were not able to display
internal stats. tiledb_stats_dump() now outputs to a temporary file which is
then converted to a Python string.

---
[ch3357]