### PR TITLE
Improve Usability of FragmentInfo API

### DIFF
--- a/examples/fragment_info.py
+++ b/examples/fragment_info.py
@@ -1,0 +1,96 @@
+# fragment_info.py
+#
+# LICENSE
+#
+# The MIT License
+#
+# Copyright (c) 2020 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import numpy as np
+import sys
+import tiledb
+
+array_name = "fragment_info"
+
+
+def create_array():
+    # The array will be 4x4 with dimensions "rows" and "cols", with domain [1,4] and space tiles 2x2.
+    dom = tiledb.Domain(
+        tiledb.Dim(name="rows", domain=(1, 4), tile=2, dtype=np.int32),
+        tiledb.Dim(name="cols", domain=(1, 4), tile=2, dtype=np.int32),
+    )
+
+    # The array will be dense with a single attribute "a" so each (i,j) cell can store an integer.
+    schema = tiledb.ArraySchema(
+        domain=dom, sparse=False, attrs=[tiledb.Attr(name="a", dtype=np.int32)]
+    )
+
+    # Create the (empty) array on disk.
+    tiledb.DenseArray.create(array_name, schema)
+
+
+def write_array_1():
+    with tiledb.DenseArray(array_name, mode="w") as A:
+        A[1:3, 1:5] = np.array(([1, 2, 3, 4, 5, 6, 7, 8]))
+
+
+def write_array_2():
+    with tiledb.DenseArray(array_name, mode="w") as A:
+        A[2:4, 2:4] = np.array(([101, 102, 103, 104]))
+
+
+def write_array_3():
+    with tiledb.DenseArray(array_name, mode="w") as A:
+        A[3:4, 4:5] = np.array(([202]))
+
+
+# Create and write array only if it does not exist
+if tiledb.object_type(array_name) != "array":
+    create_array()
+    write_array_1()
+    write_array_2()
+    write_array_3()
+
+fi = tiledb.fragment_info(array_name)
+
+# Note that load() needs to be called each time the array is written to in
+# order to get updated fragment information.
+fi.load()
+
+schema = tiledb.ArraySchema.load(array_name)
+
+for fragment_num in range(fi.fragment_num()):
+    print("Fragment number: {}".format(fragment_num))
+    print(
+        "\t> Non-Empty Domain: {}".format(fi.get_non_empty_domain(schema, fragment_num))
+    )
+    print("\t> URI: {}".format(fi.fragment_uri(fragment_num)))
+    print("\t> Fragment Version: {}".format(fi.version(fragment_num)))
+    print("\t> Timestamp Range: {}".format(fi.timestamp_range(fragment_num)))
+    print("\t> Is DenseArray: {}".format(fi.dense(fragment_num)))
+    print("\t> Is SparseArray: {}".format(fi.sparse(fragment_num)))
+    print(
+        "\t> Has Consolidated Metadata: {}".format(
+            fi.has_consolidated_metadata(fragment_num)
+        )
+    )
+    print()

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,7 @@ def find_or_install_libtiledb(setuptools_cmd):
             tiledb_ext = ext
         elif ext.name == "tiledb.core":
             core_ext = ext
-        elif ext.name == "tiledb.fragment":
+        elif ext.name == "tiledb._fragment":
             fragment_ext = ext
 
     print("tiledb_ext: ", tiledb_ext)
