### PR TITLE
Variable length attribute support for Pandas extension types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Improvements
 * Addition of `VFS()` functions `copy_file()` and `copy_dir()` [#507](https://github.com/TileDB-Inc/TileDB-Py/pull/507)
+* Add support in `from_pandas` for storing Pandas extension types as variable-length attributes [#515](https://github.com/TileDB-Inc/TileDB-Py/pull/515)
 
 ## Bug fixes
 * Multi-length attributes, regardless of fixed or var-length, do not work query properly with PyArrow enabled due to lack of Arrow List support. When using `.df[]` with PyArrow enabled, we are returning a clear message to the user to use `query(use_pyarrow=False)` [#513](https://github.com/TileDB-Inc/TileDB-Py/pull/513)

--- a/tiledb/tests/datatypes.py
+++ b/tiledb/tests/datatypes.py
@@ -1,0 +1,67 @@
+"""Minimal Pandas ExtensionDtype and ExtensionArray for representing ragged arrays"""
+
+import re
+
+import numpy as np
+
+from pandas.api.extensions import (
+    ExtensionArray,
+    ExtensionDtype,
+    register_extension_dtype,
+)
+
+
+@register_extension_dtype
+class RaggedDtype(ExtensionDtype):
+
+    type = np.ndarray
+    na_value = None
+
+    def __init__(self, dtype=np.float64):
+        self._dtype = np.dtype(dtype)
+
+    @property
+    def subtype(self):
+        return self._dtype
+
+    @property
+    def name(self):
+        return f"Ragged[{self.subtype}]"
+
+    @classmethod
+    def construct_array_type(cls):
+        return RaggedArray
+
+    @classmethod
+    def construct_from_string(cls, string):
+        if string.lower() == "ragged":
+            return cls()
+        match = re.match(r"^ragged\[(\w+)\]$", string, re.IGNORECASE)
+        if match:
+            return cls(match.group(1))
+        raise TypeError(f"Cannot construct a 'RaggedDtype' from '{string}'")
+
+
+class RaggedArray(ExtensionArray):
+    def __init__(self, arrays, dtype=None):
+        if isinstance(dtype, RaggedDtype):
+            self._dtype = dtype
+            dtype = dtype.subtype
+        else:
+            self._dtype = RaggedDtype(dtype)
+
+        self._flat_arrays = [np.asarray(array, dtype=dtype) for array in arrays]
+
+    @classmethod
+    def _from_sequence(cls, scalars, dtype=None, copy=False):
+        return cls(scalars, dtype)
+
+    def __len__(self):
+        return len(self._flat_arrays)
+
+    def __getitem__(self, i):
+        return self._flat_arrays[i]
+
+    @property
+    def dtype(self):
+        return self._dtype


### PR DESCRIPTION
This PR adds support for storing dataframe columns as TileDB [var-length attributes](https://docs.tiledb.com/main/solutions/tiledb-embedded/api-usage/writing-arrays/var-length-attributes). It introduces a new optional parameter for `tiledb.from_pandas`, `varlen_types`, a set of Pandas extension dtypes to be stored as var-length attributes. An extension dtype is considered to be var-length if the result of calling `to_numpy()` on a pandas Series of this dtype returns a "ragged array", a numpy array of arrays.

All the var-length changes are contained in the [last commit](https://github.com/TileDB-Inc/TileDB-Py/commit/ee9cb97767b0feadbdf4a3487edef54065c35020), the previous commits are refactorings.