### PR TITLE
Relax numpy requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -489,8 +489,7 @@ def cmake_available():
 def setup_requires():
     req = [
         "cython>=0.27",
-        "numpy==1.16.* ; python_version < '3.9'",
-        "numpy ; python_version >= '3.9'",
+        "numpy>=1.16",
         "setuptools>=18.0",
         "setuptools_scm>=1.5.4",
         "wheel>=0.30",


### PR DESCRIPTION
Via user request to build on linux/aarch64 (ubuntu 20 on raspberry pi 4)

These requirements need to be applied during packaging for ABI compatibility, but should
not be applied to end-user builds-from-source. Pinned NumPy versions may not have binary
wheels available, forcing a build of *NumPy* from source (likely to fail due to
extensive dependencies). eg NumPy wheels are available on linux/aarch64
NumPy 1.20 but not 1.16.