### PR TITLE
Support returning empty result from MultiRangeIndexer and DataFrameIndexer

### DIFF
--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -82,6 +82,7 @@ from .highlevel import open, save, from_numpy, empty_like, array_exists, array_f
 
 # TODO restricted imports
 from .dataframe_ import from_csv, from_pandas, from_dataframe, open_dataframe
+from .multirange_indexing import EmptyRange
 from .parquet_ import from_parquet
 
 from .version import version as __version__

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -660,7 +660,7 @@ def from_pandas(uri, dataframe, **kwargs):
             A.close()
 
 
-def open_dataframe(uri, *, attrs=None, use_arrow=None, ctx=None):
+def open_dataframe(uri, *, attrs=None, use_arrow=None, idx=slice(None), ctx=None):
     """Open TileDB array at given URI as a Pandas dataframe
 
     If the array was saved using tiledb.from_pandas, then columns
@@ -681,7 +681,7 @@ def open_dataframe(uri, *, attrs=None, use_arrow=None, ctx=None):
 
     # TODO support `distributed=True` option?
     with tiledb.open(uri, ctx=ctx) as A:
-        df = A.query(attrs=attrs, use_arrow=use_arrow).df[:]
+        df = A.query(attrs=attrs, use_arrow=use_arrow, coords=True).df[idx]
 
     if attrs and list(df.columns) != list(attrs):
         df = df[attrs]

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -527,6 +527,19 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         df_bk = tiledb.open_dataframe(uri)
         tm.assert_frame_equal(df_bk, df)
 
+    def test_dataframe_empty(self):
+        dfs = [
+            make_dataframe_basic1(),
+            make_dataframe_basic2(),
+            make_dataframe_basic3(),
+        ]
+        for i, df in enumerate(dfs, start=1):
+            for sparse in False, True:
+                uri = self.path(f"dataframe_empty_{i}_{sparse}")
+                tiledb.from_pandas(uri, df, sparse=sparse)
+                with tiledb.open(uri) as A:
+                    tm.assert_frame_equal(df.iloc[:0], A.df[tiledb.EmptyRange])
+
     def test_csv_dense(self):
         col_size = 10
         df_data = {

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -317,8 +317,13 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             tm.assert_frame_equal(df, df_readback)
 
             attrs = ["s", "q", "t"]
-            df_arrow = tiledb.open_dataframe(uri, attrs=attrs, use_arrow=use_arrow)
-            tm.assert_frame_equal(df[attrs], df_arrow)
+            df_readback = tiledb.open_dataframe(uri, attrs=attrs, use_arrow=use_arrow)
+            tm.assert_frame_equal(df[attrs], df_readback)
+
+            df_readback = tiledb.open_dataframe(
+                uri, idx=slice(2, 4), use_arrow=use_arrow
+            )
+            tm.assert_frame_equal(df[2:5], df_readback)
 
     def test_dataframe_basic2(self):
         uri = self.path("dataframe_basic_rt2")


### PR DESCRIPTION
- Introduce `tiledb.EmptyRange` sentinel value to denote an empty slice range.
- `A.multi_index[tiledb.EmptyRange]` returns a dict with values 0-length `np.array`s with the expected `dtype`.
- `A.df[tiledb.EmptyRange]` returns an empty `pd.DataFrame` with the expected column/`dtypes`.

Also extend `tiledb.open_dataframe` with an optional `idx` parameter (default=full range `slice(None, None)`).