### PR TITLE
Remove non_empty_domain_var() Fragment Info PyBind11 Function

### DIFF
--- a/tiledb/fragment.cc
+++ b/tiledb/fragment.cc
@@ -111,7 +111,7 @@ public:
   py::tuple get_non_empty_domain(py::object schema, uint32_t fid, T did) const {
     py::bool_ isvar = get_dim_isvar(schema.attr("domain"), did);
 
-    if(isvar) {
+    if (isvar) {
       pair<string, string> lims = fi_->non_empty_domain_var(fid, did);
       return py::make_tuple(lims.first, lims.second);
     }

--- a/tiledb/fragment.cc
+++ b/tiledb/fragment.cc
@@ -109,6 +109,13 @@ public:
 
   template <typename T>
   py::tuple get_non_empty_domain(py::object schema, uint32_t fid, T did) const {
+    py::bool_ isvar = get_dim_isvar(schema.attr("domain"), did);
+
+    if(isvar) {
+      pair<string, string> lims = fi_->non_empty_domain_var(fid, did);
+      return py::make_tuple(lims.first, lims.second);
+    }
+
     py::dtype type = get_dim_type(schema.attr("domain"), did);
     py::dtype array_type =
         type.kind() == 'M' ? pybind11::dtype::of<uint64_t>() : type;
@@ -130,6 +137,18 @@ public:
     return limits;
   }
 
+  py::bool_ get_dim_isvar(py::object dom, uint32_t did) const {
+    // passing templated type "did" to Python function dom.attr("dim")
+    // does not work
+    return (dom.attr("dim")(did).attr("isvar")).cast<py::bool_>();
+  }
+
+  py::bool_ get_dim_isvar(py::object dom, string did) const {
+    // passing templated type "did" to Python function dom.attr("dim")
+    // does not work
+    return (dom.attr("dim")(did).attr("isvar")).cast<py::bool_>();
+  }
+
   py::dtype get_dim_type(py::object dom, uint32_t did) const {
     // passing templated type "did" to Python function dom.attr("dim")
     // does not work
@@ -140,32 +159,6 @@ public:
     // passing templated type "did" to Python function dom.attr("dim")
     // does not work
     return (dom.attr("dim")(did).attr("dtype")).cast<py::dtype>();
-  }
-
-  py::tuple non_empty_domain_var(py::object schema) const {
-    py::list all_frags;
-    uint32_t nfrag = fragment_num();
-
-    for (uint32_t fid = 0; fid < nfrag; ++fid)
-      all_frags.append(non_empty_domain_var(schema, fid));
-
-    return all_frags;
-  }
-
-  py::tuple non_empty_domain_var(py::object schema, uint32_t fid) const {
-    py::list all_dims;
-    int ndim = (schema.attr("domain").attr("ndim")).cast<int>();
-
-    for (int did = 0; did < ndim; ++did)
-      all_dims.append(non_empty_domain_var(schema, fid, did));
-
-    return all_dims;
-  }
-
-  template <typename T>
-  py::tuple non_empty_domain_var(py::object schema, uint32_t fid, T did) const {
-    pair<string, string> lims = fi_->non_empty_domain_var(fid, did);
-    return py::make_tuple(lims.first, lims.second);
   }
 
   py::object timestamp_range(py::object fid) const {
@@ -245,20 +238,6 @@ PYBIND11_MODULE(_fragment, m) {
            static_cast<py::tuple (PyFragmentInfo::*)(py::object, uint32_t,
                                                      const string &) const>(
                &PyFragmentInfo::get_non_empty_domain))
-
-      .def("non_empty_domain_var",
-           static_cast<py::tuple (PyFragmentInfo::*)(py::object) const>(
-               &PyFragmentInfo::non_empty_domain_var))
-      .def("non_empty_domain_var",
-           static_cast<py::tuple (PyFragmentInfo::*)(py::object, uint32_t)
-                           const>(&PyFragmentInfo::non_empty_domain_var))
-      .def("non_empty_domain_var", static_cast<py::tuple (PyFragmentInfo::*)(
-                                       py::object, uint32_t, uint32_t) const>(
-                                       &PyFragmentInfo::non_empty_domain_var))
-      .def("non_empty_domain_var",
-           static_cast<py::tuple (PyFragmentInfo::*)(py::object, uint32_t,
-                                                     const string &) const>(
-               &PyFragmentInfo::non_empty_domain_var))
 
       .def("fragment_uri", &PyFragmentInfo::fragment_uri,
            py::arg("fid") = py::none())

--- a/tiledb/tests/test_fragment_info.py
+++ b/tiledb/tests/test_fragment_info.py
@@ -82,7 +82,7 @@ class FragmentInfoTest(DiskTestCase):
 
         uri = self.path("test_array_fragments_var")
         dom = tiledb.Domain(
-            tiledb.Dim(name="dim", domain=(None, None), tile=None, dtype=np.bytes_),
+            tiledb.Dim(name="dim", domain=(None, None), tile=None, dtype=np.bytes_)
         )
         schema = tiledb.ArraySchema(
             domain=dom,

--- a/tiledb/tests/test_fragment_info.py
+++ b/tiledb/tests/test_fragment_info.py
@@ -57,8 +57,10 @@ class FragmentInfoTest(DiskTestCase):
 
         if tiledb.libtiledb.version() < (2, 2, 3):
             self.assertEqual(fragments_info.version, (7, 7, 7))
-        else:
+        elif tiledb.libtiledb.version() < (2, 3, 0):
             self.assertEqual(fragments_info.version, (8, 8, 8))
+        else:
+            self.assertEqual(fragments_info.version, (9, 9, 9))
 
         for idx, frag in enumerate(fragments_info):
             self.assertEqual(frag.cell_num, 3)
@@ -70,8 +72,50 @@ class FragmentInfoTest(DiskTestCase):
 
             if tiledb.libtiledb.version() < (2, 2, 3):
                 self.assertEqual(frag.version, 7)
-            else:
+            elif tiledb.libtiledb.version() < (2, 3, 0):
                 self.assertEqual(frag.version, 8)
+            else:
+                self.assertEqual(frag.version, 9)
+
+    def test_array_fragments_var(self):
+        fragments = 3
+
+        uri = self.path("test_array_fragments_var")
+        dom = tiledb.Domain(
+            tiledb.Dim(name="dim", domain=(None, None), tile=None, dtype=np.bytes_),
+        )
+        schema = tiledb.ArraySchema(
+            domain=dom,
+            sparse=True,
+            attrs=[tiledb.Attr(name="1s", dtype=np.int32, var=True)],
+        )
+
+        tiledb.SparseArray.create(uri, schema)
+
+        for fragment_idx in range(fragments):
+            timestamp = fragment_idx + 1
+
+            data = np.array(
+                [
+                    np.array([timestamp] * 1, dtype=np.int32),
+                    np.array([timestamp] * 2, dtype=np.int32),
+                    np.array([timestamp] * 3, dtype=np.int32),
+                ],
+                dtype="O",
+            )
+
+            with tiledb.SparseArray(uri, mode="w", timestamp=timestamp) as T:
+                T[["zero", "one", "two"]] = data
+
+        fragments_info = tiledb.array_fragments(uri)
+
+        self.assertEqual(
+            fragments_info.non_empty_domain,
+            ((("one", "zero"),), (("one", "zero"),), (("one", "zero"),)),
+        )
+
+        for frag in fragments_info:
+            self.assertEqual(frag.non_empty_domain, (("one", "zero"),))
 
     def test_dense_fragments(self):
         fragments = 3
@@ -135,8 +179,10 @@ class FragmentInfoTest(DiskTestCase):
         self.assertEqual(fragment_info.sparse(), (False, False, False))
         if tiledb.libtiledb.version() < (2, 2, 3):
             self.assertEqual(fragment_info.version(), (7, 7, 7))
-        else:
+        elif tiledb.libtiledb.version() < (2, 3, 0):
             self.assertEqual(fragment_info.version(), (8, 8, 8))
+        else:
+            self.assertEqual(fragment_info.version(), (9, 9, 9))
 
     def test_sparse_fragments(self):
         fragments = 3
@@ -200,8 +246,10 @@ class FragmentInfoTest(DiskTestCase):
         self.assertEqual(fragment_info.sparse(), (True, True, True))
         if tiledb.libtiledb.version() < (2, 2, 3):
             self.assertEqual(fragment_info.version(), (7, 7, 7))
-        else:
+        elif tiledb.libtiledb.version() < (2, 3, 0):
             self.assertEqual(fragment_info.version(), (8, 8, 8))
+        else:
+            self.assertEqual(fragment_info.version(), (9, 9, 9))
 
     def test_non_empty_domain(self):
         uri = self.path("test_non_empty_domain")
@@ -357,25 +405,25 @@ class FragmentInfoTest(DiskTestCase):
         fragment_info = _fragment.info(uri, ctx)
         fragment_info.load()
 
-        self.assertEqual(fragment_info.non_empty_domain_var(schema, 0, 0), ("a", "d"))
-        self.assertEqual(fragment_info.non_empty_domain_var(schema, 0, 1), ("e", "h"))
-        self.assertEqual(fragment_info.non_empty_domain_var(schema, 1, 0), ("a", "b"))
-        self.assertEqual(fragment_info.non_empty_domain_var(schema, 1, 1), ("e", "f"))
+        self.assertEqual(fragment_info.get_non_empty_domain(schema, 0, 0), ("a", "d"))
+        self.assertEqual(fragment_info.get_non_empty_domain(schema, 0, 1), ("e", "h"))
+        self.assertEqual(fragment_info.get_non_empty_domain(schema, 1, 0), ("a", "b"))
+        self.assertEqual(fragment_info.get_non_empty_domain(schema, 1, 1), ("e", "f"))
 
-        self.assertEqual(fragment_info.non_empty_domain_var(schema, 0, "x"), ("a", "d"))
-        self.assertEqual(fragment_info.non_empty_domain_var(schema, 0, "y"), ("e", "h"))
-        self.assertEqual(fragment_info.non_empty_domain_var(schema, 1, "x"), ("a", "b"))
-        self.assertEqual(fragment_info.non_empty_domain_var(schema, 1, "y"), ("e", "f"))
+        self.assertEqual(fragment_info.get_non_empty_domain(schema, 0, "x"), ("a", "d"))
+        self.assertEqual(fragment_info.get_non_empty_domain(schema, 0, "y"), ("e", "h"))
+        self.assertEqual(fragment_info.get_non_empty_domain(schema, 1, "x"), ("a", "b"))
+        self.assertEqual(fragment_info.get_non_empty_domain(schema, 1, "y"), ("e", "f"))
 
         self.assertEqual(
-            fragment_info.non_empty_domain_var(schema, 0), (("a", "d"), ("e", "h"))
+            fragment_info.get_non_empty_domain(schema, 0), (("a", "d"), ("e", "h"))
         )
         self.assertEqual(
-            fragment_info.non_empty_domain_var(schema, 1), (("a", "b"), ("e", "f"))
+            fragment_info.get_non_empty_domain(schema, 1), (("a", "b"), ("e", "f"))
         )
 
         self.assertEqual(
-            fragment_info.non_empty_domain_var(schema),
+            fragment_info.get_non_empty_domain(schema),
             ((("a", "d"), ("e", "h")), (("a", "b"), ("e", "f"))),
         )
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1316,28 +1316,8 @@ class DenseArrayTest(DiskTestCase):
         schema = tiledb.ArraySchema(ctx=ctx, domain=dom, attrs=(attr_int, attr_float))
         tiledb.DenseArray.create(self.path("foo"), schema)
 
-        V_ints = np.array(
-            [
-                [
-                    0,
-                    1,
-                    2,
-                    3,
-                ],
-                [4, 6, 7, 5],
-            ]
-        )
-        V_floats = np.array(
-            [
-                [
-                    0.0,
-                    1.0,
-                    2.0,
-                    3.0,
-                ],
-                [4.0, 6.0, 7.0, 5.0],
-            ]
-        )
+        V_ints = np.array([[0, 1, 2, 3], [4, 6, 7, 5]])
+        V_floats = np.array([[0.0, 1.0, 2.0, 3.0], [4.0, 6.0, 7.0, 5.0]])
 
         V = {"ints": V_ints, "floats": V_floats}
         with tiledb.DenseArray(self.path("foo"), mode="w", ctx=ctx) as T:
@@ -1927,15 +1907,7 @@ class DenseVarlen(DiskTestCase):
 
     def test_array_varlen_mismatched(self):
         # Test that we raise a TypeError when passing a heterogeneous object array.
-        A = np.array(
-            [
-                b"aa",
-                b"bbb",
-                b"cccc",
-                np.uint64([1, 3, 4]),
-            ],
-            dtype=object,
-        )
+        A = np.array([b"aa", b"bbb", b"cccc", np.uint64([1, 3, 4])], dtype=object)
 
         ctx = tiledb.Ctx()
         dom = tiledb.Domain(tiledb.Dim(domain=(0, 3), tile=4, ctx=ctx), ctx=ctx)
@@ -2078,13 +2050,7 @@ class SparseArray(DiskTestCase):
         attr_int = tiledb.Attr("ints", dtype=int, ctx=ctx)
         attr_float = tiledb.Attr("floats", dtype="float", ctx=ctx)
         schema = tiledb.ArraySchema(
-            domain=dom,
-            attrs=(
-                attr_int,
-                attr_float,
-            ),
-            sparse=True,
-            ctx=ctx,
+            domain=dom, attrs=(attr_int, attr_float), sparse=True, ctx=ctx
         )
         tiledb.SparseArray.create(self.path("foo"), schema)
 
@@ -2398,9 +2364,7 @@ class SparseArray(DiskTestCase):
         ctx = tiledb.Ctx({"sm.check_coord_dups": False})
         schema = tiledb.ArraySchema(
             domain=Domain(
-                *[
-                    Dim(name="id", domain=(1, 5000), tile=25, dtype="int32", ctx=ctx),
-                ]
+                *[Dim(name="id", domain=(1, 5000), tile=25, dtype="int32", ctx=ctx)]
             ),
             attrs=[
                 Attr(name="a1", dtype="datetime64[s]", ctx=ctx),
@@ -2549,9 +2513,7 @@ class SparseArray(DiskTestCase):
     def test_sparse_string_domain2(self):
         path = self.path("sparse_string_domain2")
         ctx = tiledb.Ctx()
-        dims = [
-            tiledb.Dim(name="str", domain=(None, None), tile=None, dtype=np.bytes_),
-        ]
+        dims = [tiledb.Dim(name="str", domain=(None, None), tile=None, dtype=np.bytes_)]
         dom = tiledb.Domain(*dims)
         attrs = [tiledb.Attr(name="val", dtype=np.float64, ctx=ctx)]
 
@@ -2707,14 +2669,7 @@ class DenseIndexing(DiskTestCase):
         # slice(-1, 0, -1),
     ]
 
-    bad_index_1d = [
-        2.3,
-        "foo",
-        b"xxx",
-        None,
-        (0, 0),
-        (slice(None), slice(None)),
-    ]
+    bad_index_1d = [2.3, "foo", b"xxx", None, (0, 0), (slice(None), slice(None))]
 
     def test_index_1d(self):
         A = np.arange(1050, dtype=int)
@@ -3733,9 +3688,7 @@ class HighlevelTests(DiskTestCase):
         # This test checks that contexts are destroyed correctly.
         # It creates new contexts repeatedly, in-process, and
         # checks that the total number of threads stays stable.
-        config = {
-            "sm.num_reader_threads": 128,
-        }
+        config = {"sm.num_reader_threads": 128}
         ll = list()
         uri = self.path("test_ctx_thread_cleanup")
         with tiledb.from_numpy(uri, np.random.rand(100)) as A:
@@ -3860,13 +3813,9 @@ class NullableIOTest(DiskTestCase):
 
         schema = tiledb.ArraySchema(
             domain=tiledb.Domain(
-                *[
-                    tiledb.Dim(name="__dim_0", domain=(0, 3), tile=4, dtype="uint64"),
-                ]
+                *[tiledb.Dim(name="__dim_0", domain=(0, 3), tile=4, dtype="uint64")]
             ),
-            attrs=[
-                tiledb.Attr(name="", dtype="int64", var=False, nullable=True),
-            ],
+            attrs=[tiledb.Attr(name="", dtype="int64", var=False, nullable=True)],
         )
         tiledb.Array.create(uri, schema)
 

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -500,9 +500,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
                     ),
                 ]
             ),
-            attrs=[
-                tiledb.Attr(name="int_vals", dtype="int64", filters=attrs_filters),
-            ],
+            attrs=[tiledb.Attr(name="int_vals", dtype="int64", filters=attrs_filters)],
             coords_filters=coords_filters,
             cell_order="row-major",
             tile_order="row-major",


### PR DESCRIPTION
Remove non_empty_domain_var() Fragment Info PyBind11 Function

    * This has now been consolidated into get_non_empty_domain().