### PR TITLE
Support new A.query(dims=..., index_col=...) keyword args

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# In Progress
+
+## Improvements
+* Support selecting subset of dimensions in Array.query via new keyword argument `dims: List[String]`. The `coords=True` kwarg is still supported for compatibility, and continues to return all dimensions [#433](https://github.com/TileDB-Inc/TileDB-Py/pull/433)
+
 # TileDB-Py 0.7.3 Release Notes
 
 ## Improvements

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1226,8 +1226,10 @@ cdef class VFS(object):
 cdef class Query(object):
     cdef Array array
     cdef object attrs
-    cdef object coords
+    cdef object dims
     cdef object order
+    cdef object coords
+    cdef object index_col
     cdef object return_arrow
     cdef DomainIndexer domain_index
     cdef object multi_index

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2,7 +2,8 @@
 
 from __future__ import absolute_import
 
-import sys, os, io, re, platform, unittest, random, warnings
+import sys, os, io, re, platform, contextlib
+import unittest, random, warnings
 
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -22,6 +23,7 @@ def safe_dump(obj):
         with io.StringIO() as buf, redirect_stdout(buf):
             obj.dump()
     except ImportError:
+        # fallback on python 2
         obj.dump()
     except Exception as exc:
         print("Exception occurred calling 'obj.dump()' with redirect.", exc,
@@ -47,6 +49,9 @@ class StatsTest(DiskTestCase):
         with tiledb.from_numpy(self.path("test_stats"), np.arange(10)) as T:
             assert_array_equal(T,np.arange(10))
             tiledb.stats_dump()
+            stats = tiledb.stats_dump(print_out=False)
+            self.assertTrue("==== READ ====")
+            self.assertTrue("==== Python Stats ====" in stats)
 
 class Config(DiskTestCase):
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1173,16 +1173,6 @@ class DenseArrayTest(DiskTestCase):
             with self.assertRaises(tiledb.TileDBError):
                 T.query(attrs=("unknown"))[:]
 
-            # Ensure that query only returns specified attributes
-            q = core.PyQuery(ctx, T, ("ints",), False, 0, False)
-            q.set_ranges([[(0,1)]])
-            q.submit()
-            r = q.results()
-            self.assertTrue("ints" in r)
-            self.assertTrue("floats" not in r)
-            del q
-
-
         with tiledb.DenseArray(self.path("foo"), mode='w', ctx=ctx) as T:
             # check error ncells length
             V["ints"] = V["ints"][1:2].copy()

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -43,80 +43,7 @@ def make_2d_dense(ctx, path, attr_name=''):
     with tiledb.DenseArray(path, 'w') as A:
         A[:] = a_orig
 
-class TestMultiRange(DiskTestCase):
-
-    def test_multirange_1d_1dim_ranges(self):
-        path = self.path('test_multirange_1d_1dim_ranges')
-        attr_name = 'a'
-
-        ctx = tiledb.Ctx()
-        make_1d_dense(ctx, path, attr_name=attr_name)
-
-        expected = np. array([0],
-                             dtype=np.uint64)
-
-
-        with tiledb.DenseArray(path) as A:
-            ranges = ( ((0, 0),), )
-            expected = np.array([0], dtype=np.int64)
-            a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
-            assert_array_equal(a, expected)
-            self.assertEqual(a.dtype, expected.dtype)
-
-            #===
-        #with tiledb.DenseArray(path) as A:
-            ranges2 = ( ((1, 1), (5,8)), )
-            expected2 = np.array([1,5,6,7,8], dtype=np.int64)
-            a2 = tiledb.libtiledb.multi_index(A, (attr_name,), ranges2)[attr_name]
-            assert_array_equal(a2, expected2)
-            self.assertEqual(a2.dtype, expected2.dtype)
-
-    def test_multirange_2d_1dim_ranges(self):
-        path = self.path('test_multirange_1dim_ranges')
-        attr_name = 'a'
-
-        ctx = tiledb.Ctx()
-        make_2d_dense(ctx, path, attr_name=attr_name)
-
-        expected = np. array([ 1,  2,  3,  4,
-                               21, 22, 23, 24,
-                               25, 26, 27, 28,
-                               29, 30, 31, 32, 33,
-                               34, 35, 36],
-                             dtype=np.uint64)
-
-        ranges = (
-            ( (0, 0), (5,8), ),
-        )
-
-        with tiledb.DenseArray(path) as A:
-            a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
-
-            assert_array_equal(a, expected)
-
-    def test_multirange_2d_2dim_ranges(self):
-        ctx = tiledb.Ctx()
-        path = self.path('test_multirange_2dim_ranges')
-        attr_name = 'a'
-
-        make_2d_dense(ctx, path, attr_name=attr_name)
-
-        expected = np.array([1, 2, 3, 4,
-                             5, 6, 7, 8,
-                             9, 10, 11, 12,
-                             13, 14, 15, 16,
-                             17, 18, 19, 20])
-
-        ranges = (
-            ( (0,4), ),
-            ( (0,3), )
-        )
-
-        with tiledb.DenseArray(path) as A:
-            a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
-            assert_array_equal(a, expected)
-
-
+class TestMultiRangeAuxiliary(DiskTestCase):
     def test_shape_funcs(self):
         #-----------
         range1el = ( ((1,1),), )
@@ -279,6 +206,77 @@ class TestMultiRange(DiskTestCase):
             )
         )
 
