### PR TITLE
Fix warnings on clang and gcc

### DIFF
--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -61,7 +61,7 @@ stages:
 
     - bash: |
         set -xeo pipefail
-        python setup.py build_ext --inplace
+        python setup.py build_ext --inplace --werror
         python setup.py install
       displayName: 'Build TileDB and TileDB-Py extension (POSIX)'
       condition: ne(variables['Agent.OS'], 'Windows_NT')

--- a/setup.py
+++ b/setup.py
@@ -538,11 +538,17 @@ for arg in args:
     if arg.find("--modular") == 0:
         TILEDBPY_MODULAR = True
         sys.argv.remove(arg)
+    TILEDBPY_WERROR = False
+    if arg.find("--werror") == 0:
+        TILEDBPY_WERROR = True
+        sys.argv.remove(arg)
 
 # Global variables
 CXXFLAGS = os.environ.get("CXXFLAGS", "").split()
 if not is_windows():
     CXXFLAGS.append("-std=c++11")
+    if TILEDBPY_WERROR or TILEDB_DEBUG_BUILD:
+        CXXFLAGS.append("-Werror")
     if not TILEDB_DEBUG_BUILD:
         CXXFLAGS.append("-Wno-deprecated-declarations")
     elif TILEDB_DEBUG_BUILD:
@@ -586,7 +592,9 @@ __extensions = [
         library_dirs=LIB_DIRS,
         libraries=LIBS,
         extra_link_args=LFLAGS,
-        extra_compile_args=CXXFLAGS,
+        extra_compile_args=CXXFLAGS.copy().remove("-Werror")
+        if CXXFLAGS.count("-Werror")
+        else CXXFLAGS,
         language="c++",
     ),
     Extension(

--- a/setup.py
+++ b/setup.py
@@ -605,7 +605,7 @@ __extensions = [
         library_dirs=LIB_DIRS,
         libraries=LIBS,
         extra_link_args=LFLAGS,
-        extra_compile_args=CXXFLAGS,
+        extra_compile_args=CXXFLAGS + ["-fvisibility=hidden"],
     ),
     Extension(
         "tiledb._fragment",
@@ -615,7 +615,7 @@ __extensions = [
         library_dirs=LIB_DIRS,
         libraries=LIBS,
         extra_link_args=LFLAGS,
-        extra_compile_args=CXXFLAGS,
+        extra_compile_args=CXXFLAGS + ["-fvisibility=hidden"],
     ),
     Extension(
         "tiledb._query_condition",

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -8,10 +8,6 @@
 #include <string>
 #include <vector>
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include "numpy/arrayobject.h"
-#undef NPY_NO_DEPRECATED_API
-
 #include "npbuffer.h"
 #include "util.h"
 #include <pybind11/numpy.h>

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -179,6 +179,29 @@ py::dtype tiledb_dtype(tiledb_datatype_t type, uint32_t cell_val_num) {
       return py::dtype("M8[fs]");
     case TILEDB_DATETIME_AS:
       return py::dtype("M8[as]");
+
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 3
+    /* duration types map to timedelta */
+    case TILEDB_TIME_HR:
+      return py::dtype("m8[h]");
+    case TILEDB_TIME_MIN:
+      return py::dtype("m8[m]");
+    case TILEDB_TIME_SEC:
+      return py::dtype("m8[s]");
+    case TILEDB_TIME_MS:
+      return py::dtype("m8[ms]");
+    case TILEDB_TIME_US:
+      return py::dtype("m8[us]");
+    case TILEDB_TIME_NS:
+      return py::dtype("m8[ns]");
+    case TILEDB_TIME_PS:
+      return py::dtype("m8[ps]");
+    case TILEDB_TIME_FS:
+      return py::dtype("m8[fs]");
+    case TILEDB_TIME_AS:
+      return py::dtype("m8[as]");
+#endif
+
     case TILEDB_ANY:
       break;
     }
@@ -503,6 +526,17 @@ public:
       case TILEDB_DATETIME_PS:
       case TILEDB_DATETIME_FS:
       case TILEDB_DATETIME_AS: {
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 3
+      case TILEDB_TIME_HR:
+      case TILEDB_TIME_MIN:
+      case TILEDB_TIME_SEC:
+      case TILEDB_TIME_MS:
+      case TILEDB_TIME_US:
+      case TILEDB_TIME_NS:
+      case TILEDB_TIME_PS:
+      case TILEDB_TIME_FS:
+      case TILEDB_TIME_AS:
+#endif
         py::dtype dtype = tiledb_dtype(tiledb_type, 1);
         auto dt0 = py::isinstance<py::int_>(r0) ? r0 : r0.attr("astype")(dtype);
         auto dt1 = py::isinstance<py::int_>(r1) ? r1 : r1.attr("astype")(dtype);

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -951,7 +951,8 @@ public:
       ssize_t final_validity_count = buf.validity_vals_read;
 
       assert(final_data_nbytes <= buf.data.size());
-      assert(final_offsets_count <= (ssize_t)(buf.offsets.size() + arrow_offset_size));
+      assert(final_offsets_count <=
+             (ssize_t)(buf.offsets.size() + arrow_offset_size));
 
       buf.data.resize({final_data_nbytes});
       buf.offsets.resize({final_offsets_count});

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <cmath>
 #include <cstring>
 #include <future>
 #include <iostream>

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -257,7 +257,7 @@ uint8_bool_to_uint8_bitmap(py::array_t<uint8_t> validity_array) {
 
 uint64_t count_zeros(py::array_t<uint8_t> a) {
   uint64_t count = 0;
-  for (size_t idx = 0; idx < a.size(); idx++)
+  for (ssize_t idx = 0; idx < a.size(); idx++)
     count += (a.data()[idx] == 0) ? 1 : 0;
   return count;
 }

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -924,7 +924,6 @@ public:
           now - start_incomplete_buffer_update;
     }
 
-    auto start_incomplete = std::chrono::high_resolution_clock::now();
     {
       py::gil_scoped_release release;
       query_->submit();
@@ -1092,7 +1091,6 @@ public:
     }
 
     if (g_stats) {
-      auto now = std::chrono::high_resolution_clock::now();
       g_stats.get()->counters["py.query_retries_count"] += TimerType(retries_);
     }
     std::cout << "retries: " << retries_ << std::endl;

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -766,7 +766,7 @@ public:
       result.append(b.data);
       result.append(b.offsets);
     }
-    return result;
+    return std::move(result);
   }
 
   void set_buffers() {
@@ -1300,14 +1300,13 @@ public:
         auto est_sizes = query_->est_result_size_var(name);
         est_offsets = std::get<0>(est_sizes);
         est_data_bytes = std::get<1>(est_sizes);
-        est_offsets = est_offsets;
       } else {
         est_data_bytes = query_->est_result_size(name);
       }
       results[py::str(name)] = py::make_tuple(est_offsets, est_data_bytes);
     }
 
-    return results;
+    return std::move(results);
   }
 
   py::array _test_array() {

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -946,12 +946,12 @@ public:
       auto name = bp.first;
       auto &buf = bp.second;
 
-      auto final_data_nbytes = buf.data_vals_read * buf.elem_nbytes;
-      auto final_offsets_count = buf.offsets_read + arrow_offset_size;
-      auto final_validity_count = buf.validity_vals_read;
+      ssize_t final_data_nbytes = buf.data_vals_read * buf.elem_nbytes;
+      ssize_t final_offsets_count = buf.offsets_read + arrow_offset_size;
+      ssize_t final_validity_count = buf.validity_vals_read;
 
       assert(final_data_nbytes <= buf.data.size());
-      assert(final_offsets_count <= buf.offsets.size() + arrow_offset_size);
+      assert(final_offsets_count <= (ssize_t)(buf.offsets.size() + arrow_offset_size));
 
       buf.data.resize({final_data_nbytes});
       buf.offsets.resize({final_offsets_count});

--- a/tiledb/fragment.cc
+++ b/tiledb/fragment.cc
@@ -94,7 +94,7 @@ public:
     for (uint32_t fid = 0; fid < nfrag; ++fid)
       all_frags.append(get_non_empty_domain(schema, fid));
 
-    return all_frags;
+    return std::move(all_frags);
   }
 
   py::tuple get_non_empty_domain(py::object schema, uint32_t fid) const {
@@ -104,7 +104,7 @@ public:
     for (int did = 0; did < ndim; ++did)
       all_dims.append(get_non_empty_domain(schema, fid, did));
 
-    return all_dims;
+    return std::move(all_dims);
   }
 
   template <typename T>
