### PR TITLE
Fix and test multi_index bug with ranges at 0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# In Progress
+
+## Bug fixes
+* Fix bug in Array.multi_index with slice range including 0 (incorrectly used the nonempty domain as endpoint) [#473](https://github.com/TileDB-Inc/TileDB-Py/pull/473)
+
 # TileDB-Py 0.8.2 Release Notes
 
 ## Packaging Notes

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ from sys import version_info as ver
 print("setup.py sys.argv is: ", sys.argv)
 
 # Target branch
-TILEDB_VERSION = "2.2.3"
+TILEDB_VERSION = "dev"
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION
 

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -602,12 +602,12 @@ public:
 
     if (var) {
       auto size_pair = query_->est_result_size_var(name);
-#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR == 2
-      buf_nbytes = size_pair[0];
-      offsets_num = size_pair[1];
-#else
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR < 2
       buf_nbytes = size_pair.first;
       offsets_num = size_pair.second;
+#else
+      buf_nbytes = size_pair[0];
+      offsets_num = size_pair[1];
 #endif
     } else {
       buf_nbytes = query_->est_result_size(name);

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -47,8 +47,8 @@ def sel_to_subranges(dim_sel, nonempty_domain=None):
                 # we are missing one or both endpoints, maybe use nonempty_domain
                 if nonempty_domain is None:
                     raise TileDBError("Open-ended slicing requires a valid nonempty_domain")
-                rstart = range.start if range.start else nonempty_domain[0]
-                rend = range.stop if range.stop else nonempty_domain[1]
+                rstart =  nonempty_domain[0] if range.start is None else range.start
+                rend =  nonempty_domain[1] if range.stop is None else range.stop
 
             subranges.append( (rstart,rend) )
         elif isinstance(range, tuple):

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -13,6 +13,10 @@ from unittest import TestCase
 import numpy as np
 from numpy.testing import assert_equal, assert_array_equal
 
+def assert_tail_equal(a, *rest, **kwargs):
+    """Assert that all arrays in target equal first array"""
+    for target in rest:
+        assert_array_equal(a, target, **kwargs)
 
 class DiskTestCase(TestCase):
     pathmap = dict()

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -309,11 +309,7 @@ class TestMultiRange(DiskTestCase):
 
         make_2d_dense(ctx, path, attr_name=attr_name)
 
-        expected = np.array([1, 2, 3, 4,
-                             5, 6, 7, 8,
-                             9, 10, 11, 12,
-                             13, 14, 15, 16,
-                             17, 18, 19, 20])
+        expected = np.arange(1,21)
 
         ranges = (
             ( (0,4), ),
@@ -323,6 +319,44 @@ class TestMultiRange(DiskTestCase):
         with tiledb.DenseArray(path) as A:
             a = tiledb.libtiledb.multi_index(A, (attr_name,), ranges)[attr_name]
             assert_array_equal(a, expected)
+
+            # test slicing start=end on 1st dim at 0 (bug fix)
+            assert_tail_equal(
+                np.array([[1, 2, 3, 4]]),
+                A.multi_index[:0][attr_name],
+                A.multi_index[0:0][attr_name],
+            )
+
+            # test slicing start=end on 2nd dim at 0 (bug fix)
+            assert_tail_equal(
+                np.arange(1,34,4).reshape((9,1)),
+                A.multi_index[:,:0][attr_name],
+                A.multi_index[:,0:0][attr_name],
+            )
+
+            # test slicing start=end on 1st dim at 1
+            assert_array_equal(
+                np.array([[5,6,7,8]]),
+                A.multi_index[1:1][attr_name]
+            )
+
+            # test slicing start=end on 2nd dim at 1
+            assert_array_equal(
+                np.arange(2,35,4).reshape((9,1)),
+                A.multi_index[:,1:1][attr_name]
+            )
+
+            # test slicing start=end on 1st dim at max range
+            assert_array_equal(
+                np.array([[33, 34, 35, 36]]),
+                A.multi_index[8:8][attr_name]
+            )
+
+            # test slicing start=end on 2nd dim at max range
+            assert_tail_equal(
+                np.arange(4,37,4).reshape((9,1)),
+                A.multi_index[:,3:3][attr_name],
+            )
 
     def test_multirange_1d_dense_int64(self):
         attr_name = ''


### PR DESCRIPTION
Fix bug in Array.multi_index with slice range including 0 (incorrectly used the nonempty domain as endpoint)