### PR TITLE
Fix read of query returning only empty var-length strings for attribute

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -863,8 +863,6 @@ public:
 
     auto start = std::chrono::high_resolution_clock::now();
 
-    if (buf.size() < 1)
-      TPY_ERROR_LOC(std::string("Unexpected empty buffer array ('") + name + "')");
     if (off.size() < 1)
       TPY_ERROR_LOC(std::string("Unexpected empty offsets array ('") + name + "')");
 

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -5402,12 +5402,11 @@ cdef class SparseArrayImpl(Array):
             if name == '__attr':
                 final_name = ''
             if self.schema._needs_var_buffer(name):
-                if len(results[name][1]) > 0:
+                if len(results[name][1]) > 0: # note: len(offsets) > 0
                     arr = q.unpack_buffer(name, results[name][0], results[name][1])
                 else:
                     arr = results[name][0]
                     final_dtype = self.schema.attr_or_dim_dtype(name)
-                    print((arr, len(arr), final_dtype))
                     if (len(arr) < 1 and
                             (np.issubdtype(final_dtype, np.bytes_) or
                              np.issubdtype(final_dtype, np.unicode_))):


### PR DESCRIPTION
If a query range only returns empty strings for a var-length attribute, then
the data buffer will have zero-length and the offsets denote the empty
cells. Remove the zero-length check. See:

  https://github.com/TileDB-Inc/TileDB/blob/dev/test/src/unit-empty-var-length.cc