### PR TITLE
Fix and test sparse dimension type selection when from_pandas array type is…

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# In Progress
+
+  ## Bug fixes
+  * Fix sparse dimension type selection when array type is not specified to from_pandas [#429](https://github.com/TileDB-Inc/TileDB-Py/pull/408)
+
 # TileDB-Py 0.7.2 Release Notes
 
 ## TileDB Embedded updates:

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -44,9 +44,12 @@ def check_dataframe_deps():
 # - handle missing values
 # - handle extended datatypes
 
+# Note: 'None' is used to indicate optionality for many of these options
+#       For example, if the `sparse` argument is unspecified we will default
+#       to False (dense) unless the input has string or heterogenous indexes.
 TILEDB_KWARG_DEFAULTS = {
     'ctx': None,
-    'sparse': False,
+    'sparse': None,
     'index_dims': None,
     'allows_duplicates': True,
     'mode': 'ingest',
@@ -316,6 +319,7 @@ def create_dims(ctx, dataframe, index_dims,
                          tile=dim_tile, full_domain=full_domain,
                          index_dtype=index_dtype))
 
+
     if any([d.dtype in (np.bytes_, np.unicode_) for d in dim_types]):
         if sparse is False:
             raise TileDBError("Cannot create dense array with string-typed dimensions")
@@ -328,6 +332,10 @@ def create_dims(ctx, dataframe, index_dims,
             raise TileDBError("Cannot create dense array with heterogeneous dimension data types")
         elif sparse is None:
             sparse = True
+
+    # Fall back to default dense type if unspecified and not inferred from dimension types
+    if sparse is None:
+        sparse = False
 
     ndim = len(dim_types)
 

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -627,3 +627,11 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         uri = self.path("test_small_domain_range")
         df = pd.DataFrame({'data': [2]}, index=[0])
         tiledb.from_pandas(uri, df)
+
+        data = {'data': np.array([1,2,3]), 'index': np.array(['a', 'b', 'c'], dtype=np.dtype('|S'))}
+        df = pd.DataFrame.from_dict(data)
+        df = df.set_index(['index'])
+        uri = self.path("test_string_index_infer")
+        tiledb.from_pandas(uri, df)
+        with tiledb.open(uri) as A:
+            self.assertTrue(A.schema.domain.dim(0).dtype == np.dtype('|S'))


### PR DESCRIPTION
… not specified

When no array type is specified to from_pandas, we must try to choose the
correct dimension types based on the index (if any).