### PR TITLE
Fix intermittent crash due to incorrect pybind11 object scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       shell: bash
       
     - name: 'Install dependencies'
-      run: python -m pip install --upgrade -r requirements_dev.txt
+      run: python -m pip install --upgrade -r misc/requirements_ci.txt
       shell: bash
 
     - name: 'Build TileDB and TileDB-Py extension (Windows)'

--- a/examples/parallel_csv_ingestion.py
+++ b/examples/parallel_csv_ingestion.py
@@ -125,7 +125,7 @@ def from_csv_mp(
     # Setting start method to 'spawn' is required before TileDB 2.1 to
     # avoid problems with TBB when spawning via fork.
     # NOTE: *must be inside __main__* or a function.
-    if multiprocessing.get_start_method(True) is not "spawn":
+    if multiprocessing.get_start_method(True) != "spawn":
         multiprocessing.set_start_method("spawn", True)
 
     # Get a list of of CSVs from the target path

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -43,7 +43,7 @@ stages:
       displayName: 'Print env'
 
     - script: |
-        python -m pip install --upgrade -r requirements_dev.txt
+        python -m pip install --upgrade -r misc/requirements_ci.txt
       displayName: 'Install dependencies'
 
     - script: |

--- a/misc/requirements_ci.txt
+++ b/misc/requirements_ci.txt
@@ -1,0 +1,3 @@
+dask
+distributed
+-r ../requirements_dev.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,6 @@ pybind11
 wheel
 setuptools-scm
 tox
-dask
 pandas ; python_version > '3.5'
 psutil
 pyarrow

--- a/tiledb/highlevel.py
+++ b/tiledb/highlevel.py
@@ -94,7 +94,7 @@ def from_numpy(uri, array, ctx=None, **kw):
     :param str uri: URI for the TileDB array (any supported TileDB URI)
     :param numpy.ndarray array: dense numpy array to persist
     :param tiledb.Ctx ctx: A TileDB Context
-    :param \*\*kwargs: additional arguments to pass to the DenseArray constructor
+    :param kwargs: additional arguments to pass to the DenseArray constructor
     :rtype: tiledb.DenseArray
     :return: An open DenseArray (read mode) with a single anonymous attribute
     :raises TypeError: cannot convert ``uri`` to unicode string

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     import_failed = True
 
-import unittest
+import unittest, os
 
 import tiledb
 from tiledb.tests.common import DiskTestCase
@@ -18,6 +18,8 @@ class DaskSupport(DiskTestCase):
     def setUp(self):
         if import_failed:
             self.skipTest("Dask not available")
+        elif os.name == "nt":
+            self.skipTest("Skipping tests on Windows")
         else:
             super().setUp()
 


### PR DESCRIPTION
- fixes [ch6276], a crash due to incorrect object lifetime in conversion path leading to rare use-after-GC
- ensure actually running, and fix, the full `parallel_csv_ingestion` test (was previously only running the `example()` write path, because the test is not discoverable)