### PR TITLE
Sync with release-0.8.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# TileDB-Py 0.8.2 Release Notes
+
+## Packaging Notes
+* This is a version bump to fix numpy compatibility pinning in the wheel build system.
+
 # TileDB-Py 0.8.1 Release Notes
 
 ## TileDB Embedded updates:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ exclude .dockerignore
 exclude .readthedocs.yml
 exclude .travis.yml
 exclude azure-pipelines.yml
-exclude misc/azure-*.yml
+exclude misc/*
 exclude requirements_dev.txt
 exclude tox.ini
 

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -1,7 +1,7 @@
 stages:
 - stage: Release
   variables:
-    TILEDBPY_VERSION: 0.8.0
+    TILEDBPY_VERSION: 0.8.2
     LIBTILEDB_VERSION: 2.2.3
     LIBTILEDB_SHA: dbaf5ffaab10f60524355423e9965d750d9b2919
     SDKROOT: '/Applications/Xcode_10.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'

--- a/misc/pypi_linux/build.sh
+++ b/misc/pypi_linux/build.sh
@@ -14,19 +14,6 @@ set -ex
 
 export TILEDB_PY_REPO="/opt/TileDB-Py"
 
-# build python35 wheel
-cd /home/tiledb
-git clone $TILEDB_PY_REPO TileDB-Py35
-git -C TileDB-Py35 checkout $TILEDBPY_VERSION
-
-cd /home/tiledb/TileDB-Py35
-/opt/python/cp35-cp35m/bin/python3.5 setup.py build_ext bdist_wheel --tiledb=/usr/local
-auditwheel repair dist/*.whl
-/opt/python/cp35-cp35m/bin/python3.5 -m pip install wheelhouse/*.whl
-cd tiledb/tests
-#/opt/python/cp35-cp35m/bin/python3.5 -m unittest
-
-
 # build python36 wheel
 cd /home/tiledb
 git clone $TILEDB_PY_REPO TileDB-Py36
@@ -76,7 +63,6 @@ auditwheel repair dist/*.whl
 cd tiledb/tests
 
 # copy build products out
-cp /home/tiledb/TileDB-Py35/wheelhouse/* /wheels
 cp /home/tiledb/TileDB-Py36/wheelhouse/* /wheels
 cp /home/tiledb/TileDB-Py37/wheelhouse/* /wheels
 cp /home/tiledb/TileDB-Py38/wheelhouse/* /wheels

--- a/setup.py
+++ b/setup.py
@@ -481,14 +481,14 @@ def cmake_available():
     except:
         return False
 
-numpy_required_version = 'numpy>=1.16'
 def setup_requires():
-    req = ['cython>=0.27',
-           numpy_required_version,
-           'setuptools>=18.0',
-           'setuptools_scm>=1.5.4',
-           'wheel>=0.30',
-           'pybind11']
+    req = ["cython>=0.27",
+           "numpy==1.16.5 ; python_version < '3.9'",
+           "numpy ; python_version >= '3.9'",
+           "setuptools>=18.0",
+           "setuptools_scm>=1.5.4",
+           "wheel>=0.30",
+           "pybind11>=2.6.2"]
     # Add cmake requirement if libtiledb is not found and cmake is not available.
     if not libtiledb_exists(LIB_DIRS) and not cmake_available():
         req.append('cmake>=3.11.0')
@@ -695,7 +695,7 @@ setup(
     ext_modules=__extensions,
     setup_requires=setup_requires(),
     install_requires=[
-        numpy_required_version,
+        'numpy>=1.16.5',
         'wheel>=0.30'
     ],
     tests_require=TESTS_REQUIRE,

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -712,7 +712,7 @@ class ArrayTest(DiskTestCase):
 
     # needs core fix in 2.2.4
     @unittest.skipIf((platform.system() == 'Windows' and
-                     libtiledb.version() == (2,2,3)),
+                     tiledb.libtiledb.version() == (2,2,3)),
                      "")
     def test_array_doesnt_exist(self):
         ctx = tiledb.Ctx()


### PR DESCRIPTION
Sync with `0.8.2` which was tagged and uploaded after full CI+release job build on this commit.
- https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=9359&view=results
- https://dev.azure.com/isaiahnorton/isaiahnorton/_build/results?buildId=509&view=results