### PR TITLE
Fix CSV/dataframe ingest error due to setting tile=0 with small index range

### DIFF
--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -212,8 +212,11 @@ def dim_for_column(ctx, name, dim_info, col, tile=None, full_domain=False, ndim=
     if not dim_info.dtype in (np.bytes_, np.unicode):
         if np.issubdtype(dtype, np.integer):
             dim_range = np.uint64(np.abs(np.uint64(dim_max) - np.uint64(dim_min)))
+            # we can't make a tile larger than the dimension range
             if dim_range < tile:
                 tile = dim_range
+            if tile < 1:
+                tile = 1
         elif np.issubdtype(dtype, np.float64):
             dim_range = dim_max - dim_min
             if dim_range < tile:

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -596,3 +596,8 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             df_bk = df_bk.set_index(['time'])
 
             tm.assert_frame_equal(df_bk, df_orig)
+
+    def test_dataframe_misc(self):
+        uri = self.path("test_small_domain_range")
+        df = pd.DataFrame({'data': [2]}, index=[0])
+        tiledb.from_pandas(uri, df)


### PR DESCRIPTION
Fixes bug where we set tile=0 when ingesting a CSV with only 1 row,
or an indexed dataframe with index range of 0. Leading to tile extent check failure in core.