### PR TITLE
Ctx context manager and ContextVar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.16.*
 setuptools
+contextvars ;python_version<"3.7"
 dataclasses ;python_version<"3.7"

--- a/setup.py
+++ b/setup.py
@@ -685,6 +685,7 @@ setup(
     install_requires=[
         "numpy>=1.16",
         "wheel>=0.30",
+        "contextvars ;python_version<'3.7'",
         "dataclasses ;python_version<'3.7'",
     ],
     packages=find_packages(),

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -33,6 +33,7 @@ except:
         # Otherwise try loading by name only.
         ctypes.CDLL(lib_name)
 
+from .ctx import default_ctx, scope_ctx
 from .libtiledb import (
     Array,
     Ctx,
@@ -59,7 +60,6 @@ from .libtiledb import (
     ChecksumMD5Filter,
     ChecksumSHA256Filter,
     consolidate,
-    default_ctx,
     group_create,
     object_type,
     ls,

--- a/tiledb/ctx.py
+++ b/tiledb/ctx.py
@@ -1,0 +1,47 @@
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+import tiledb
+
+_ctx_var = ContextVar("ctx")
+
+
+@contextmanager
+def scope_ctx(config=None):
+    """
+    Context manager for setting the default `tiledb.Ctx` context variable when entering
+    a block of code and restoring it to its previous value when exiting the block.
+
+    :param config: :py:class:`tiledb.Config` object or dictionary with config parameters.
+    :return: Ctx
+    """
+    token = _ctx_var.set(tiledb.Ctx(config))
+    try:
+        yield _ctx_var.get()
+    finally:
+        _ctx_var.reset(token)
+
+
+def default_ctx(config=None):
+    """
+    Returns, and optionally initializes, the default `tiledb.Ctx` context variable.
+
+    This Ctx object is used by Python API functions when no `ctx` keyword argument
+    is provided. Most API functions accept an optional `ctx` kwarg, but that is typically
+    only necessary in advanced usage with multiple contexts per program.
+
+    For initialization, this function must be called before any other tiledb functions.
+    The initialization call accepts a  :py:class:`tiledb.Config` object to override the
+    defaults for process-global parameters.
+
+    :param config: :py:class:`tiledb.Config` object or dictionary with config parameters.
+    :return: Ctx
+    """
+    try:
+        ctx = _ctx_var.get()
+        if config is not None:
+            raise tiledb.TileDBError("Global context already initialized!")
+    except LookupError:
+        ctx = tiledb.Ctx(config)
+        _ctx_var.set(ctx)
+    return ctx

--- a/tiledb/ctx.py
+++ b/tiledb/ctx.py
@@ -7,15 +7,20 @@ _ctx_var = ContextVar("ctx")
 
 
 @contextmanager
-def scope_ctx(config=None):
+def scope_ctx(ctx_or_config=None):
     """
     Context manager for setting the default `tiledb.Ctx` context variable when entering
     a block of code and restoring it to its previous value when exiting the block.
 
-    :param config: :py:class:`tiledb.Config` object or dictionary with config parameters.
+    :param ctx_or_config: :py:class:`tiledb.Ctx` or :py:class:`tiledb.Config` object
+        or dictionary with config parameters.
     :return: Ctx
     """
-    token = _ctx_var.set(tiledb.Ctx(config))
+    if not isinstance(ctx_or_config, tiledb.Ctx):
+        ctx = tiledb.Ctx(ctx_or_config)
+    else:
+        ctx = ctx_or_config
+    token = _ctx_var.set(ctx)
     try:
         yield _ctx_var.get()
     finally:

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -11,6 +11,7 @@ import sys
 from collections import OrderedDict
 
 from .array import DenseArray, SparseArray
+from .ctx import default_ctx
 
 ###############################################################################
 #     Numpy initialization code (critical)                                    #
@@ -19,53 +20,6 @@ from .array import DenseArray, SparseArray
 # https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.import_array
 np.import_array()
 
-###############################################################################
-#     Global Ctx object                                                       #
-###############################################################################
-# Ctx used by default in all constructors
-# Users needing a specific context should pass their own context as kwarg.
-cdef Ctx _global_ctx = None
-def _get_global_ctx():
-    return _global_ctx
-
-def default_ctx(config = None):
-    """
-    Returns, and optionally initializes, the global default `tiledb.Ctx` object.
-
-    This Ctx object is used by Python API functions when no `ctx` keyword argument
-    is provided. Most API functions accept an optional `ctx` kwarg, but that
-    is typically only necessary in advanced usage with multiple contexts per
-    program.
-
-    For initialization, this function must be called before any other
-    tiledb functions. The initialization call accepts a  :py:class:`tiledb.Config`
-    object to override the defaults for process-global parameters.
-
-    :param config (default None): :py:class:`tiledb.Config` object or
-        dictionary with config parameters.
-    :return: Ctx
-    """
-    global _global_ctx
-    if _global_ctx is not None:
-        if config is not None:
-            raise TileDBError("Global context already initialized!")
-    else:
-        _global_ctx = Ctx(config)
-
-    return _global_ctx
-
-def initialize_ctx(config = None):
-    """
-    (deprecated) Please use `tiledb.default_ctx(config)`.
-
-    Initialize the TileDB-Py default Ctx. This function exists primarily to
-    allow configuration overrides for global per-process parameters, such as
-    the TBB thread count in particular.
-
-    :param config: Config object or dictionary with config parameters.
-    :return:  None
-    """
-    return default_ctx(config)
 
 ###############################################################################
 #    MODULAR IMPORTS                                                          #

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -3907,17 +3907,29 @@ class ContextTest(unittest.TestCase):
     def test_scope_ctx(self):
         key = "sm.tile_cache_size"
         ctx0 = tiledb.default_ctx()
-        assert ctx0.config()[key] == "10000000"
-        with tiledb.scope_ctx({key: 42}) as ctx1:
-            assert ctx1 is tiledb.default_ctx()
-            assert ctx1.config()[key] == "42"
-            with tiledb.scope_ctx({key: 6712}) as ctx2:
-                assert ctx2 is tiledb.default_ctx()
-                assert ctx2.config()[key] == "6712"
-            assert ctx1 is tiledb.default_ctx()
-            assert ctx1.config()[key] == "42"
-        assert ctx0 is tiledb.default_ctx()
-        assert ctx0.config()[key] == "10000000"
+        new_config_dict = {key: 42}
+        new_config = tiledb.Config({key: 78})
+        new_ctx = tiledb.Ctx({key: 61})
+
+        assert tiledb.default_ctx() is ctx0
+        assert tiledb.default_ctx().config()[key] == "10000000"
+
+        with tiledb.scope_ctx(new_config_dict) as ctx1:
+            assert tiledb.default_ctx() is ctx1
+            assert tiledb.default_ctx().config()[key] == "42"
+            with tiledb.scope_ctx(new_config) as ctx2:
+                assert tiledb.default_ctx() is ctx2
+                assert tiledb.default_ctx().config()[key] == "78"
+                with tiledb.scope_ctx(new_ctx) as ctx3:
+                    assert tiledb.default_ctx() is ctx3 is new_ctx
+                    assert tiledb.default_ctx().config()[key] == "61"
+                assert tiledb.default_ctx() is ctx2
+                assert tiledb.default_ctx().config()[key] == "78"
+            assert tiledb.default_ctx() is ctx1
+            assert tiledb.default_ctx().config()[key] == "42"
+
+        assert tiledb.default_ctx() is ctx0
+        assert tiledb.default_ctx().config()[key] == "10000000"
 
     def test_init_config(self):
         self.assertEqual(-1, init_test_wrapper())


### PR DESCRIPTION
### Problem description

Most `tiledb` functions and classes accept an optional `ctx` parameter. This is less than ideal for the following reasons:

- **Verbose**
Taking [examples/string_float_int_dimensions.py](https://github.com/TileDB-Inc/TileDB-Py/blob/dev/examples/string_float_int_dimensions.py#L43) as an example, `ctx` is initialized and passed to 6 different calls:

```
ctx = tiledb.Ctx()

dom = tiledb.Domain(
    *[
        tiledb.Dim(name="str_dim", domain=(None, None), dtype=np.bytes_, ctx=ctx),
        tiledb.Dim(name="int64_dim", domain=(0, 100), tile=10, dtype=np.int64, ctx=ctx),
        tiledb.Dim(
            name="float64_dim",
            domain=(-100.0, 100.0),
            tile=10,
            dtype=np.float64,
            ctx=ctx,
        ),
    ],
    ctx=ctx
)

att = tiledb.Attr(name="a", ctx=ctx, dtype=np.int64)
schema = tiledb.ArraySchema(
    ctx=ctx, domain=dom, attrs=(att,), sparse=True, capacity=10000
)
tiledb.SparseArray.create(path, schema)
```
- **Error-prone**
In the example above `ctx` is not passed to the `tiledb.SparseArray.create` call, most likely an accidental omission. In this particular example it doesn't matter because the default global `Ctx` instance is equal to `tiledb.Ctx()` but it could matter if `ctx` was initialized with a different `Config`. Such accidental omissions happen in several places in [tiledb.dataframe_](https://github.com/TileDB-Inc/TileDB-Py/blob/dev/tiledb/dataframe_.py).

- **Global variable**
A global `Ctx` instance can be initialized and used by default via `tiledb.default_ctx()`. This solves the above verbosity and error-proneness issues at the cost of introducing a global variable. In addition to the [usual drawbacks](https://wiki.c2.com/?GlobalVariablesAreBad) of global variables, the global `Ctx` can be initialized only once in a program's lifetime.

---

### Proposal
This PR introduces the following enhancements:
- Adds a new `tiledb.ctx(config=None)` context manager for specifying a `tiledb.Ctx` within a block of code. This `Ctx` is both returned by the context manager (for explicit usage) and set as "global" within the scope of the block (for implicit usage).
- Replaces the global variable default with a [ContextVar](https://www.python.org/dev/peps/pep-0567/) (introduced in Python 3.7 and available as 3rd party backport for 3.6). In short, a `ContextVar` can be thought of as a generalization of global or thread-local variables that also plays well with asynchronous (async/await) code.
- Removes the (long deprecated) `tiledb.initialize_ctx` function.

Once/if this is accepted, a following PR will clean up the redundant and/or verbose explicit `ctx` usage with appropriate `tiledb.ctx()` context blocks.
