### PR TITLE
Make 'rows' dimension transparent in dataframe read-back

### DIFF
--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -233,7 +233,7 @@ def get_index_metadata(dataframe):
     for index in dataframe.index.names:
         index_md_name = index
         if index == None:
-            index_md_name = 'rows'
+            index_md_name = '__tiledb_rows'
         # Note: this may be expensive.
         md[index_md_name] = dtype_from_column(dataframe.index.get_level_values(index)).dtype
 
@@ -266,7 +266,7 @@ def create_dims(ctx, dataframe, index_dims,
             name = index.name
         else:
             index_dtype = np.dtype('uint64')
-            name = 'rows'
+            name = '__tiledb_rows'
 
         index_dict[name] = index.values
 
@@ -541,8 +541,8 @@ def _tiledb_result_as_dataframe(readable_array, result_dict):
         elif index_dims and col_name in index_dims:
             new_col = pd.Series(col_val, dtype=index_dims[col_name])
             result_dict[col_name] = new_col
-            if col_name == 'rows':
-                rename_cols['rows'] = None
+            if col_name == '__tiledb_rows':
+                rename_cols['__tiledb_rows'] = None
                 indexes.append(None)
             else:
                 indexes.append(col_name)

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4878,8 +4878,9 @@ cdef class SparseArrayImpl(Array):
             sparse_attributes.append(attr._internal_name)
             sparse_values.append(attr_val)
 
-        assert len(sparse_attributes) == len(val.keys())
-        assert len(sparse_values) == len(val.values())
+        if (len(sparse_attributes) != len(val.keys())) \
+            or (len(sparse_values) != len(val.values())):
+            raise TileDBError("Sparse write input data count does not match number of attributes")
 
         _write_array(
             self.ctx.ptr, self.ptr, self,

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4128,14 +4128,14 @@ cdef class Array(object):
         ...    A = tiledb.open(tmp)
         ...    A.df[1]
         ...    A.df[1:5]
-           rows  col1_f  col2_int
-        0     1     0.1         1
-           rows  col1_f  col2_int
-        0     1     0.1         1
-        1     2     0.2         2
-        2     3     0.3         3
-        3     4     0.4         4
-        4     5     0.5         5
+              col1_f  col2_int
+           1     0.1         1
+              col1_f  col2_int
+           1     0.1         1
+           2     0.2         2
+           3     0.3         3
+           4     0.4         4
+           5     0.5         5
 
         """
 

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -167,8 +167,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         tiledb.from_dataframe(uri, df, sparse=False, ctx=ctx)
 
         # TODO tiledb.read_dataframe
-        with tiledb.open(uri) as B:
-            df_readback = pd.DataFrame.from_dict(B[:])
+        df_readback = tiledb.open_dataframe(uri)
 
         tm.assert_frame_equal(df, df_readback)
 
@@ -509,16 +508,11 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         tiledb.from_csv(tmp_array, tmp_csv, fillna={'v': 0})
 
         def check_array(path, df):
+            # update the value in the original dataframe to match what we expect on read-back
+            df['v'][4] = 0
+
             with tiledb.open(path) as A:
-                res = A[:]
-                # check the value in the raw array
-                self.assertEqual(res['v'][4], 0)
-
-                df_bk = pd.DataFrame(res)
-                df_bk.pop('rows')
-
-                # update the value in the original dataframe to match what we expect on read-back
-                df['v'][4] = 0
+                df_bk = A.df[:] #pd.DataFrame.from_dict(res)
                 tm.assert_frame_equal(df_bk, df)
 
         check_array(tmp_array, copy.deepcopy(df))


### PR DESCRIPTION
This change hides the 'rows' name we use for generated schema dimension name when no index is specified. A read-back dataframe using `.df[]` or `open_dataframe` should look the same as a direct `pd.read_csv` of the source data. See before/after here: https://github.com/TileDB-Inc/TileDB-Py/compare/ihn/df_readback_rows_x?expand=1#diff-1e19c4fe9825fc13a5d649c9d7745a2d49f2c9be3a247f7fa9b0526fc7ac5142L4131-R4138

By request, and also fixes a bug @eddelbuettel noticed running a prior notebook (plus improved reporting for that error by throwing instead of giving a context-free `assert`ion).