### PR TITLE
Fix ch7727: correctly cap offset and validity buffer allocations

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# TileDB-Py 0.8.10 Release Notes
+
+## Improvements
+* Disabled libtiledb Werror compilation argument for from-source builds via setup.py [#574](https://github.com/TileDB-Inc/TileDB-Py/pull/574)
+* Relaxed NumPy version requirements for from-source builds via setup.py [#575](https://github.com/TileDB-Inc/TileDB-Py/pull/575)
+
 # TileDB-Py 0.8.9 Release Notes
 
 ## TileDB Embedded updates:

--- a/tiledb/tests/test_defects.py
+++ b/tiledb/tests/test_defects.py
@@ -1,0 +1,22 @@
+import numpy as np
+import tiledb
+
+from tiledb.tests.common import DiskTestCase
+
+
+class DefectTest(DiskTestCase):
+    def test_ch7727_float32_dim_estimate_incorrect(self):
+        # set max allocation: because windows won't overallocate
+        with tiledb.scope_ctx({"py.alloc_max_bytes": 1024 ** 2 * 100}):
+            uri = self.path()
+            dom = tiledb.Domain(tiledb.Dim("x", domain=(1, 100), dtype=np.float32))
+            att = tiledb.Attr("", dtype=np.bytes_)
+            schema = tiledb.ArraySchema(domain=dom, attrs=(att,), sparse=True)
+            tiledb.Array.create(uri, schema)
+
+            with tiledb.open(uri, mode="w") as T:
+                T[50.4] = b"hello"
+
+            with tiledb.open(uri, mode="r") as T:
+                assert T[:][""] == b"hello"
+                assert T[50.4][""] == b"hello"


### PR DESCRIPTION
- Fix and add test for ch7727
  - Correctly cap offset and validity buffer allocations in case of estimate overflow
- Set minimum for `alloc_max_bytes_` parameter to 1 MB or error out