### PR TITLE
Sync changes from release-0.7.4

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,7 @@
 # In Progress
 
+# TileDB-Py 0.7.4 Release Notes
+
 ## Improvements
 * Support selecting subset of dimensions in Array.query via new keyword argument `dims: List[String]`. The `coords=True` kwarg is still supported for compatibility, and continues to return all dimensions [#433](https://github.com/TileDB-Inc/TileDB-Py/pull/433)
 * Support Dim(filters=FilterList) keyword argument to set filters on a per-Dim basis [#434](https://github.com/TileDB-Inc/TileDB-Py/pull/434)
@@ -7,12 +9,11 @@
 * Add ArraySchema.check wrapping `tiledb_array_schema_check` [#435](https://github.com/TileDB-Inc/TileDB-Py/pull/435)
 * Add support for attribute fill values `tiledb.Attr(fill=...)` and `Attr.fill` getter [#437](https://github.com/TileDB-Inc/TileDB-Py/pull/437)
 
-
 ## API Changes
-* Addition of FragmentInfo API [#426](https://github.com/TileDB-Inc/TileDB-Py/pull/426)
 * tiledb.from_csv keyword arg `attrs_filters` renamed to `attr_filters` [#434](https://github.com/TileDB-Inc/TileDB-Py/pull/434)
 
----
+## Bug fixes
+* Fix bug in `multi_index` slicing of dense arrays [#438](https://github.com/TileDB-Inc/TileDB-Py/pull/438)
 
 # TileDB-Py 0.7.3 Release Notes
 

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -1,7 +1,7 @@
 stages:
 - stage: Release
   variables:
-    TILEDBPY_VERSION: 0.7.3
+    TILEDBPY_VERSION: 0.7.4
     LIBTILEDB_VERSION: 2.1.3
     LIBTILEDB_SHA: 47bee7cda48a38b0c20b7fa2205b6a7dd0c7edda
     SDKROOT: '/Applications/Xcode_10.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -574,8 +574,13 @@ public:
 
     if (var) {
       auto size_pair = query_->est_result_size_var(name);
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR == 2
       buf_nbytes = size_pair[0];
       offsets_num = size_pair[1];
+#else
+      buf_nbytes = size_pair.first;
+      offsets_num = size_pair.second;
+#endif
     } else {
       buf_nbytes = query_->est_result_size(name);
     }

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2584,7 +2584,6 @@ cdef class Dim(object):
                 check_error(ctx,
                     tiledb_dimension_set_filter_list(ctx.ptr, dim_ptr, filter_list_ptr))
         except:
-            tiledb_dimension_free(&dim_ptr)
             raise
 
         self.ctx = ctx


### PR DESCRIPTION
Syncing from [0.7.4](https://github.com/TileDB-Inc/TileDB-Py/tree/release-0.7.4)
- bug fix for Dim constructor found during testing the release
- HISTORY.md sync
- a compatibility fix for 2.1.3 to simplify cherry-picking when we do a 0.7.5 (the FragmentInfo changes are self-contained other than setup.py, so they are easy to revert on the release branch)