### PR TITLE
Fix Domain tile representation round-tripping

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2680,7 +2680,7 @@ cdef class Dim(object):
                 filters_str +=  repr(f) + ", "
             filters_str += "])"
 
-        return "Dim(name={0!r}, domain={1!s}, tile={2!s}, dtype='{3!s}'{4})" \
+        return "Dim(name={0!r}, domain={1!s}, tile='{2!s}', dtype='{3!s}'{4})" \
             .format(self.name, self.domain, self.tile, self.dtype, filters_str)
 
     def __len__(self):


### PR DESCRIPTION
This uses `{!r}` to get `repr` for the tiling rather than `str` (which returns eg `600 seconds` for `timedelta64(600,'s')` -- the latter cannot be parsed.