@@ -627,7 +627,7 @@ __extensions = [
         extra_compile_args=CXXFLAGS,
     ),
     Extension(
-        "tiledb.fragment",
+        "tiledb._fragment",
         ["tiledb/fragment.cc"],
         include_dirs=INC_DIRS + [get_pybind_include(), get_pybind_include(user=True)],
         language="c++",

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -80,6 +80,8 @@ from .libtiledb import (
 
 from .array import DenseArray, SparseArray
 
+from ._fragment import info as fragment_info
+
 from .highlevel import open, save, from_numpy, empty_like, array_exists
 
 # TODO restricted imports

--- a/tiledb/tests/test_fragment_info.py
+++ b/tiledb/tests/test_fragment_info.py
@@ -1,10 +1,8 @@
 import tiledb
 from tiledb.tests.common import DiskTestCase
+
 import itertools
 import numpy as np
-
-if tiledb.libtiledb.version() >= (2, 2):
-    from tiledb import fragment
 
 
 class FragmentInfoTest(DiskTestCase):
@@ -14,7 +12,7 @@ class FragmentInfoTest(DiskTestCase):
             self.skipTest("Only run FragmentInfo test with TileDB>=2.2")
 
     def test_uri_dne(self):
-        fragment_info = fragment.info(tiledb.default_ctx(), "does_not_exist")
+        fragment_info = tiledb.fragment_info("does_not_exist")
         with self.assertRaises(tiledb.TileDBError):
             fragment_info.load()
 
@@ -33,7 +31,7 @@ class FragmentInfoTest(DiskTestCase):
 
         tiledb.DenseArray.create(uri, schema)
 
-        fragment_info = fragment.info(ctx, uri)
+        fragment_info = tiledb.fragment_info(uri)
 
         for fragment_idx in range(fragments):
             timestamp = fragment_idx + 1
@@ -98,7 +96,7 @@ class FragmentInfoTest(DiskTestCase):
 
         tiledb.SparseArray.create(uri, schema)
 
-        fragment_info = fragment.info(ctx, uri)
+        fragment_info = tiledb.fragment_info(uri)
 
         for fragment_idx in range(fragments):
             timestamp = fragment_idx + 1
@@ -174,7 +172,7 @@ class FragmentInfoTest(DiskTestCase):
             y = [-1.5, -1.25]
             T[x, y] = np.array(range(2))
 
-        fragment_info = fragment.info(ctx, uri)
+        fragment_info = tiledb.fragment_info(uri, ctx)
         fragment_info.load()
 
         x_dt = schema.domain.dim(0).dtype
@@ -238,7 +236,7 @@ class FragmentInfoTest(DiskTestCase):
             )
             T[dates] = np.array(range(3))
 
-        fragment_info = fragment.info(ctx, uri)
+        fragment_info = tiledb.fragment_info(uri, ctx)
         fragment_info.load()
 
         self.assertEqual(
@@ -299,7 +297,7 @@ class FragmentInfoTest(DiskTestCase):
             y_dims = [b"e", b"f"]
             T[x_dims, y_dims] = np.array([1, 2])
 
-        fragment_info = fragment.info(ctx, uri)
+        fragment_info = tiledb.fragment_info(uri, ctx)
         fragment_info.load()
 
         self.assertEqual(fragment_info.non_empty_domain_var(schema, 0, 0), ("a", "d"))
@@ -333,7 +331,7 @@ class FragmentInfoTest(DiskTestCase):
 
         tiledb.SparseArray.create(uri, schema)
 
-        fragment_info = fragment.info(ctx, uri)
+        fragment_info = tiledb.fragment_info(uri, ctx)
 
         with tiledb.SparseArray(uri, mode="w", ctx=ctx) as T:
             a = np.array([1, 2, 3, 4])
@@ -343,7 +341,7 @@ class FragmentInfoTest(DiskTestCase):
             b = np.array([1, 2])
             T[b] = b
 
-        fragment_info = fragment.info(ctx, uri)
+        fragment_info = tiledb.fragment_info(uri, ctx)
         fragment_info.load()
 
         self.assertEqual(fragment_info.cell_num(0), len(a))
@@ -363,7 +361,7 @@ class FragmentInfoTest(DiskTestCase):
 
         tiledb.DenseArray.create(uri, schema)
 
-        fragment_info = fragment.info(ctx, uri)
+        fragment_info = tiledb.fragment_info(uri, ctx)
 
         for fragment_idx in range(fragments):
             with tiledb.DenseArray(uri, mode="w", ctx=ctx) as T:
@@ -406,7 +404,7 @@ class FragmentInfoTest(DiskTestCase):
 
         tiledb.DenseArray.create(uri, schema)
 
-        fragment_info = fragment.info(ctx, uri)
+        fragment_info = tiledb.fragment_info(uri, ctx)
 
         for fragment_idx in range(fragments):
             with tiledb.DenseArray(uri, mode="w", ctx=ctx) as T:


### PR DESCRIPTION
* fragment_info() is now exposed to the user and does not have to be
  explicitly exported
* The first parameter of fragment_info() is now the URI. The second
  parameter is the context which is now optional and defaults to
  tiledb.default_ctx()
* The fragment module has been renamed to _fragment so that there is
  only one entry point called fragment* at the top-level
* Add usage example