### PR TITLE
Fix error condition 'return' -> 'raise'; cython backtrace note

### DIFF
--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -4,6 +4,17 @@ import ctypes
 import os
 import sys
 
+# un-comment this section to fix Cython backtrace line-numbers in
+# IPython/Jupyter. see https://bugs.python.org/issue32797#msg323167
+# ---
+#try:
+#    from importlib.machinery import ExtensionFileLoader
+#except ImportError:
+#    pass  # Python 2
+#else:
+#    del ExtensionFileLoader.get_source
+# ---
+
 if os.name == "posix":
     if sys.platform == "darwin":
         lib_name = "libtiledb.dylib"

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -455,7 +455,7 @@ cdef _raise_tiledb_error(tiledb_error_t* err_ptr):
     if ret != TILEDB_OK:
         tiledb_error_free(&err_ptr)
         if ret == TILEDB_OOM:
-            return MemoryError()
+            raise MemoryError()
         raise TileDBError("error retrieving error message")
     cdef unicode message_string
     try:
@@ -519,7 +519,7 @@ def stats_dump():
     import tiledb.core
     print(tiledb.core.python_internal_stats())
 
-        
+
 cpdef unicode ustring(object s):
     """Coerce a python object to a unicode string"""
 


### PR DESCRIPTION
- Fix error condition 'return' -> 'raise'
- Note on fix for Cython line numbers in Jupyter