### PR TITLE
Add Verbosity Flag To stats_dump()

### DIFF
--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -31,8 +31,8 @@ cdef extern from "tiledb/tiledb.h":
     void tiledb_stats_enable()
     void tiledb_stats_disable()
     void tiledb_stats_reset()
-    int32_t tiledb_stats_dump(FILE* out)
     int32_t tiledb_stats_dump_str(char** out)
+    int32_t tiledb_stats_raw_dump_str(char** out)
     int32_t tiledb_stats_free_str(char** out)
 
     # Enums


### PR DESCRIPTION
* By default, stats_dump() will display top-level information that is
  most relevent to end users.