### PR TITLE
Refactor tests to use pytest only

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+python_classes = *Test*
+python_files = "test_*.py"
+testpaths = ./tiledb/tests

--- a/tiledb/tests/test_compat.py
+++ b/tiledb/tests/test_compat.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import sys, os, io, re, platform, unittest, random, warnings
-
 import numpy as np
 import tarfile, base64
 from io import BytesIO
@@ -11,14 +9,10 @@ from numpy.testing import assert_array_equal
 import tiledb
 from tiledb.tests.common import (
     DiskTestCase,
-    assert_subarrays_equal,
-    rand_utf8,
-    rand_ascii,
-    rand_ascii_bytes,
 )
 
 
-class BackwardCompatibilityTests(DiskTestCase):
+class TestBackwardCompatibility(DiskTestCase):
     def test_compat_tiledb_py_0_5_anon_attr_dense(self):
         # array written with the following script:
         """

--- a/tiledb/tests/test_core.py
+++ b/tiledb/tests/test_core.py
@@ -62,7 +62,7 @@ class CoreCCTest(DiskTestCase):
             assert_array_equal(res, a[:])
 
     def test_pyquery_init(self):
-        uri = self.path("test_pyquery_basic")
+        uri = self.path("test_pyquery_init")
         intmax = np.iinfo(np.int64).max
         config_dict = {"sm.tile_cache_size": "100", "py.init_buffer_bytes": str(intmax)}
         ctx = tiledb.Ctx(config=config_dict)

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     import_failed = True
 
-import unittest, os
+import os
 
 import tiledb
 from tiledb.tests.common import DiskTestCase
@@ -14,7 +14,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_approx_equal
 
 
-class DaskSupport(DiskTestCase):
+class TestDaskSupport(DiskTestCase):
     def setUp(self):
         if import_failed:
             self.skipTest("Dask not available")

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -242,7 +242,7 @@ class TestDimType:
             assert A.schema.domain.dim(0).name == df.index.name
 
 
-class PandasDataFrameRoundtrip(DiskTestCase):
+class TestPandasDataFrameRoundtrip(DiskTestCase):
     def setUp(self):
         if pd is None:
             self.skipTest("Pandas not available")

--- a/tiledb/tests/test_util.py
+++ b/tiledb/tests/test_util.py
@@ -3,19 +3,12 @@
 
 import tiledb
 from tiledb import *
-from tiledb.libtiledb import index_as_tuple, replace_ellipsis
 from tiledb.tests.common import DiskTestCase
 
 import numpy as np
 from numpy.testing import (
-    assert_equal,
-    assert_approx_equal,
     assert_array_equal,
-    assert_raises,
 )
-
-import unittest
-from unittest import TestCase
 
 
 class UtilTest(DiskTestCase):


### PR DESCRIPTION
- replace `unittest.TestCase` base class with standalone DiskTestCase
  class (implementing the assert methods we use)
- allows using pytest parameterization on any test, which is not
  possible with subclasses of unittest.TestCase