### PR TITLE
Add CPython 3.9 builder section for manylinux wheels

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
 # In progress
+
+# TileDB-Py 0.7.1 Release Notes
+
 ## Improvements
 * Added support for `df[]` indexing via `tiledb.Array.query` [#411](https://github.com/TileDB-Inc/TileDB-Py/pull/411)
 * Modified `stats_dump` to return internal stats as string, allowing for output in Jupyter notebooks [#403](https://github.com/TileDB-Inc/TileDB-Py/pull/403)

--- a/misc/pypi_linux/build.sh
+++ b/misc/pypi_linux/build.sh
@@ -75,6 +75,16 @@ auditwheel repair dist/*.whl
 /opt/python/cp38-cp38/bin/python3.8 -m pip install wheelhouse/*.whl
 cd tiledb/tests
 
+# build python39 wheel
+cd /home/tiledb
+git clone $TILEDB_PY_REPO TileDB-Py39
+git -C TileDB-Py39 checkout $TILEDBPY_VERSION
+
+cd /home/tiledb/TileDB-Py39
+/opt/python/cp39-cp39/bin/python3.9 setup.py build_ext bdist_wheel --tiledb=/usr/local
+auditwheel repair dist/*.whl
+/opt/python/cp38-cp38/bin/python3.9 -m pip install wheelhouse/*.whl
+cd tiledb/tests
 
 # copy build products out
 cp /home/tiledb/TileDB-Py27/wheelhouse/* /wheels
@@ -82,3 +92,4 @@ cp /home/tiledb/TileDB-Py35/wheelhouse/* /wheels
 cp /home/tiledb/TileDB-Py36/wheelhouse/* /wheels
 cp /home/tiledb/TileDB-Py37/wheelhouse/* /wheels
 cp /home/tiledb/TileDB-Py38/wheelhouse/* /wheels
+cp /home/tiledb/TileDB-Py39/wheelhouse/* /wheels


### PR DESCRIPTION
Add missing cp39 section to the linux wheel build script.