### PR TITLE
Try to fix hanging CI: don't let pytest recurse into .git [ch6686]

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 python_classes = *Test*
 python_files = "test_*.py"
 testpaths = ./tiledb/tests
+filterwarnings =
+    ignore
+norecursedirs = .git build


### PR DESCRIPTION
GHA CI is consistently hanging, and after some [debug builds](https://github.com/TileDB-Inc/TileDB-Py/actions/runs/756722444) it appears the problem may be due to recursing into .git.