### PR TITLE
Add nonempty_domain test, Attr fill values, query fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,9 @@
 * Support selecting subset of dimensions in Array.query via new keyword argument `dims: List[String]`. The `coords=True` kwarg is still supported for compatibility, and continues to return all dimensions [#433](https://github.com/TileDB-Inc/TileDB-Py/pull/433)
 * Support Dim(filters=FilterList) keyword argument to set filters on a per-Dim basis [#434](https://github.com/TileDB-Inc/TileDB-Py/pull/434)
 * Support tiledb.from_csv setting attribute and dimension filters by dictionary of {name: filter} [#434](https://github.com/TileDB-Inc/TileDB-Py/pull/434)
-* Add ArraySchema.check wrapping `tiledb_array_schema_check` [#435]((https://github.com/TileDB-Inc/TileDB-Py/pull/435)
+* Add ArraySchema.check wrapping `tiledb_array_schema_check` [#435](https://github.com/TileDB-Inc/TileDB-Py/pull/435)
+* Add support for attribute fill values `tiledb.Attr(fill=...)` and `Attr.fill` getter [#437](https://github.com/TileDB-Inc/TileDB-Py/pull/437)
+
 
 ## API Changes
 * tiledb.from_csv keyword arg `attrs_filters` renamed to `attr_filters` [#434](https://github.com/TileDB-Inc/TileDB-Py/pull/434)

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -28,6 +28,19 @@ stages:
         versionSpec: '$(python.version)'
         architecture: 'x64'
 
+    # Print python and pip version information for debugging.
+    # Azure pipelines windows images have been unstable or out of sync, causing
+    # build failures in the pip step below when the 'bash' task uses the wrong
+    # python or has issue that causes un-corrected cygwin-style paths to be
+    # passed to pip.
+    - bash: |
+        echo "==== Python information ===="
+        which python
+        which pip
+        python --version
+        echo "============================"
+      displayName: 'Print python version in bash task'
+
     - script: |
         printenv
       displayName: 'Print env'
@@ -53,6 +66,7 @@ stages:
 
     - bash: |
         set -xeo pipefail
+
         python -m unittest tiledb.tests.all.suite_test
 
         # Test wheel build, install, and run

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -71,10 +71,12 @@ stages:
 
         # Test wheel build, install, and run
         python setup.py bdist_wheel
-        whl_file=`pwd`/dist/`ls dist/*.whl`
-        pushd /tmp
-        echo "Installing wheel file: '$whl_file'"
-        pip install $whl_file
+        #whl_file=`pwd`/dist/`ls dist/*.whl`
+        mkdir /tmp/wheel_test
+        cp dist/*.whl /tmp/wheel_test
+        pushd /tmp/wheel_test
+        ls
+        pip install *.whl
         python -c "import tiledb ; tiledb.libtiledb.version()"
       displayName: 'Run tests'
 

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1009,6 +1009,14 @@ std::string python_internal_stats() {
   auto counters = g_stats.get()->counters;
 
   std::ostringstream os;
+
+  // core.cc is only tracking read time right now; don't print if we
+  // have no query submission time
+  auto rq_time = counters["py.read_query_initial_submit_time"].count();
+  if (rq_time == 0)
+    return os.str();
+
+  os << std::endl;
   os << "==== Python Stats ====" << std::endl << std::endl;
   os << "- TileDB-Py Indexing Time: " << counters["py.__getitem__time"].count() << std::endl;
   os << "  * TileDB-Py query execution time: " << counters["py.read_query_time"].count() << std::endl;

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -337,6 +337,11 @@ cdef extern from "tiledb/tiledb.h":
         const tiledb_attribute_t* attr,
         tiledb_filter_list_t* filter_list)
 
+    int tiledb_attribute_set_fill_value(
+        tiledb_ctx_t *ctx,
+        tiledb_attribute_t *attr,
+        const void *value, uint64_t size)
+
     int tiledb_attribute_set_cell_val_num(
         tiledb_ctx_t* ctx,
         tiledb_attribute_t* attr,
@@ -356,6 +361,12 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_ctx_t* ctx,
         const tiledb_attribute_t* attr,
         tiledb_filter_list_t** filter_list)
+
+    int tiledb_attribute_get_fill_value(
+        tiledb_ctx_t *ctx,
+        tiledb_attribute_t *attr,
+        const void **value,
+        uint64_t *size)
 
     int tiledb_attribute_get_cell_val_num(
         tiledb_ctx_t* ctx,
@@ -1156,6 +1167,7 @@ cdef class Attr(object):
     cdef from_ptr(const tiledb_attribute_t* ptr, Ctx ctx=*)
     cdef unicode _get_name(Attr self)
     cdef unsigned int _cell_val_num(Attr self) except? 0
+    cdef tiledb_datatype_t _get_type(Attr self) except? TILEDB_CHAR
 
 
 cdef class Dim(object):

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4376,17 +4376,16 @@ cdef class Query(object):
             domain = array.schema.domain
             for dname in dims:
                 if not domain.has_dim(dname):
-                    raise ValueError("Selected dimension does not exist: '{name}")
+                    raise TileDBError("Selected dimension does not exist: '{name}")
             self.dims = dims
         elif coords is True:
             domain = array.schema.domain
             self.dims = [domain.dim(i).name for i in range(domain.ndim)]
 
         if attrs is not None:
-            attr_names = [array.schema.attr(i).name for i in range(array.schema.nattr)]
-            for name in attr_names:
+            for name in attrs:
                 if not array.schema.has_attr(name):
-                    raise ValueError(f"Selected attribute does not exist: '{name}'")
+                    raise TileDBError(f"Selected attribute does not exist: '{name}'")
         self.attrs = attrs
 
         if order == None:

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -325,6 +325,27 @@ class AttributeTest(unittest.TestCase):
         #self.assertEqual(compressor, None, "default to no compression")
         #self.assertEqual(level, -1, "default compression level when none is specified")
 
+    def test_attribute_fill(self):
+        attr = tiledb.Attr("foo", dtype=np.float32, fill=0.5)
+        self.assertEqual(attr.fill, 0.5)
+
+        # single char string
+        attr = tiledb.Attr("foo", dtype=bytes, fill=b's')
+        self.assertEqual(attr.fill, b's')
+
+        # multi char string
+        attr = tiledb.Attr("foo", dtype=bytes, fill=b'stuv1111')
+        self.assertEqual(attr.fill, b'stuv1111')
+
+        # datetime with fill
+        attr = tiledb.Attr("foo", dtype=np.datetime64('','ns'), fill=np.timedelta64(1,'ns'))
+        self.assertEqual(attr.fill, np.timedelta64(1,'ns'))
+
+        # multi-cell attr
+        attr = tiledb.Attr("foo", dtype=[("",np.int32),("",np.int32),("", np.int32)],
+                           fill=(1,2,3))
+        self.assertEqual(attr.fill, np.array((1,2,3),dtype=attr.dtype))
+
     def test_full_attribute(self):
         ctx = tiledb.Ctx()
         filter_list = tiledb.FilterList([tiledb.ZstdFilter(10, ctx=ctx)], ctx=ctx)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -46,11 +46,18 @@ class StatsTest(DiskTestCase):
         tiledb.libtiledb.stats_reset()
         tiledb.libtiledb.stats_disable()
 
+        tiledb.libtiledb.stats_enable()
         with tiledb.from_numpy(self.path("test_stats"), np.arange(10)) as T:
+            pass
+
+        # basic output check for read stats
+        tiledb.libtiledb.stats_reset()
+        with tiledb.open(self.path("test_stats")) as T:
+            tiledb.libtiledb.stats_enable()
             assert_array_equal(T,np.arange(10))
             tiledb.stats_dump()
             stats = tiledb.stats_dump(print_out=False)
-            self.assertTrue("==== READ ====")
+            self.assertTrue("==== READ ====" in stats)
             self.assertTrue("==== Python Stats ====" in stats)
 
 class Config(DiskTestCase):

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1214,7 +1214,7 @@ class DenseArrayTest(DiskTestCase):
             self.assertEqual(R["ints"].shape, (8,))
 
             with self.assertRaises(tiledb.TileDBError):
-                T.query(attrs=("unknown"))[:]
+                T.query(attrs=("unknown",))[:]
 
         with tiledb.DenseArray(self.path("foo"), mode='w', ctx=ctx) as T:
             # check error ncells length

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -672,6 +672,11 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         tiledb.from_dataframe(uri, df, sparse=True)
 
         with tiledb.open(uri) as A:
+            with self.assertRaises(tiledb.TileDBError):
+                A.query(dims=['nodimnodim'])
+            with self.assertRaises(tiledb.TileDBError):
+                A.query(attrs=['noattrnoattr'])
+
             res_df = A.query(dims=['time'], attrs=['int_vals']).df[:]
             self.assertTrue('time' == res_df.index.name)
             self.assertTrue('int_vals' in res_df)


### PR DESCRIPTION
- Add test for nonempty_domain with heterogeneous (string, float) dims
- Add support for attribute fill values
- Fix and test error for query(attrs=[],dims=[]) invalid selection
- Add version printouts to stats_dump, and minor cleanups