### PR TITLE
Multirange indexing refactoring

### DIFF
--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -299,15 +299,18 @@ def _update_df_from_meta(
 ) -> DataFrame:
     col_dtypes = {}
     if "__pandas_attribute_repr" in array_meta:
-        col_dtypes.update(json.loads(array_meta["__pandas_attribute_repr"]))
+        attr_dtypes = json.loads(array_meta["__pandas_attribute_repr"])
+        for name, dtype in attr_dtypes.items():
+            if name in df:
+                col_dtypes[name] = dtype
 
     index_names = []
     if "__pandas_index_dims" in array_meta:
         index_dtypes = json.loads(array_meta["__pandas_index_dims"])
         index_names.extend(index_dtypes.keys())
-        for name in index_names:
+        for name, dtype in index_dtypes.items():
             if name in df:
-                col_dtypes[name] = index_dtypes[name]
+                col_dtypes[name] = dtype
 
     if col_dtypes:
         df = df.astype(col_dtypes)

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -94,12 +94,11 @@ class MultiRangeIndexer(object):
     Implements multi-range indexing.
     """
 
-    def __init__(self, array, query=None, use_arrow=False):
+    def __init__(self, array, query=None):
         if not isinstance(array, Array):
             raise TypeError("Internal error: MultiRangeIndexer expected tiledb.Array")
         self.array_ref = weakref.ref(array)
         self.query = query
-        self.use_arrow = use_arrow
 
     @property
     def array(self):
@@ -111,114 +110,7 @@ class MultiRangeIndexer(object):
         return array
 
     def __getitem__(self, idx):
-        return self._run_query(self.query, idx, preload_metadata=False)
-
-    def _run_query(self, query, idx, *, preload_metadata):
-        # implements multi-range / outer / orthogonal indexing
-        array = self.array
-        schema = array.schema
-        dom = schema.domain
-        attr_names = tuple(schema.attr(i)._internal_name for i in range(schema.nattr))
-        if schema.sparse:
-            dim_names = tuple(dom.dim(i).name for i in range(dom.ndim))
-        else:
-            dim_names = tuple()
-
-        # set default order
-        # - TILEDB_UNORDERED for sparse
-        # - TILEDB_ROW_MAJOR for dense
-        order = "U" if schema.sparse else "C"
-
-        # if this indexing operation is part of a query (A.query().df)
-        # then we need to respect the settings of the query
-        if query is not None:
-            # if we are called via Query object, then we need to respect Query semantics
-            if query.attrs is not None:
-                attr_names = tuple(query.attrs)
-            else:
-                pass  # query.attrs might be None -> all
-
-            if query.dims is False:
-                dim_names = tuple()
-            elif query.dims is not None:
-                dim_names = tuple(query.dims)
-            elif query.coords is False:
-                dim_names = tuple()
-
-            # set query order
-            order = query.order
-
-        # convert order to layout
-        if order is None or order == "C":
-            layout = 0
-        elif order == "F":
-            layout = 1
-        elif order == "G":
-            layout = 2
-        elif order == "U":
-            layout = 3
-        else:
-            raise ValueError(
-                "order must be 'C' (TILEDB_ROW_MAJOR), "
-                "'F' (TILEDB_COL_MAJOR), "
-                "'U' (TILEDB_UNORDERED),"
-                "or 'G' (TILEDB_GLOBAL_ORDER)"
-            )
-
-        # initialize the pybind11 query object
-        q = PyQuery(
-            array._ctx_(),
-            array,
-            attr_names,
-            dim_names,
-            layout,
-            self.use_arrow,
-        )
-
-        q._preload_metadata = preload_metadata
-        ranges = getitem_ranges(array, idx)
-        q.set_ranges(ranges)
-        q.submit()
-
-        if query is not None and query.return_arrow:
-            return q._buffers_to_pa_table()
-
-        if isinstance(self, DataFrameIndexer) and self.use_arrow:
-            return q
-
-        result_dict = OrderedDict(q.results())
-
-        final_names = dict()
-        for name, item in result_dict.items():
-            if len(item[1]) > 0:
-                arr = q.unpack_buffer(name, item[0], item[1])
-            else:
-                arr = item[0]
-                final_dtype = schema.attr_or_dim_dtype(name)
-                if len(arr) < 1 and (
-                    np.issubdtype(final_dtype, np.bytes_)
-                    or np.issubdtype(final_dtype, np.unicode_)
-                ):
-                    # special handling to get correctly-typed empty array
-                    # (expression below changes itemsize from 0 to 1)
-                    arr.dtype = final_dtype.str + "1"
-                else:
-                    arr.dtype = schema.attr_or_dim_dtype(name)
-            if name == "__attr":
-                final_names[name] = ""
-            result_dict[name] = arr
-
-        for name, replacement in final_names.items():
-            result_dict[replacement] = result_dict.pop(name)
-
-        if schema.sparse:
-            return result_dict
-        else:
-            result_shape = mr_dense_result_shape(ranges, schema.shape)
-            for arr in result_dict.values():
-                # TODO check/test layout
-                arr.shape = result_shape
-            return result_dict
+        return _run_query(idx, self.array, self.query)
 
 
 class DataFrameIndexer(MultiRangeIndexer):
@@ -228,27 +120,29 @@ class DataFrameIndexer(MultiRangeIndexer):
     """
 
     def __init__(self, array, query=None, use_arrow=None):
