### PR TITLE
Preload array metadata in the dataframe query path

### DIFF
--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -85,6 +85,7 @@ class MultiRangeIndexer(object):
             use_arrow_real = use_arrow_real and use_arrow
 
         self.use_arrow = use_arrow_real
+        self._preload_metadata : bool = False
 
     @property
     def array(self):
@@ -194,6 +195,7 @@ class MultiRangeIndexer(object):
                     layout,
                     self.use_arrow)
 
+        q._preload_metadata = self._preload_metadata
         q.set_ranges(ranges)
         q.submit()
 
@@ -250,6 +252,8 @@ class DataFrameIndexer(MultiRangeIndexer):
         # we need to use a Query in order to get coords for a dense array
         if not self.query:
             self.query = tiledb.libtiledb.Query(self.array, coords=True)
+
+        self._preload_metadata = True
 
         result = super(DataFrameIndexer, self).__getitem__(idx)
 


### PR DESCRIPTION
This PR adds an asynchronous call to array.metadata_num before
submitting the query in the `.df` path.

We unconditionally check `array.meta` in the `.df` path in order
to get any type mappings stored there. This currently happens
synchronously after the query submission, which requires more
network i/o calls to get metadata, because libtiledb metadata
loading is lazy. Instead, initiate an async metadata operation
so that libtiledb fetches (and caches) the metadata ahead of
time.