### PR TITLE
Add Array.open support for timestamp ranges

### DIFF
--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -625,6 +625,26 @@ cdef extern from "tiledb/tiledb.h":
         const tiledb_array_schema_t* array_schema,
         FILE* out)
 
+    int tiledb_array_get_open_timestamp_start(
+        tiledb_ctx_t* ctx,
+        tiledb_array_t* array,
+        uint64_t* timestamp_start)
+
+    int tiledb_array_get_open_timestamp_end(
+        tiledb_ctx_t* ctx,
+        tiledb_array_t* array,
+        uint64_t* timestamp_end)
+
+    int tiledb_array_set_open_timestamp_start(
+        tiledb_ctx_t* ctx,
+        tiledb_array_t* array,
+        uint64_t timestamp_start)
+
+    int tiledb_array_set_open_timestamp_end(
+        tiledb_ctx_t* ctx,
+        tiledb_array_t* array,
+        uint64_t timestamp_end)
+
     int tiledb_array_put_metadata(
         tiledb_ctx_t* ctx,
         tiledb_array_t* array,


### PR DESCRIPTION
tiledb.Array.open `timestamp` kwarg now supports a tuple of `(start: Int, end: Int)`
to open the array within a specific timestamp range.

Example:

```
    with tiledb.open(path, timestamp=(1234, 5678)) as A:
        ... # read A considering only fragments between
            #   (1234, 5678)
            # both endpoints inclusive
```

The existing `timestamp: Int` kwarg signature is unchanged.