+        super().__init__(array, query)
         if use_arrow is None:
             use_arrow = True
-        super().__init__(
-            array, query, use_arrow=bool(use_arrow and pyarrow is not None)
-        )
+        self.use_arrow = bool(use_arrow and pyarrow is not None)
 
     def __getitem__(self, idx):
         check_dataframe_deps()
 
         idx_start = time.time()
+        array = self.array
 
         # we need to use a Query in order to get coords for a dense array
-        query = self.query or Query(self.array, coords=True)
-        result = self._run_query(query, idx, preload_metadata=True)
+        query = self.query or Query(array, coords=True)
+        result = _run_query(
+            idx, array, query, use_arrow=self.use_arrow, preload_metadata=True
+        )
 
         pd_start = time.time()
 
-        if not self.use_arrow:
-            df = _tiledb_result_as_dataframe(self.array, result)
+        if isinstance(result, dict):
+            df = _tiledb_result_as_dataframe(array, result)
         elif isinstance(result, PyQuery):
-            df = _pyarrow_to_pandas(self.array, result, query)
+            df = _pyarrow_to_pandas(array, result, query)
         elif isinstance(result, pyarrow.Table):
             # support the `query(return_arrow=True)` mode and return Table untouched
             df = result
@@ -261,6 +155,93 @@ class DataFrameIndexer(MultiRangeIndexer):
             increment_stat("py.__getitem__time", end - idx_start)
 
         return df