+class TestMultiRange(DiskTestCase):
+    def test_multirange_1d_1dim_ranges(self):
+        path = self.path('test_multirange_1d_1dim_ranges')
+        attr_name = 'a'
+
+        ctx = tiledb.Ctx()
+        make_1d_dense(ctx, path, attr_name=attr_name)
+
+        expected = np. array([0],
+                             dtype=np.uint64)
+
+
+        with tiledb.DenseArray(path) as A:
+            ranges = ( ((0, 0),), )
+            expected = np.array([0], dtype=np.int64)
+            a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
+            assert_array_equal(a, expected)
+            self.assertEqual(a.dtype, expected.dtype)
+
+            #===
+        #with tiledb.DenseArray(path) as A:
+            ranges2 = ( ((1, 1), (5,8)), )
+            expected2 = np.array([1,5,6,7,8], dtype=np.int64)
+            a2 = tiledb.libtiledb.multi_index(A, (attr_name,), ranges2)[attr_name]
+            assert_array_equal(a2, expected2)
+            self.assertEqual(a2.dtype, expected2.dtype)
+
+    def test_multirange_2d_1dim_ranges(self):
+        path = self.path('test_multirange_1dim_ranges')
+        attr_name = 'a'
+
+        ctx = tiledb.Ctx()
+        make_2d_dense(ctx, path, attr_name=attr_name)
+
+        expected = np. array([ 1,  2,  3,  4,
+                               21, 22, 23, 24,
+                               25, 26, 27, 28,
+                               29, 30, 31, 32, 33,
+                               34, 35, 36],
+                             dtype=np.uint64)
+
+        ranges = (
+            ( (0, 0), (5,8), ),
+        )
+
+        with tiledb.DenseArray(path) as A:
+            a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
+
+            assert_array_equal(a, expected)
+
+    def test_multirange_2d_2dim_ranges(self):
+        ctx = tiledb.Ctx()
+        path = self.path('test_multirange_2dim_ranges')
+        attr_name = 'a'
+
+        make_2d_dense(ctx, path, attr_name=attr_name)
+
+        expected = np.array([1, 2, 3, 4,
+                             5, 6, 7, 8,
+                             9, 10, 11, 12,
+                             13, 14, 15, 16,
+                             17, 18, 19, 20])
+
+        ranges = (
+            ( (0,4), ),
+            ( (0,3), )
+        )
+
+        with tiledb.DenseArray(path) as A:
+            a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
+            assert_array_equal(a, expected)
 
     def test_multirange_1d_dense_int64(self):
         attr_name = ''

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -248,12 +248,12 @@ class TestMultiRange(DiskTestCase):
         with tiledb.DenseArray(path) as A:
             ranges = ( ((0, 0),), )
             expected = np.array([0], dtype=np.int64)
-            a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
+            res = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)
+            a = res[attr_name]
             assert_array_equal(a, expected)
             self.assertEqual(a.dtype, expected.dtype)
+            self.assertEqual(len(res.keys()), 2)
 
-            #===
-        #with tiledb.DenseArray(path) as A:
             ranges2 = ( ((1, 1), (5,8)), )
             expected2 = np.array([1,5,6,7,8], dtype=np.int64)
             a2 = tiledb.libtiledb.multi_index(A, (attr_name,), ranges2)[attr_name]

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -226,7 +226,9 @@ class TestMultiRange(DiskTestCase):
             assert_array_equal(res['idx'], idx)
 
         uri = self.path("multirange_behavior_dense")
-        tiledb.from_numpy(uri, data)
+        with tiledb.from_numpy(uri, data):
+            pass
+
         with tiledb.open(uri) as B:
             res = B.multi_index[0:9] # TODO: this should accept [:]
             # always return data


### PR DESCRIPTION
- Add support for sub-selection of dimensions to return, via `A.query(dims=[...])`. Previously, the only controlling option `coords=True`, which returned all dimensions. `coords=True` is still supported for backward compatibility.

- Add support for query(index_col=...) keyword arg
This option allows to select dimensions or attributes to set as index(es) when
returning a dataframe, or prevent setting any index at all based on saved
array metadata.