### PR TITLE
Enable running TileDB-Py tests against s3

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,60 @@
+import tiledb
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--vfs", default="file")
+    parser.addoption("--vfs-config", default=None)
+
+
+def pytest_configure(config):
+    # default must be set here rather than globally
+    pytest.tiledb_vfs = "file"
+
+    vfs_config(config)
+
+
+def vfs_config(pytestconfig):
+    vfs_config_override = {}
+
+    vfs = pytestconfig.getoption("vfs")
+    if vfs == "s3":
+        pytest.tiledb_vfs = "s3"
+
+        vfs_config_override.update(
+            {
+                "vfs.s3.endpoint_override": "localhost:9999",
+                "vfs.s3.aws_access_key_id": "minio",
+                "vfs.s3.aws_secret_access_key": "miniosecretkey",
+                "vfs.s3.scheme": "https",
+                "vfs.s3.verify_ssl": False,
+                "vfs.s3.use_virtual_addressing": False,
+            }
+        )
+
+    vfs_config_arg = pytestconfig.getoption("vfs-config", None)
+    if vfs_config_arg:
+        pass
+
+    tiledb._orig_ctx = tiledb.Ctx
+
+    def get_config(config):
+        final_config = {}
+        if isinstance(config, tiledb.Config):
+            final_config = config.dict()
+        elif config:
+            final_config = config
+
+        final_config.update(vfs_config_override)
+        return final_config
+
+    class PatchedCtx(tiledb.Ctx):
+        def __init__(self, config=None):
+            super().__init__(get_config(config))
+
+    class PatchedConfig(tiledb.Config):
+        def __init__(self, params=None):
+            super().__init__(get_config(params))
+
+    tiledb.Ctx = PatchedCtx
+    tiledb.Config = PatchedConfig

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -17,11 +17,6 @@ stages:
         linux_py3:
           imageName: 'ubuntu-16.04'
           python.version: '3.6'
-        linux_py3_libtiledb23:
-          imageName: 'ubuntu-16.04'
-          python.version: '3.6'
-          TILEDB_VERSION: 'dev'
-          SYSTEM: ''
       maxParallel: 4
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.pytest.ini_options]
+python_classes = "*Test*"
+python_files = "test_*.py"
+testpaths = ["tiledb/tests"]
+addopts = "--ignore=tiledb/tests/perf --ignore=tiledb/tests/__pycache__"
+filterwarnings = [
+    "error",
+    "default::pytest.PytestWarning",
+    "default::DeprecationWarning:distributed"
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,0 @@
-[pytest]
-python_classes = *Test*
-python_files = "test_*.py"
-testpaths = tiledb/tests
-addopts = --ignore=tiledb/tests/perf --ignore=tiledb/tests/__pycache__
-filterwarnings =
-    error
-    default::pytest.PytestWarning
-    default::DeprecationWarning:distributed

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -6546,6 +6546,8 @@ class FileIO(io.RawIOBase):
     def write(self, buff):
         if not self.writable():
             raise IOError("cannot write to read-only FileIO handle")
+        if isinstance(buff, str):
+            buff = buff.encode()
         nbytes = len(buff)
         self.vfs.write(self.fh, buff)
         self._nbytes += nbytes

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -14,9 +14,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal, assert_equal
 
-global path_scheme
-path_scheme = ""
-
 
 def assert_tail_equal(a, *rest, **kwargs):
     """Assert that all arrays in target equal first array"""

--- a/tiledb/tests/test_compat.py
+++ b/tiledb/tests/test_compat.py
@@ -5,10 +5,16 @@ import tarfile
 import numpy as np
 from numpy.testing import assert_array_equal
 
+import pytest
 import tiledb
 from tiledb.tests.common import DiskTestCase
 
 
+# This test writes to local filesystem, skip
+#   TODO: unskip if we support transparent file ops on a VFS
+@pytest.mark.skipif(
+    pytest.tiledb_vfs != "file", reason="Do not run compat test against non-file VFS"
+)
 class TestBackwardCompatibility(DiskTestCase):
     def test_compat_tiledb_py_0_5_anon_attr_dense(self):
         # array written with the following script:

--- a/tiledb/tests/test_fragment_info.py
+++ b/tiledb/tests/test_fragment_info.py
@@ -147,15 +147,13 @@ class FragmentInfoTest(DiskTestCase):
                 fragment_info.timestamp_range(fragment_idx), (timestamp, timestamp)
             )
 
-            if uri[0] != "/":
-                uri = "/" + uri.replace("\\", "/")
-
-            expected_uri = "file://{uri}/__{ts}_{ts}".format(uri=uri, ts=timestamp)
+            expected_uri = "__{ts}_{ts}".format(uri=uri, ts=timestamp)
             actual_uri = fragment_info.fragment_uri(fragment_idx)
 
             all_expected_uris.append(expected_uri)
 
