### PR TITLE
Retry pytest recurse/exclude options

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,3 @@ filterwarnings =
     error
     default::pytest.PytestWarning
     default::DeprecationWarning:distributed
-norecursedirs = .git build

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
 python_classes = *Test*
 python_files = "test_*.py"
-testpaths = ./tiledb/tests
+testpaths = tiledb/tests
+addopts = --ignore=tiledb/tests/perf --ignore=tiledb/tests/__pycache__
 filterwarnings =
     error
     default::pytest.PytestWarning


### PR DESCRIPTION
Overriding `norecursedirs` removes some useful defaults, so try specific ignore paths instead.