### PR TITLE
Bug fixes; concurrent compatibility for libtiledb 2.1/2.2

### DIFF
--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -20,6 +20,10 @@ stages:
         linux_py3:
           imageName: 'ubuntu-16.04'
           python.version: '3.7'
+        linux_py3_tiledb21:
+          imageName: 'ubuntu-16.04'
+          python.version: '3.8'
+          TILEDB_VERSION: '2.1.6'
       maxParallel: 4
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ from sys import version_info as ver
 print("setup.py sys.argv is: ", sys.argv)
 
 # Target branch
-TILEDB_VERSION = "2.2.1-rc1"
+TILEDB_VERSION = "2.2.1"
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION
 

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -922,7 +922,12 @@ public:
     if (query_->query_status() != tiledb::Query::Status::COMPLETE)
       TPY_ERROR_LOC("Cannot convert buffers unless Query is complete");
 
+    #if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 2
+    tiledb::arrow::ArrowAdapter adapter(query_);
+    #else
     tiledb::arrow::ArrowAdapter adapter(&ctx_, query_.get());
+    #endif
+
     std::unique_ptr<PAPair> pa_pair(new PAPair());
 
     adapter.export_buffer(name.c_str(), &(pa_pair->array_), &(pa_pair->schema_));
@@ -939,7 +944,12 @@ public:
 
     auto pa = py::module::import("pyarrow");
     auto pa_array_import = pa.attr("Array").attr("_import_from_c");
+
+    #if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 2
+    tiledb::arrow::ArrowAdapter adapter(query_);
+    #else
     tiledb::arrow::ArrowAdapter adapter(&ctx_, query_.get());
+    #endif
 
     py::list names;
     py::list results;

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -854,7 +854,7 @@ public:
       py::object o;
       auto data_ptr = (char*)buf.data() + last;
       if (is_unicode)
-        if (data_ptr[0] == '\0' && size == 1) {
+        if (size == 0 || (data_ptr[0] == '\0' && size == 1)) {
           o = py::str("");
         } else {
           if (!deduplicate_) {
@@ -875,7 +875,7 @@ public:
           }
         }
       else if (is_str)
-        if (data_ptr[0] == '\0' && size == 1) {
+        if (size == 0 || (data_ptr[0] == '\0' && size == 1)) {
           o = py::bytes("");
         } else {
           o = py::bytes(data_ptr, size);

--- a/tiledb/debug.cc
+++ b/tiledb/debug.cc
@@ -11,7 +11,15 @@ __attribute__((used)) static void pyprint(pybind11::object o) {
   pybind11::print(o);
 }
 
-// TODO need version for py::handle
+__attribute__((used)) static void pyprint(pybind11::handle h) {
+  pybind11::print(h);
+}
+
+__attribute__((used)) static std::string pyrepr(py::handle h) {
+  auto locals = py::dict("_v"_a = h);
+  return py::cast<std::string>(py::eval("repr(_v)", py::globals(), locals));
+}
+
 __attribute__((used)) static std::string pyrepr(py::object o) {
   auto locals = py::dict("_v"_a = o);
   return py::cast<std::string>(py::eval("repr(_v)", py::globals(), locals));

--- a/tiledb/fragment.cc
+++ b/tiledb/fragment.cc
@@ -1,3 +1,4 @@
+
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/numpy.h>
@@ -10,6 +11,8 @@
 
 #include <tiledb/tiledb> // C++
 #include "util.h"
+
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 2
 
 #if !defined(NDEBUG)
 #include "debug.cc"
@@ -298,3 +301,5 @@ PYBIND11_MODULE(fragment, m) {
 }
 
 }; // namespace tiledbpy
+
+#endif

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -114,15 +114,14 @@ class NumpyConvert {
     // loop over array objects and write to output buffer
     size_t idx = 0;
     for (auto u : input_) {
-      py::handle u_encoded = u;
-
       // don't encode if we already have bytes
       if (PyUnicode_Check(u.ptr())) {
         // TODO see if we can do this with PyUnicode_AsUTF8String
-        u_encoded = npstrencode(u);
+        py::object u_encoded = npstrencode(u);
+        PyBytes_AsStringAndSize(u_encoded.ptr(), const_cast<char**>(&input_p), &sz);
+      } else {
+        PyBytes_AsStringAndSize(u.ptr(), const_cast<char**>(&input_p), &sz);
       }
-
-      PyBytes_AsStringAndSize(u_encoded.ptr(), const_cast<char**>(&input_p), &sz);
 
       // record the offset (equal to the current bytes written)
       offset_buf_->data()[idx] = data_nbytes_;

--- a/tiledb/tests/test_fragment_info.py
+++ b/tiledb/tests/test_fragment_info.py
@@ -1,12 +1,17 @@
 import tiledb
-from tiledb import fragment
 from tiledb.tests.common import DiskTestCase
-
 import itertools
 import numpy as np
 
+if tiledb.libtiledb.version() >= (2,2):
+    from tiledb import fragment
 
 class FragmentInfoTest(DiskTestCase):
+    def setUp(self):
+        super(FragmentInfoTest, self).setUp()
+        if not tiledb.libtiledb.version() >= (2,2):
+            self.skipTest("Only run FragmentInfo test with TileDB>=2.2")
+
     def test_uri_dne(self):
         fragment_info = fragment.info(tiledb.default_ctx(), "does_not_exist")
         with self.assertRaises(tiledb.TileDBError):
@@ -61,7 +66,7 @@ class FragmentInfoTest(DiskTestCase):
 
             self.assertTrue(fragment_info.dense(fragment_idx))
             self.assertFalse(fragment_info.sparse(fragment_idx))
-        
+
         all_actual_uris = fragment_info.fragment_uri()
         for actual_uri, expected_uri in zip(all_actual_uris, all_expected_uris):
             self.assertTrue(actual_uri.startswith(expected_uri))
@@ -131,7 +136,7 @@ class FragmentInfoTest(DiskTestCase):
             self.assertTrue(
                 actual_uri.endswith(str(fragment_info.version(fragment_idx)))
             )
-        
+
         self.assertEqual(fragment_info.timestamp_range(), ((1, 1), (2, 2), (3, 3)))
         self.assertEqual(fragment_info.dense(), (False, False, False))
         self.assertEqual(fragment_info.sparse(), (True, True, True))
@@ -377,7 +382,7 @@ class FragmentInfoTest(DiskTestCase):
         self.assertEqual(fragment_info.unconsolidated_metadata_num(), 0)
         for fragment_idx in range(fragments):
             self.assertTrue(fragment_info.has_consolidated_metadata(fragment_idx))
-        
+
         self.assertEqual(fragment_info.has_consolidated_metadata(), (True, True, True))
 
     def test_fragments_to_vacuum(self):


### PR DESCRIPTION
- Fix object lifetime in array->buffer write
- Fix read compatibility for empty strings written with 2.1 or 2.2
- Misc fixes for concurrent compatibility with libtiledb 2.1/2.2
- Add CI entry for libtiledb 2.1