@@ -134,7 +134,7 @@ public:
                               datetime64(dates[1], datetime_data(type)));
     }
 
-    return limits;
+    return std::move(limits);
   }
 
   py::bool_ get_dim_isvar(py::object dom, uint32_t did) const {

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -6,10 +6,6 @@
 #include <string>
 #include <vector>
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include "numpy/arrayobject.h"
-#undef NPY_NO_DEPRECATED_API
-
 #include "util.h"
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -85,8 +85,8 @@ private:
     // For consistency and to avoid complications in other APIs, we are storing
     // all string arrays as var-length.
 
-    size_t input_itemsize = input_.itemsize();
-    assert(input_itemsize > 0); // must have fixed-length array
+    // must have fixed-width element
+    assert(input_.itemsize() > 0);
 
     // we know exact offset count
     offset_buf_->resize(input_len_);
@@ -152,8 +152,7 @@ private:
   void convert_bytes() {
     // Convert array of bytes objects or ASCII strings to buffer+offsets
 
-    size_t input_itemsize = input_.itemsize();
-    assert(input_itemsize > 0); // must have fixed-length array
+    assert(input_.itemsize() > 0); // must have fixed-length array
 
     // we know exact offset count
     offset_buf_->resize(input_len_);
@@ -311,7 +310,6 @@ private:
         // TODO error check?
         PyBytes_AsStringAndSize(pyobj_p, const_cast<char **>(&input_p), &sz);
       } else if (api.PyArray_Check_(pyobj_p)) {
-        auto pao = (PyArrayObject *)pyobj_p;
         auto arr = py::cast<py::array>(pyobj_p);
         sz = arr.nbytes();
         input_p = (const char *)arr.data();

--- a/tiledb/query_condition.cc
+++ b/tiledb/query_condition.cc
@@ -92,8 +92,8 @@ public:
         ctx_.ptr().get(), qc_->ptr().get(), rhs.qc_->ptr().get(),
         combination_op, &combined_qc));
 
-    pyqc.qc_ = std::move(std::shared_ptr<QueryCondition>(
-        new QueryCondition(pyqc.ctx_, combined_qc)));
+    pyqc.qc_ = std::shared_ptr<QueryCondition>(
+        new QueryCondition(pyqc.ctx_, combined_qc));
 
     return pyqc;
   }

--- a/tiledb/util.h
+++ b/tiledb/util.h
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #ifndef TILEDB_PY_UTIL_H
 #define TILEDB_PY_UTIL_H
 


### PR DESCRIPTION
This PR fixes all errors in C++ code under `-Werror`, and enables that option. Cython currently excluded.