### PR TITLE
Suppress Overflow Warning When Performing Modular Arithmetic

### DIFF
--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -232,7 +232,12 @@ def dim_for_column(ctx, name, dim_info, col, tile=None, full_domain=False,
                 date_unit = np.datetime_data(dtype)[0]
                 dim_min = np.datetime64(dtype_min + 1, date_unit)
                 tile_max = np.iinfo(np.uint64).max - tile
-                if np.abs(np.uint64(dtype_max) - np.uint64(dtype_min)) > tile_max:
+
+                # modular arithmetic gives misleading overflow warning.
+                with np.errstate(over="ignore"):
+                    dtype_range = np.uint64(dtype_max) - np.uint64(dtype_min)
+
+                if np.abs(dtype_range) > tile_max:
                     dim_max = np.datetime64(dtype_max - tile, date_unit)
             elif dtype is np.int64:
                 dim_min = dtype_min + 1

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -15,7 +15,10 @@ def mr_dense_result_shape(ranges, base_shape = None):
     new_shape = list()
     for i,rr in enumerate(ranges):
         if rr != ():
-            m = list(map(lambda y: abs(np.uint64(y[1]) - np.uint64(y[0])) + np.uint64(1), rr))
+            # modular arithmetic gives misleading overflow warning.
+            with np.errstate(over="ignore"):
+                m = list(map(lambda y: abs(np.uint64(y[1]) - np.uint64(y[0])) + np.uint64(1), rr))
+
             new_shape.append(np.sum(m))
         else:
             if base_shape is None:


### PR DESCRIPTION
* The wraparound arithmetic is intentional and handled correctly but
  still triggers Numpy's overflow warning.