### PR TITLE
Add support for iterating over incomplete queries

### DIFF
--- a/examples/incomplete_iteration.py
+++ b/examples/incomplete_iteration.py
@@ -1,0 +1,98 @@
+# quickstart_dense.py
+#
+# LICENSE
+#
+# The MIT License
+#
+# Copyright (c) 2020 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# DESCRIPTION
+#
+# Please refer to the TileDB and TileDB-Py documentation for more information:
+#   https://docs.tiledb.com/main/solutions/tiledb-embedded/api-usage
+#   https://tiledb-inc-tiledb.readthedocs-hosted.com/projects/tiledb-py/en/stable/python-api.html
+#
+# When run, this program will create a 1D dense array, write some data
+# to it, and read slices back by iteration over incomplete queries.
+#
+
+import numpy as np
+import sys
+import tiledb
+
+# Name of the array to create.
+array_name = "incomplete_iteration"
+
+
+def create_array():
+    # The array will be 100 cells with dimensions "x".
+    dom = tiledb.Domain(tiledb.Dim(name="x", domain=(0, 99), tile=100, dtype=np.int64))
+
+    # The array will be dense with a single string typed attribute "a"
+    schema = tiledb.ArraySchema(
+        domain=dom, sparse=True, attrs=[tiledb.Attr(name="a", dtype=str)]
+    )
+
+    # Create the (empty) array on disk.
+    tiledb.SparseArray.create(array_name, schema)
+
+
+def write_array():
+    # Open the array and write to it.
+    with tiledb.open(array_name, mode="w") as A:
+        extent = A.schema.domain.dim("x").domain
+        ncells = extent[1] - extent[0] + 1
+
+        # Data is the Latin alphabet with varying repeat lengths
+        data = [chr(i % 26 + 97) * (i % 52) for i in range(ncells)]
+
+        # Coords are the dimension range
+        coords = np.arange(extent[0], extent[1] + 1)
+
+        A[coords] = data
+
+
+def read_array_iterated():
+    # in order to force iteration, restrict the buffer sizes
+    # this setting gives 5 iterations for the example data
+    init_buffer_bytes = 800
+    cfg = tiledb.Config(
+        {
+            "py.init_buffer_bytes": init_buffer_bytes,
+            "py.exact_init_buffer_bytes": "true",
+        }
+    )
+
+    with tiledb.open(array_name, config=cfg) as A:
+        # iterate over results as a dataframe
+        iterable = A.query(return_incomplete=True).df[:]
+
+        for i, result in enumerate(iterable):
+            print(f"--- result {i} is a '{type(result)}' with size {len(result)}")
+            print(result)
+            print("---")
+
+    print(f"Query completed after {i} iterations")
+
+
+create_array()
+write_array()
+read_array_iterated()

--- a/examples/incomplete_iteration.py
+++ b/examples/incomplete_iteration.py
@@ -1,4 +1,4 @@
-# quickstart_dense.py
+# incomplete_iteration.py
 #
 # LICENSE
 #

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -809,15 +809,17 @@ public:
       auto &buf = bp.second;
 
       // Check if values buffer should be resized
-      if ((int64_t)(buf.data_vals_read * buf.elem_nbytes) >
-          (buf.data.nbytes() + 1) / 2) {
+      if ((buf.data_vals_read == 0) ||
+          (int64_t)(buf.data_vals_read * buf.elem_nbytes) >
+              (buf.data.nbytes() + 1) / 2) {
         size_t new_size = buf.data.size() * 2;
         buf.data.resize({new_size}, false);
       }
 
       // Check if offset buffer should be resized
-      if (buf.isvar && (int64_t)(buf.offsets_read * sizeof(uint64_t)) >
-                           (buf.offsets.nbytes() + 1) / 2) {
+      if ((buf.isvar && buf.offsets_read == 0) ||
+          ((int64_t)(buf.offsets_read * sizeof(uint64_t)) >
+           (buf.offsets.nbytes() + 1) / 2)) {
         size_t new_offsets_size = buf.offsets.size() * 2;
         buf.offsets.resize({new_offsets_size}, false);
       }

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -662,6 +662,16 @@ public:
                           validity_num, var, nullable)});
   }
 
