### PR TITLE
Test on python 3.6 with ubuntu 16.04

### DIFF
--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -16,7 +16,7 @@ stages:
           python.version: '3.7'
         linux_py3:
           imageName: 'ubuntu-16.04'
-          python.version: '3.7'
+          python.version: '3.6'
       maxParallel: 4
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -719,7 +719,7 @@ setup(
     },
     ext_modules=__extensions,
     setup_requires=setup_requires(),
-    install_requires=["numpy>=1.16", "wheel>=0.30"],
+    install_requires=["numpy>=1.16", "wheel>=0.30", "dataclasses ;python_version<'3.7'"],
     tests_require=TESTS_REQUIRE,
     packages=find_packages(),
     cmdclass=LazyCommandClass(),


### PR DESCRIPTION
- We have good test coverage for higher versions w/ github actions, so we should test 3.6 as well until EOL.
- Add conditional requirement of [dataclasses](https://pypi.org/project/dataclasses/) backport for python 3.6, which will be used in some dataframe code (and probably other places)