### PR TITLE
More dataframe updates

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,4 +8,5 @@ tox
 dask
 pandas ; python_version > '3.5'
 psutil
+pyarrow
 -r requirements.txt

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -266,7 +266,7 @@ public:
         //        [](Query* p){} /* note: no deleter*/);
 
     tiledb_layout_t layout = (tiledb_layout_t)py_layout.cast<int32_t>();
-    if (issparse && layout == TILEDB_UNORDERED) {
+    if (!issparse && layout == TILEDB_UNORDERED) {
           TPY_ERROR_LOC("TILEDB_UNORDERED read is not supported for dense arrays")
     }
     query_->set_layout(layout);

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -490,6 +490,9 @@ def from_pandas(uri, dataframe, **kwargs):
                                              filters=attrs_filters,
                                              column_types=column_types)
 
+        # don't set allows_duplicates=True for dense
+        allows_duplicates = allows_duplicates and sparse
+
         # now create the ArraySchema
         schema = tiledb.ArraySchema(
             domain=domain,

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -415,7 +415,6 @@ def from_pandas(uri, dataframe, **kwargs):
 
     """
     check_dataframe_deps()
-
     import pandas as pd
 
     if 'tiledb_args' in kwargs:
@@ -440,6 +439,9 @@ def from_pandas(uri, dataframe, **kwargs):
     fillna = tiledb_args.get('fillna', None)
     date_spec = tiledb_args.get('date_spec', None)
     column_types = tiledb_args.get('column_types', None)
+
+    if mode != 'append' and tiledb.array_exists(uri):
+        raise TileDBError("Array URI '{}' already exists!".format(uri))
 
     write = True
     create_array = True
@@ -740,6 +742,9 @@ def from_csv(uri, csv_file, **kwargs):
             pandas_args['nrows'] = 500
         elif mode not in ['ingest', 'append']:
             raise TileDBError("Invalid mode specified ('{}')".format(mode))
+
+    if mode != 'append' and tiledb.array_exists(uri):
+        raise TileDBError("Array URI '{}' already exists!".format(uri))
 
     # this is a pandas pass-through argument, do not pop!
     chunksize = kwargs.get('chunksize', None)

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -17,6 +17,29 @@ else:
     unicode_type = unicode
 unicode_dtype = np.dtype(unicode_type)
 
+def check_dataframe_deps():
+    pd_error = """Pandas version >= 1.0 required for dataframe functionality.
+                  Please `pip install pandas>=1.0` to proceed."""
+    pa_error = """PyArrow version >= 1.0 required for dataframe functionality.
+                  Please `pip install pyarrow>=1.0` to proceed."""
+
+    try:
+        import pandas as pd
+    except ImportError:
+        raise Exception(pd_error)
+
+    from distutils.version import LooseVersion
+    if LooseVersion(pd.__version__) < LooseVersion("1.0"):
+        raise Exception(pd_error)
+
+    try:
+        import pyarrow as pa
+    except ImportError:
+        raise Exception(pa_error)
+
+    if LooseVersion(pa.__version__) < LooseVersion("1.0"):
+        raise Exception(pa_error)
+
 # TODO
 # - handle missing values
 # - handle extended datatypes
@@ -391,6 +414,8 @@ def from_pandas(uri, dataframe, **kwargs):
     :return: None
 
     """
+    check_dataframe_deps()
+
     import pandas as pd
 
     if 'tiledb_args' in kwargs:
@@ -590,6 +615,8 @@ def open_dataframe(uri, ctx=None):
     >>> tiledb.object_type("iris.tldb")
     'array'
     """
+    check_dataframe_deps()
+
     if ctx is None:
         ctx = tiledb.default_ctx()
     # TODO support `distributed=True` option?
@@ -676,11 +703,8 @@ def from_csv(uri, csv_file, **kwargs):
     >>> tiledb.object_type("iris.tldb")
     'array'
     """
-    try:
-        import pandas
-    except ImportError as exc:
-        print("tiledb.from_csv requires pandas")
-        raise
+    check_dataframe_deps()
+    import pandas
 
     if 'tiledb_args' in kwargs:
         tiledb_args = kwargs.get('tiledb_args')

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -5078,14 +5078,14 @@ cdef class SparseArrayImpl(Array):
             raise TileDBError("SparseArray is not opened for reading")
 
         cdef tiledb_layout_t layout = TILEDB_UNORDERED
-        if order is None or order == 'C':
+        if order is None or order == 'U':
+            layout = TILEDB_UNORDERED
+        elif order == 'C':
             layout = TILEDB_ROW_MAJOR
         elif order == 'F':
             layout = TILEDB_COL_MAJOR
         elif order == 'G':
             layout = TILEDB_GLOBAL_ORDER
-        elif order == 'U':
-            pass
         else:
             raise ValueError("order must be 'C' (TILEDB_ROW_MAJOR), "\
                              "'F' (TILEDB_COL_MAJOR), "\

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -129,7 +129,9 @@ class MultiRangeIndexer(object):
         dom = self.schema.domain
         attr_names = tuple(self.schema.attr(i)._internal_name for i in range(self.schema.nattr))
         coords = None
-        order = 'C' # TILEDB_ROW_MAJOR
+
+        # default TILEDB_UNORDERED for sparse, TILEDB_ROW_MAJOR for dense
+        order = 'U' if self.schema.sparse else 'C'
         if self.query is not None:
             # if we are called via Query object, then we need to respect Query semantics
             attr_names = tuple(self.query.attrs) if self.query.attrs else attr_names # query.attrs might be None -> all
@@ -146,7 +148,8 @@ class MultiRangeIndexer(object):
             layout = 3
         else:
             raise ValueError("order must be 'C' (TILEDB_ROW_MAJOR), "\
-                             "'F' (TILEDB_COL_MAJOR), "\
+                             "'F' (TILEDB_COL_MAJOR), "
+                             "'U' (TILEDB_UNORDERED),"
                              "or 'G' (TILEDB_GLOBAL_ORDER)")
 
         from tiledb.core import PyQuery

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -202,7 +202,8 @@ class DataFrameIndexer(MultiRangeIndexer):
     [] operator uses multi_index semantics.
     """
     def __getitem__(self, idx):
-        from .dataframe_ import _tiledb_result_as_dataframe
+        from .dataframe_ import _tiledb_result_as_dataframe, check_dataframe_deps
+        check_dataframe_deps()
 
         idx_start = time.time()
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1847,7 +1847,7 @@ class SparseArray(DiskTestCase):
         schema = tiledb.ArraySchema(domain=dom, attrs=(att,), sparse=True, ctx=ctx)
         tiledb.SparseArray.create(uri, schema)
 
-        coords = np.random.rand(100) * 10000
+        coords = np.random.uniform(low=1, high=10000, size=100)
         data = np.random.rand(100)
 
         with tiledb.SparseArray(uri, mode='w', ctx=ctx) as T:


### PR DESCRIPTION
- Add version check for dataframe dependencies to avoid various column type errors observed with pandas < 1.0
- Don't pass allows_duplicates=True to dense array constructor
- Add check for existing array URI before any CSV/dataframe ops (potentially i/o-intensive before getting to array creation error)
- Test and fix unordered query for multi_index/df