-            self.assertTrue(actual_uri.startswith(expected_uri))
+            # use .contains because the protocol can vary
+            self.assertTrue(expected_uri in actual_uri)
             self.assertTrue(
                 actual_uri.endswith(str(fragment_info.version(fragment_idx)))
             )
@@ -165,7 +163,7 @@ class FragmentInfoTest(DiskTestCase):
 
         all_actual_uris = fragment_info.fragment_uri()
         for actual_uri, expected_uri in zip(all_actual_uris, all_expected_uris):
-            self.assertTrue(actual_uri.startswith(expected_uri))
+            self.assertTrue(expected_uri in actual_uri)
             self.assertTrue(
                 actual_uri.endswith(str(fragment_info.version(fragment_idx)))
             )
@@ -214,12 +212,12 @@ class FragmentInfoTest(DiskTestCase):
             if uri[0] != "/":
                 uri = "/" + uri.replace("\\", "/")
 
-            expected_uri = "file://{uri}/__{ts}_{ts}".format(uri=uri, ts=timestamp)
+            expected_uri = "/__{ts}_{ts}".format(uri=uri, ts=timestamp)
             actual_uri = fragment_info.fragment_uri(fragment_idx)
 
             all_expected_uris.append(expected_uri)
 
-            self.assertTrue(actual_uri.startswith(expected_uri))
+            self.assertTrue(expected_uri in actual_uri)
             self.assertTrue(
                 actual_uri.endswith(str(fragment_info.version(fragment_idx)))
             )
@@ -229,7 +227,7 @@ class FragmentInfoTest(DiskTestCase):
 
         all_actual_uris = fragment_info.fragment_uri()
         for actual_uri, expected_uri in zip(all_actual_uris, all_expected_uris):
-            self.assertTrue(actual_uri.startswith(expected_uri))
+            self.assertTrue(expected_uri in actual_uri)
             self.assertTrue(
                 actual_uri.endswith(str(fragment_info.version(fragment_idx)))
             )
@@ -309,7 +307,7 @@ class FragmentInfoTest(DiskTestCase):
                 name="day",
                 domain=(np.datetime64("2010-01-01"), np.datetime64("2020")),
                 dtype="datetime64[D]",
-            ),
+            )
         )
         att = tiledb.Attr()
         schema = tiledb.ArraySchema(sparse=True, domain=dom, attrs=(att,))
@@ -467,8 +465,7 @@ class FragmentInfoTest(DiskTestCase):
         )
 
         tiledb.consolidate(
-            uri,
-            config=tiledb.Config(params={"sm.consolidation.mode": "fragment_meta"}),
+            uri, config=tiledb.Config(params={"sm.consolidation.mode": "fragment_meta"})
         )
 
         fragment_info.load()

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -3904,6 +3904,13 @@ class IncompleteTest(DiskTestCase):
         assert idx == len(full_data)
 
 
+class TestTest(DiskTestCase):
+    def test_path(self, pytestconfig):
+        path = self.path("foo")
+        if pytestconfig.getoption("vfs") == "s3":
+            assert path.startswith("s3://")
+
+
 # if __name__ == '__main__':
 #    # run a single example for in-process debugging
 #    # better to use `pytest --gdb` if available

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -3466,16 +3466,12 @@ class TestVFS(DiskTestCase):
             expected = expected + ("dir1", "dir2", "dir3")
 
         self.assertSetEqual(
+            set(expected),
             set(
-                os.path.normpath(os.path.join(p.netloc, p.path))
-                for p in map(
-                    lambda x: urllib.parse.urlsplit(os.path.join(basepath, x)), expected
+                map(
+                    lambda x: os.path.basename(x.split("test_vfs_ls")[1]),
+                    self.vfs.ls(basepath),
                 )
-            ),
-            set(
-                # vfs.ls includes drive on Windows
-                os.path.normpath(os.path.join(p.netloc, os.path.splitdrive(p.path)[1]))
-                for p in map(urllib.parse.urlsplit, self.vfs.ls(basepath))
             ),
         )
 


### PR DESCRIPTION
This PR makes it possible to run TileDB-Py tests against S3, replacing the sketch in #396. A new `--vfs` (default `"file"`) parameter is configured in pytest, used as:

```
pytest --vfs=s3
```

which will currently use local minio settings corresponding to the settings in the core `scripts/run-minio.sh` script.

Some tests are modified to run correctly against S3, for example using `tiledb.FileIO` and `tiledb.VFS` for directory and r/w file operations respectively, instead of using python local filesystem functions. A handful of tests are skipped if not feasible to modify at this point (eg it seems that `tiledb.Config` does not support loading a config from a URI).