+
+
+def _run_query(idx, array, query, *, use_arrow=False, preload_metadata=False):
+    pyquery = _get_pyquery(array, query, use_arrow)
+    pyquery._preload_metadata = preload_metadata
+    ranges = getitem_ranges(array, idx)
+    pyquery.set_ranges(ranges)
+    pyquery.submit()
+
+    if query is not None and query.return_arrow:
+        return pyquery._buffers_to_pa_table()
+
+    if use_arrow:
+        return pyquery
+
+    schema = array.schema
+    result_dict = _get_pyquery_results(pyquery, schema)
+    if not schema.sparse:
+        result_shape = mr_dense_result_shape(ranges, schema.shape)
+        for arr in result_dict.values():
+            # TODO check/test layout
+            arr.shape = result_shape
+    return result_dict
+
+
+def _get_pyquery(array, query, use_arrow):
+    schema = array.schema
+    attr_names = tuple(schema.attr(i)._internal_name for i in range(schema.nattr))
+    if schema.sparse:
+        dom = schema.domain
+        dim_names = tuple(dom.dim(i).name for i in range(dom.ndim))
+    else:
+        dim_names = ()
+
+    # if this indexing operation is part of a query (A.query().df)
+    # then we need to respect the settings of the query
+    if query is not None:
+        if query.attrs is not None:
+            attr_names = tuple(query.attrs)
+
+        if query.dims is not None:
+            dim_names = tuple(query.dims or ())
+        elif query.coords is False:
+            dim_names = ()
+
+        order = query.order
+    else:
+        # set default order:  TILEDB_UNORDERED for sparse,  TILEDB_ROW_MAJOR for dense
+        order = "U" if schema.sparse else "C"
+
+    try:
+        layout = "CFGU".index(order)
+    except ValueError:
+        raise ValueError(
+            "order must be 'C' (TILEDB_ROW_MAJOR), 'F' (TILEDB_COL_MAJOR),  "
+            "'U' (TILEDB_UNORDERED), or 'G' (TILEDB_GLOBAL_ORDER)"
+        )
+
+    return PyQuery(
+        array._ctx_(),
+        array,
+        attr_names,
+        dim_names,
+        layout,
+        use_arrow,
+    )
+
+
+def _get_pyquery_results(pyquery, schema):
+    result_dict = OrderedDict()
+    for name, item in pyquery.results().items():
+        if len(item[1]) > 0:
+            arr = pyquery.unpack_buffer(name, item[0], item[1])
+        else:
+            arr = item[0]
+            final_dtype = schema.attr_or_dim_dtype(name)
+            if len(arr) < 1 and (
+                np.issubdtype(final_dtype, np.bytes_)
+                or np.issubdtype(final_dtype, np.unicode_)
+            ):
+                # special handling to get correctly-typed empty array
+                # (expression below changes itemsize from 0 to 1)
+                arr.dtype = final_dtype.str + "1"
+            else:
+                arr.dtype = schema.attr_or_dim_dtype(name)
+        result_dict[name if name != "__attr" else ""] = arr
+    return result_dict
 
 
 def _pyarrow_to_pandas(array, pyquery, query, debug=False):

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -343,7 +343,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
         tm.assert_frame_equal(df, df_readback)
 
         with tiledb.open(uri) as B:
-            tm.assert_frame_equal(df, B.df[:], check_index_type=False)
+            tm.assert_frame_equal(df, B.df[:])
 
     def test_dataframe_csv_rt1(self):
         def rand_dtype(dtype, size):
@@ -778,7 +778,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
 
             # test .df[] indexing
             df_idx_res = A.df[int(ned[0]) : int(ned[1])]
-            tm.assert_frame_equal(df_idx_res, df, check_index_type=False)
+            tm.assert_frame_equal(df_idx_res, df)
 
             # test .df[] indexing with query
             df_idx_res = A.query(attrs=["time"]).df[int(ned[0]) : int(ned[1])]
@@ -807,7 +807,7 @@ class PandasDataFrameRoundtrip(DiskTestCase):
             df["v"][4] = 0
 
             df_bk = tiledb.open_dataframe(path)
-            tm.assert_frame_equal(df_bk, df, check_index_type=False)
+            tm.assert_frame_equal(df_bk, df)
 
         ### Test 1
         col_size = 10


### PR DESCRIPTION
Extensive refactoring of the `multirange_indexing` module. Better reviewed on a commit-by-commit basis as the whole module has been touched.
- Reduce the state surface of the `MultiRangeIndexer` and `DataframeIndexer` classes by converting most private methods to standalone functions.
- Break up long functions to smaller ones.
- Remove duplicate logic, e.g. in determining the pandas dataframe index. Line count reduced by ~150 in total.
- Tighten the checks and conversions of input `idx` to ranges. 
- Add a `timing` context manager.
- Add type annotations.