### PR TITLE
Use nonempty_domain for open_dataframe whole-array loading

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # In progress
 ## Improvements
 * Modified `stats_dump` to return internal stats as string, allowing for output in Jupyter notebooks [#403](https://github.com/TileDB-Inc/TileDB-Py/pull/403)
+* `open_dataframe` now uses the underlying Array's `nonempty_domain` [#409](https://github.com/TileDB-Inc/TileDB-Py/pull/409)
 
 # TileDB-Py 0.7.0 Release Notes
 

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -575,11 +575,10 @@ def open_dataframe(uri, ctx=None):
     """
     if ctx is None:
         ctx = tiledb.default_ctx()
-
     # TODO support `distributed=True` option?
-
     with tiledb.open(uri, ctx=ctx) as A:
-        data = A[:]
+        nonempty = A.nonempty_domain()
+        data = A.multi_index.__getitem__(tuple(slice(s1, s2) for s1,s2 in nonempty))
         new_df = _tiledb_result_as_dataframe(A, data)
 
     return new_df

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -12,7 +12,7 @@ def mr_dense_result_shape(ranges, base_shape = None):
     new_shape = list()
     for i,rr in enumerate(ranges):
         if rr != ():
-            m = list(map(lambda y: abs(y[1] - y[0]) + 1, rr))
+            m = list(map(lambda y: abs(np.uint64(y[1]) - np.uint64(y[0])) + np.uint64(1), rr))
             new_shape.append(np.sum(m))
         else:
             if base_shape is None:

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -166,9 +166,12 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         ctx = tiledb.Ctx()
         tiledb.from_dataframe(uri, df, sparse=False, ctx=ctx)
 
-        # TODO tiledb.read_dataframe
         df_readback = tiledb.open_dataframe(uri)
+        tm.assert_frame_equal(df, df_readback)
 
+        uri = self.path("dataframe_basic_rt1_unlimited")
+        tiledb.from_dataframe(uri, df, full_domain=True, sparse=False, ctx=ctx)
+        df_readback = tiledb.open_dataframe(uri)
         tm.assert_frame_equal(df, df_readback)
 
     def test_dataframe_basic2(self):
@@ -321,10 +324,6 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         tmp_array2 = os.path.join(tmp_dir, "array2")
         tiledb.from_csv(tmp_array2, tmp_csv,
                         sparse=False)
-        with tiledb.open(tmp_array2) as A:
-            # with sparse=False and no index column, we expect to have unlimited domain
-            self.assertEqual(A.schema.domain.dim(0).domain[1], 18446744073709541615)
-
 
     def test_csv_col_to_sparse_dims(self):
         df = make_dataframe_basic3(20)


### PR DESCRIPTION
Fixes the last issue with #408 (I added a work-around there for [ch3767]).

closes [ch3779]