### PR TITLE
tiledb.from_pandas fixes for fillna and date_spec

### DIFF
--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -670,7 +670,7 @@ def _tiledb_result_as_dataframe(readable_array, result_dict):
 def open_dataframe(uri, ctx=None):
     """Open TileDB array at given URI as a Pandas dataframe
 
-    If the array was saved using tiledb.from_dataframe, then columns
+    If the array was saved using tiledb.from_pandas, then columns
     will be interpreted as non-primitive pandas or numpy types when
     available.
 

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4413,7 +4413,7 @@ cdef class Array(object):
         >>> with tempfile.TemporaryDirectory() as tmp: # doctest: +SKIP
         ...    data = {'col1_f': np.arange(0.0,1.0,step=0.1), 'col2_int': np.arange(10)}
         ...    df = pd.DataFrame.from_dict(data)
-        ...    tiledb.from_dataframe(tmp, df)
+        ...    tiledb.from_pandas(tmp, df)
         ...    A = tiledb.open(tmp)
         ...    A.df[1]
         ...    A.df[1:5]

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -286,13 +286,13 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         df = make_dataframe_basic1()
 
         ctx = tiledb.Ctx()
-        tiledb.from_dataframe(uri, df, sparse=False, ctx=ctx)
+        tiledb.from_pandas(uri, df, sparse=False, ctx=ctx)
 
         df_readback = tiledb.open_dataframe(uri)
         tm.assert_frame_equal(df, df_readback)
 
         uri = self.path("dataframe_basic_rt1_unlimited")
-        tiledb.from_dataframe(uri, df, full_domain=True, sparse=False, ctx=ctx)
+        tiledb.from_pandas(uri, df, full_domain=True, sparse=False, ctx=ctx)
         df_readback = tiledb.open_dataframe(uri)
         tm.assert_frame_equal(df, df_readback)
 
@@ -305,7 +305,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
 
         df = make_dataframe_basic2()
 
-        tiledb.from_dataframe(uri, df, sparse=False)
+        tiledb.from_pandas(uri, df, sparse=False)
 
         df_readback = tiledb.open_dataframe(uri)
         tm.assert_frame_equal(df, df_readback)
@@ -408,7 +408,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             new_df = df.drop_duplicates(subset=col)
             new_df.set_index(col, inplace=True)
 
-            tiledb.from_dataframe(uri, new_df, sparse=True)
+            tiledb.from_pandas(uri, new_df, sparse=True)
 
             with tiledb.open(uri) as A:
                 self.assertEqual(A.domain.dim(0).name, col)
@@ -428,7 +428,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         df_dict = df.to_dict(orient="series")
         df.set_index(["time", "double_range"], inplace=True)
 
-        tiledb.from_dataframe(uri, df, sparse=True)
+        tiledb.from_pandas(uri, df, sparse=True)
 
         with tiledb.open(uri) as A:
             ned_time = A.nonempty_domain()[0]
@@ -561,7 +561,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         df.to_csv(tmp_csv, index=False)
 
         attrs_filters = tiledb.FilterList([tiledb.ZstdFilter(1)])
-        # from_dataframe default is 1, so use 7 here to check
+        # from_pandas default is 1, so use 7 here to check
         #   the arg is correctly parsed/passed
         coords_filters = tiledb.FilterList([tiledb.ZstdFilter(7)])
 
@@ -857,7 +857,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         df = make_dataframe_basic3(col_size)
         df.set_index(["time"], inplace=True)
 
-        tiledb.from_dataframe(uri, df, sparse=True)
+        tiledb.from_pandas(uri, df, sparse=True)
 
         with tiledb.open(uri) as A:
             with self.assertRaises(tiledb.TileDBError):

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -761,7 +761,6 @@ class PandasDataFrameRoundtrip(DiskTestCase):
                 tmp_array2,
                 tmp_csv2,
                 fillna={"v": 0},
-                dtype={"v": pd.Int64Dtype()},
                 column_types={"v": pd.Int64Dtype()},
                 sparse=True,
             )

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -474,6 +474,25 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             df_bk = A.df[:]
             tm.assert_frame_equal(df_bk, df, check_index_type=False)
 
+    def test_dataframe_date_spec(self):
+        date_fmt = "%d/%m/%Y"
+        df = make_dataframe_basic3()
+        df["date"] = df["time"].dt.strftime(date_fmt)
+
+        df_copy = df.copy()
+
+        uri = self.path("df_date_spec")
+        tiledb.from_pandas(uri, df, date_spec={"date": date_fmt})
+
+        # check that original df has not changed
+        tm.assert_frame_equal(df, df_copy)
+
+        # update the column in the original dataframe to match what we expect on read-back
+        df["date"] = pd.to_datetime(df["date"], format=date_fmt)
+        with tiledb.open(uri) as A:
+            df_bk = A.df[:]
+            tm.assert_frame_equal(df_bk, df, check_index_type=False)
+
     def test_csv_dense(self):
         col_size = 10
         df_data = {


### PR DESCRIPTION
Fixes the following bugs:
- `fillna`: https://github.com/TileDB-Inc/TileDB-Py/commit/4256a976c8d52f3911f81d42ac74b1bd8b722064
   - Don't mutate the input dataframe
- `date_spec`: https://github.com/TileDB-Inc/TileDB-Py/pull/516/commits/6394edd5db8a6ab749cd063709cee362e7fa6ee6
   - Don't mutate the input dataframe
   - Always store the `date_spec` attributes as `datetime`

The previous commits are unrelated refactorings.