### PR TITLE
Fix incorrect type for add_range with int8 dimension

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -436,7 +436,7 @@ public:
         break;
       }
       case TILEDB_INT8: {
-        using T = uint8_t;
+        using T = int8_t;
         query_->add_range(dim_idx, r0.cast<T>(), r1.cast<T>());
         break;
       }

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2901,7 +2901,6 @@ cdef class Domain(object):
         cdef Py_ssize_t ndim = len(dims)
         if ndim == 0:
             raise TileDBError("Domain must have ndim >= 1")
-        cdef Dim dimension = dims[0]
 
         if (ndim > 1):
             if all(dim.name == '__dim_0' for dim in dims):
@@ -2915,7 +2914,12 @@ cdef class Domain(object):
         if rc != TILEDB_OK:
             check_error(ctx, rc)
         assert(domain_ptr != NULL)
+
+        cdef Dim dimension
         for i in range(ndim):
+            if not isinstance(dims[i], Dim):
+                raise TypeError("Cannot create Domain with non-Dim value for 'dims' argument")
+
             dimension = dims[i]
             rc = tiledb_domain_add_dimension(
                 ctx.ptr, domain_ptr, dimension.ptr)
@@ -3340,8 +3344,12 @@ cdef class ArraySchema(object):
             tiledb_array_schema_free(&schema_ptr)
             _raise_ctx_err(ctx.ptr, rc)
         cdef tiledb_attribute_t* attr_ptr = NULL
+        cdef Attr attribute
         for attr in attrs:
-            attr_ptr = (<Attr> attr).ptr
+            if not isinstance(attr, Attr):
+                raise TypeError("Cannot create schema with non-Attr value for 'attrs' argument")
+            attribute = attr
+            attr_ptr = attribute.ptr
             rc = tiledb_array_schema_add_attribute(ctx.ptr, schema_ptr, attr_ptr)
             if rc != TILEDB_OK:
                 tiledb_array_schema_free(&schema_ptr)

--- a/tiledb/tests/fixtures.py
+++ b/tiledb/tests/fixtures.py
@@ -7,6 +7,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from tiledb.tests.common import assert_subarrays_equal, rand_utf8
 
+INTEGER_DTYPES = ["u1", "u2", "u4", "u8", "i1", "i2", "i4", "i8"]
+
 
 @pytest.fixture(scope="module", params=["hilbert", "row-major"])
 def sparse_cell_order(request):

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2611,8 +2611,12 @@ class TestSparseArray(DiskTestCase):
 
         tiledb.SparseArray.create(path, schema)
 
-        c1 = np.array([1, 2, 3, 4])
-        c2 = np.array([2, 1, 3, 4])
+        if tiledb.libtiledb.version() >= (2, 3) and sparse_cell_order == "hilbert":
+            c1 = np.array([2, 1, 3, 4])
+            c2 = np.array([1, 2, 3, 4])
+        else:
+            c1 = np.array([1, 2, 3, 4])
+            c2 = np.array([2, 1, 3, 4])
 
         data = np.array(
             [
@@ -2630,8 +2634,8 @@ class TestSparseArray(DiskTestCase):
         with tiledb.SparseArray(path) as A:
             res = A[:]
             assert_subarrays_equal(res[""], data)
-            assert_array_equal(res["__dim_0"], c1)
-            assert_array_equal(res["__dim_1"], c2)
+            assert_unordered_equal(res["__dim_0"], c1)
+            assert_unordered_equal(res["__dim_1"], c2)
 
     def test_sparse_mixed_domain_uint_float64(self, sparse_cell_order):
         path = self.path("mixed_domain_uint_float64")

--- a/tiledb/util.py
+++ b/tiledb/util.py
@@ -1,0 +1,37 @@
+import tiledb
+import numpy as np
+from typing import Iterable
+from tiledb.dataframe_ import ColumnInfo
+
+
+def _sparse_schema_from_dict(input_attrs, input_dims):
+    attr_infos = {k: ColumnInfo.from_values(v) for k, v in input_attrs.items()}
+    dim_infos = {k: ColumnInfo.from_values(v) for k, v in input_dims.items()}
+
+    dims = list()
+    for name, dim_info in dim_infos.items():
+        dim_dtype = np.bytes_ if dim_info.dtype == np.dtype("U") else dim_info.dtype
+        dtype_min, dtype_max = tiledb.libtiledb.dtype_range(dim_info.dtype)
+
+        if np.issubdtype(dim_dtype, np.integer):
+            dtype_max = dtype_max - 1
+        if np.issubdtype(dim_dtype, np.integer) and dtype_min < 0:
+            dtype_min = dtype_min + 1
+
+        dims.append(
+            tiledb.Dim(
+                name=name, domain=(dtype_min, dtype_max), dtype=dim_dtype, tile=1
+            )
+        )
+
+    attrs = list()
+    for name, attr_info in attr_infos.items():
+        dtype_min, dtype_max = tiledb.libtiledb.dtype_range(attr_info.dtype)
+
+        attrs.append(tiledb.Attr(name=name, dtype=dim_dtype))
+
+    return tiledb.ArraySchema(domain=tiledb.Domain(*dims), attrs=attrs, sparse=True)
+
+
+def schema_from_dict(attrs, dims):
+    return _sparse_schema_from_dict(attrs, dims)


### PR DESCRIPTION
- Fixes #572, due incorrect type used in `add_range` template call
- Adds regression tests for indexing with all integer dimension types