+  py::object get_buffers() {
+    py::list result;
+    for (auto &bp : buffers_) {
+      const BufferInfo b = bp.second;
+      result.append(b.data);
+      result.append(b.offsets);
+    }
+    return result;
+  }
+
   void set_buffers() {
     for (auto bp : buffers_) {
       auto name = bp.first;
@@ -1195,6 +1205,7 @@ PYBIND11_MODULE(core, m) {
       .def("buffer_dtype", &PyQuery::buffer_dtype)
       .def("unpack_buffer", &PyQuery::unpack_buffer)
       .def_readwrite("_preload_metadata", &PyQuery::preload_metadata_)
+      .def("_get_buffers", &PyQuery::get_buffers)
       .def("_buffer_to_pa", &PyQuery::buffer_to_pa)
       .def("_buffers_to_pa_table", &PyQuery::buffers_to_pa_table)
       .def("_test_array", &PyQuery::_test_array)

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1117,9 +1117,6 @@ public:
   py::object buffers_to_pa_table() {
     using namespace pybind11::literals;
 
-    if (query_->query_status() != tiledb::Query::Status::COMPLETE)
-      TPY_ERROR_LOC("Query must be complete to convert buffers");
-
     auto pa = py::module::import("pyarrow");
     auto pa_array_import = pa.attr("Array").attr("_import_from_c");
 

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1083,6 +1083,13 @@ public:
     return pa_table;
   }
 
+  py::object is_incomplete() {
+    if (!query_) {
+      throw TileDBPyError("Internal error: PyQuery not initialized!");
+    }
+    return py::cast<bool>(query_->query_status() == tiledb::Query::Status::INCOMPLETE);
+  }
+
   py::array _test_array() {
     py::array_t<uint8_t> a;
     a.resize({10});
@@ -1193,6 +1200,7 @@ PYBIND11_MODULE(core, m) {
       .def("_test_array", &PyQuery::_test_array)
       .def("_test_err",
            [](py::object self, std::string s) { throw TileDBPyError(s); })
+      .def_property_readonly("is_incomplete", &PyQuery::is_incomplete)
       .def_property_readonly("_test_init_buffer_bytes",
                              &PyQuery::_test_init_buffer_bytes);
 

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -337,7 +337,7 @@ public:
   }
 
   void init_config() {
-     // get config parameters
+    // get config parameters
     std::string tmp_str;
     if (config_has_key(ctx_.config(), "py.init_buffer_bytes")) {
       tmp_str = ctx_.config().get("py.init_buffer_bytes");
@@ -377,15 +377,15 @@ public:
     }
 
     if (config_has_key(ctx_.config(), "py.exact_init_buffer_bytes")) {
-      tmp_str = ctx_.config().get( "py.exact_init_buffer_bytes");
+      tmp_str = ctx_.config().get("py.exact_init_buffer_bytes");
       if (tmp_str == "true") {
         exact_init_bytes_ = true;
       } else if (tmp_str == "false") {
         exact_init_bytes_ = false;
       } else {
-        throw std::invalid_argument(
-            "Failed to convert configuration 'py.exact_init_buffer_bytes' to bool ('" +
-            tmp_str + "')");
+        throw std::invalid_argument("Failed to convert configuration "
+                                    "'py.exact_init_buffer_bytes' to bool ('" +
+                                    tmp_str + "')");
       }
     }
 
@@ -899,7 +899,8 @@ public:
     }
 
     // allocate buffers for attributes
-    //   - schema.attributes() is unordered, but we need to return ordered results
+    //   - schema.attributes() is unordered, but we need to return ordered
+    //   results
     for (size_t attr_idx = 0; attr_idx < schema.attribute_num(); attr_idx++) {
       auto attr = schema.attribute(attr_idx);
       if (std::find(attrs_.begin(), attrs_.end(), attr.name()) ==
@@ -911,12 +912,13 @@ public:
   }
 
   void submit_read() {
-    if (retries_ > 0 && query_->query_status() == tiledb::Query::Status::INCOMPLETE) {
+    if (retries_ > 0 &&
+        query_->query_status() == tiledb::Query::Status::INCOMPLETE) {
       buffers_.clear();
       assert(buffers_.size() == 0);
 
       buffers_order_.clear();
-      //reset_read_elem_num();
+      // reset_read_elem_num();
     } else if (buffers_.size() != 0) {
       // we have externally imported buffers
       return;
@@ -964,7 +966,8 @@ public:
     }
 
     // TODO: would be nice to have a callback here for custom realloc strategy
-    while (!return_incomplete_ && query_->query_status() == Query::Status::INCOMPLETE) {
+    while (!return_incomplete_ &&
+           query_->query_status() == Query::Status::INCOMPLETE) {
       if (++retries_ > max_retries)
         TPY_ERROR_LOC(
             "Exceeded maximum retries ('py.max_incomplete_retries': '" +
@@ -1149,7 +1152,6 @@ public:
         c_pa_array.n_buffers = 2;
       }
 
-
       py::object pa_array = pa_array_import(py::int_((ptrdiff_t)&c_pa_array),
                                             py::int_((ptrdiff_t)&c_pa_schema));
 
@@ -1166,7 +1168,8 @@ public:
     if (!query_) {
       throw TileDBPyError("Internal error: PyQuery not initialized!");
     }
-    return py::cast<bool>(query_->query_status() == tiledb::Query::Status::INCOMPLETE);
+    return py::cast<bool>(query_->query_status() ==
+                          tiledb::Query::Status::INCOMPLETE);
   }
 
   py::object estimated_result_sizes() {
@@ -1179,7 +1182,8 @@ public:
 
       if (is_var(name)) {
         query_->est_result_size_var(name);
-        std::tie(est_offsets, est_data_bytes) = query_->est_result_size_var(name);
+        std::tie(est_offsets, est_data_bytes) =
+            query_->est_result_size_var(name);
         est_offsets = est_offsets;
       } else {
         est_data_bytes = query_->est_result_size(name);
@@ -1288,30 +1292,30 @@ std::string python_internal_stats() {
 }
 
 PYBIND11_MODULE(core, m) {
-  auto pq = py::class_<PyQuery>(m, "PyQuery")
-      .def(py::init<py::object, py::object, py::iterable, py::object,
-                    py::object, py::object>())
-      .def("buffer_dtype", &PyQuery::buffer_dtype)
-      .def("results", &PyQuery::results)
-      .def("set_ranges", &PyQuery::set_ranges)
-      .def("set_subarray", &PyQuery::set_subarray)
-      .def("submit", &PyQuery::submit)
-      .def("unpack_buffer", &PyQuery::unpack_buffer)
-      .def("estimated_result_sizes", &PyQuery::estimated_result_sizes)
-      .def("_get_buffers", &PyQuery::get_buffers)
-      .def("_buffer_to_pa", &PyQuery::buffer_to_pa)
-      .def("_buffers_to_pa_table", &PyQuery::buffers_to_pa_table)
-      .def("_test_array", &PyQuery::_test_array)
-      .def("_test_err",
-           [](py::object self, std::string s) { throw TileDBPyError(s); })
-      .def_readwrite("_preload_metadata", &PyQuery::preload_metadata_)
-      .def_readwrite("_return_incomplete", &PyQuery::return_incomplete_)
-      // properties
-      .def_property_readonly("is_incomplete", &PyQuery::is_incomplete)
-      .def_property_readonly("_test_init_buffer_bytes",
-                             &PyQuery::_test_init_buffer_bytes)
-      .def_readonly("retries", &PyQuery::retries_);
-
+  auto pq =
+      py::class_<PyQuery>(m, "PyQuery")
+          .def(py::init<py::object, py::object, py::iterable, py::object,
+                        py::object, py::object>())
+          .def("buffer_dtype", &PyQuery::buffer_dtype)
+          .def("results", &PyQuery::results)
+          .def("set_ranges", &PyQuery::set_ranges)
+          .def("set_subarray", &PyQuery::set_subarray)
+          .def("submit", &PyQuery::submit)
+          .def("unpack_buffer", &PyQuery::unpack_buffer)
+          .def("estimated_result_sizes", &PyQuery::estimated_result_sizes)
+          .def("_get_buffers", &PyQuery::get_buffers)
+          .def("_buffer_to_pa", &PyQuery::buffer_to_pa)
+          .def("_buffers_to_pa_table", &PyQuery::buffers_to_pa_table)
+          .def("_test_array", &PyQuery::_test_array)
+          .def("_test_err",
+               [](py::object self, std::string s) { throw TileDBPyError(s); })
+          .def_readwrite("_preload_metadata", &PyQuery::preload_metadata_)
+          .def_readwrite("_return_incomplete", &PyQuery::return_incomplete_)
+          // properties
+          .def_property_readonly("is_incomplete", &PyQuery::is_incomplete)
+          .def_property_readonly("_test_init_buffer_bytes",
+                                 &PyQuery::_test_init_buffer_bytes)
+          .def_readonly("retries", &PyQuery::retries_);
 
   m.def("array_to_buffer", &convert_np);
 

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1182,8 +1182,9 @@ public:
 
       if (is_var(name)) {
         query_->est_result_size_var(name);
-        std::tie(est_offsets, est_data_bytes) =
-            query_->est_result_size_var(name);
+        auto est_sizes = query_->est_result_size_var(name);
+        est_offsets = std::get<0>(est_sizes);
+        est_data_bytes = std::get<1>(est_sizes);
         est_offsets = est_offsets;
       } else {
         est_data_bytes = query_->est_result_size(name);

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1270,7 +1270,7 @@ std::string python_internal_stats() {
 
   os << std::endl;
   os << "==== Python Stats ====" << std::endl << std::endl;
-  os << "- TileDB-Py Indexing Time: " << counters["py.__getitem__time"].count()
+  os << "- TileDB-Py Indexing Time: " << counters["py.getitem_time"].count()
      << std::endl;
   os << "  * TileDB-Py query execution time: "
      << counters["py.read_query_time"].count() << std::endl;

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1097,7 +1097,7 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_vfs_t* vfs,
         const char* old_uri,
         const char* new_uri) nogil
-    
+
     int tiledb_vfs_copy_file(
         tiledb_ctx_t* ctx,
         tiledb_vfs_t* vfs,
@@ -1302,7 +1302,9 @@ cdef class Query(object):
     cdef object order
     cdef object coords
     cdef object index_col
+    cdef object use_arrow
     cdef object return_arrow
+    cdef object return_incomplete
     cdef DomainIndexer domain_index
     cdef object multi_index
     cdef object df

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4683,6 +4683,10 @@ cdef class DenseArrayImpl(Array):
         :param order: 'C', 'F', or 'G' (row-major, col-major, tiledb global order)
         :param use_arrow: if True, return dataframes via PyArrow if applicable.
         :param return_arrow: if True, return results as a PyArrow Table if applicable.
+        :param return_incomplete: if True, initialize and return a query which will return
+            iterable objects over the indexed range. See usage example in 'examples/incomplete_iteration.py'.
+            If False (default False), queries will be internally run to completion by resizing buffers and
+            resubmitting until query is complete.
         :return: A proxy Query object that can be used for indexing into the DenseArray
             over the defined attributes, in the given result layout (order).
 

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import time
 import weakref
@@ -5,6 +6,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from numbers import Real
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union, cast
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -33,6 +35,12 @@ EmptyRange = object()
 # TODO: expand with more accepted scalar types
 Scalar = Real
 Range = Tuple[Scalar, Scalar]
+
+
+@dataclass
+class EstimatedResultSize:
+    offsets_bytes: int
+    data_bytes: int
 
 
 @contextmanager

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -218,7 +218,7 @@ class MultiRangeIndexer(object):
 
         https://tiledb-inc-tiledb.readthedocs-hosted.com/en/stable/c++-api.html#query
 
-        :return: OrderedDict of key -> EstimatedResultSize dataclass
+        :return: OrderedDict of key: str -> EstimatedResultSize
         """
         results = {}
         if not self.pyquery:

--- a/tiledb/tests/fixtures.py
+++ b/tiledb/tests/fixtures.py
@@ -1,6 +1,42 @@
 import pytest
+import random
+
+import tiledb
+import numpy as np
+
+from numpy.testing import assert_array_equal
+from tiledb.tests.common import assert_subarrays_equal, rand_utf8
 
 
 @pytest.fixture(scope="module", params=["hilbert", "row-major"])
 def sparse_cell_order(request):
     yield request.param
+
+
+@pytest.fixture(scope="class")
+def test_incomplete_return_array(tmpdir_factory):
+    tmp_path = str(tmpdir_factory.mktemp("array"))
+    ncells = 20
+    nvals = 10
+
+    data = np.array([rand_utf8(nvals - i % 2) for i in range(ncells)], dtype="O")
+
+    ctx = tiledb.default_ctx()
+
+    dom = tiledb.Domain(
+        tiledb.Dim(domain=(0, len(data) - 1), tile=len(data), ctx=ctx), ctx=ctx
+    )
+    att = tiledb.Attr(dtype=str, var=True, ctx=ctx)
+
+    schema = tiledb.ArraySchema(dom, (att,), sparse=True, ctx=ctx)
+
+    coords = np.arange(ncells)
+
+    tiledb.SparseArray.create(tmp_path, schema)
+    with tiledb.SparseArray(tmp_path, mode="w", ctx=ctx) as T:
+        T[coords] = data
+
+    with tiledb.SparseArray(tmp_path, mode="r", ctx=ctx) as T:
+        assert_subarrays_equal(data, T[:][""])
+
+    return tmp_path

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1482,99 +1482,6 @@ class DenseArrayTest(DiskTestCase):
             df = A.df[:]
             assert_array_equal(df[""], data)
 
-    def test_incomplete_dense_varlen(self):
-        ncells = 10
-
-        path = self.path("incomplete_dense_varlen")
-        str_data = [rand_utf8(random.randint(0, n)) for n in range(ncells)]
-        data = np.array(str_data, dtype=np.unicode_)
-
-        # basic write
-        ctx = tiledb.Ctx()
-        dom = tiledb.Domain(
-            tiledb.Dim(domain=(1, len(data)), tile=len(data), ctx=ctx), ctx=ctx
-        )
-        att = tiledb.Attr(dtype=np.unicode_, var=True, ctx=ctx)
-
-        schema = tiledb.ArraySchema(dom, (att,), ctx=ctx)
-
-        tiledb.DenseArray.create(path, schema)
-        with tiledb.DenseArray(path, mode="w", ctx=ctx) as T:
-            T[:] = data
-
-        with tiledb.DenseArray(path, mode="r", ctx=ctx) as T:
-            assert_array_equal(data, T[:])
-
-        # set the memory to the max length of a cell
-        # these settings force ~100 retries
-        # TODO would be good to check repeat count here; not yet exposed
-        #      Also would be useful to have max cell config in libtiledb.
-        init_buffer_bytes = 1024 ** 2
-        config = tiledb.Config(
-            {
-                "sm.memory_budget": ncells,
-                "sm.memory_budget_var": ncells,
-                "py.init_buffer_bytes": init_buffer_bytes,
-            }
-        )
-
-        ctx2 = tiledb.Ctx(config=config)
-        self.assertEqual(config["py.init_buffer_bytes"], str(init_buffer_bytes))
-
-        with tiledb.DenseArray(path, mode="r", ctx=ctx2) as T2:
-            df = T2.query(attrs=[""]).df[:]
-            assert_array_equal(df[""], data)
-
-    def test_incomplete_sparse_varlen(self):
-        ncells = 100
-
-        path = self.path("incomplete_sparse_varlen")
-        str_data = [rand_utf8(random.randint(0, n)) for n in range(ncells)]
-        data = np.array(str_data, dtype=np.unicode_)
-        coords = np.arange(ncells)
-
-        # basic write
-        ctx = tiledb.Ctx()
-        dom = tiledb.Domain(
-            tiledb.Dim(domain=(0, len(data) + 100), tile=len(data), ctx=ctx), ctx=ctx
-        )
-        att = tiledb.Attr(dtype=np.unicode_, var=True, ctx=ctx)
-
-        schema = tiledb.ArraySchema(dom, (att,), sparse=True, ctx=ctx)
-
-        tiledb.SparseArray.create(path, schema)
-        with tiledb.SparseArray(path, mode="w", ctx=ctx) as T:
-            T[coords] = data
-
-        with tiledb.SparseArray(path, mode="r", ctx=ctx) as T:
-            assert_array_equal(data, T[:][""])
-
-        # set the memory to the max length of a cell
-        # these settings force ~100 retries
-        # TODO would be good to check repeat count here; not yet exposed
-        #      Also would be useful to have max cell config in libtiledb.
-        init_buffer_bytes = 1024 ** 2
-        config = tiledb.Config(
-            {
-                "sm.memory_budget": ncells,
-                "sm.memory_budget_var": ncells,
-                "py.init_buffer_bytes": init_buffer_bytes,
-            }
-        )
-
-        ctx2 = tiledb.Ctx(config=config)
-        self.assertEqual(config["py.init_buffer_bytes"], str(init_buffer_bytes))
-
-        with tiledb.SparseArray(path, mode="r", ctx=ctx2) as T2:
-            assert_array_equal(data, T2[:][""])
-
-            assert_array_equal(data, T2.multi_index[0:ncells][""])
-
-            # ensure that empty results are handled correctly
-            assert_array_equal(
-                T2.multi_index[101:105][""], np.array([], dtype=np.dtype("<U"))
-            )
-
     def test_written_fragment_info(self):
         uri = self.path("test_written_fragment_info")
 
@@ -1649,7 +1556,7 @@ class DenseArrayTest(DiskTestCase):
         # D[d1, 1]
 
 
-class TestDenseVarlen(DiskTestCase):
+class TestVarlen(DiskTestCase):
     def test_varlen_write_bytes(self):
         A = np.array(
             [
@@ -3989,6 +3896,99 @@ class NullableIOTest(DiskTestCase):
                 slice(0, 4), np.ones(4), {"": np.array([0, 1, 0, 1], dtype=np.uint8)}
             )
 
+
+class IncompleteTest(DiskTestCase):
+    def test_incomplete_dense_varlen(self):
+        ncells = 10
+        path = self.path("incomplete_dense_varlen")
+        str_data = [rand_utf8(random.randint(0, n)) for n in range(ncells)]
+        data = np.array(str_data, dtype=np.unicode_)
+
+        # basic write
+        ctx = tiledb.Ctx()
+        dom = tiledb.Domain(
+            tiledb.Dim(domain=(1, len(data)), tile=len(data), ctx=ctx), ctx=ctx
+        )
+        att = tiledb.Attr(dtype=np.unicode_, var=True, ctx=ctx)
+
+        schema = tiledb.ArraySchema(dom, (att,), ctx=ctx)
+
+        tiledb.DenseArray.create(path, schema)
+        with tiledb.DenseArray(path, mode="w", ctx=ctx) as T:
+            T[:] = data
+
+        with tiledb.DenseArray(path, mode="r", ctx=ctx) as T:
+            assert_array_equal(data, T[:])
+
+        # set the memory to the max length of a cell
+        # these settings force ~100 retries
+        # TODO would be good to check repeat count here; not yet exposed
+        #      Also would be useful to have max cell config in libtiledb.
+        init_buffer_bytes = 1024 ** 2
+        config = tiledb.Config(
+            {
+                "sm.memory_budget": ncells,
+                "sm.memory_budget_var": ncells,
+                "py.init_buffer_bytes": init_buffer_bytes,
+            }
+        )
+
+        ctx2 = tiledb.Ctx(config=config)
+        self.assertEqual(config["py.init_buffer_bytes"], str(init_buffer_bytes))
+
+        with tiledb.DenseArray(path, mode="r", ctx=ctx2) as T2:
+            df = T2.query(attrs=[""]).df[:]
+            assert_array_equal(df[""], data)
+
+    def test_incomplete_sparse_varlen(self):
+        ncells = 100
+
+        path = self.path("incomplete_sparse_varlen")
+        str_data = [rand_utf8(random.randint(0, n)) for n in range(ncells)]
+        data = np.array(str_data, dtype=np.unicode_)
+        coords = np.arange(ncells)
+
+        # basic write
+        ctx = tiledb.Ctx()
+        dom = tiledb.Domain(
+            tiledb.Dim(domain=(0, len(data) + 100), tile=len(data), ctx=ctx), ctx=ctx
+        )
+        att = tiledb.Attr(dtype=np.unicode_, var=True, ctx=ctx)
+
+        schema = tiledb.ArraySchema(dom, (att,), sparse=True, ctx=ctx)
+
+        tiledb.SparseArray.create(path, schema)
+        with tiledb.SparseArray(path, mode="w", ctx=ctx) as T:
+            T[coords] = data
+
+        with tiledb.SparseArray(path, mode="r", ctx=ctx) as T:
+            assert_array_equal(data, T[:][""])
+
+        # set the memory to the max length of a cell
+        # these settings force ~100 retries
+        # TODO would be good to check repeat count here; not yet exposed
+        #      Also would be useful to have max cell config in libtiledb.
+        init_buffer_bytes = 1024 ** 2
+        config = tiledb.Config(
+            {
+                "sm.memory_budget": ncells,
+                "sm.memory_budget_var": ncells,
+                "py.init_buffer_bytes": init_buffer_bytes,
+            }
+        )
+
+        ctx2 = tiledb.Ctx(config=config)
+        self.assertEqual(config["py.init_buffer_bytes"], str(init_buffer_bytes))
+
+        with tiledb.SparseArray(path, mode="r", ctx=ctx2) as T2:
+            assert_array_equal(data, T2[:][""])
+
+            assert_array_equal(data, T2.multi_index[0:ncells][""])
+
+            # ensure that empty results are handled correctly
+            assert_array_equal(
+                T2.multi_index[101:105][""], np.array([], dtype=np.dtype("<U"))
+            )
 
 # if __name__ == '__main__':
 #    # run a single example for in-process debugging


### PR DESCRIPTION
- Adds a new `Array.query` option `return_incomplete` to enable iteration over incomplete results (rather than running queries to completion by reallocating buffers and resubmitting, as is the default).
  - When enabled, indexing the `query` returns an iterator which will return results for each incomplete query as consumed. Example:
```
with tiledb.open(uri) as A:
  for df in A.query(return_incomplete=True).df[slice_start:slice_end]:
    print(df) # df is a pandas DataFrame
```
  - Adds usage example in `examples/incomplete_iteration.py`

- Also adds `estimated_result_sizes` getter to return estimated buffer sizes (from `tiledb::Query::est_result_size_*`) on the _initialized_ iterator object.