### PR TITLE
Updates for 0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# project.toml: Forces build isolation and other problems; ecosystem still spotty.
+pyproject.toml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,9 @@
 ## Improvements
 * Addition of `QueryCondition` API to filter query on attributes [#576](https://github.com/TileDB-Inc/TileDB-Py/pull/576)
 
+## API Changes
+* `from_dataframe` function has been removed; deprecated in TileDB-Py 0.6 and replaced by `from_pandas`.
+
 # TileDB-Py 0.8.11 Release Notes
 
 ## Bug fixes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@
 * TileDB-Py 0.9.0 includes TileDB Embedded [TileDB 2.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.3) with a significant
   number of new features and improvements.
 
+## Improvements
+* Addition of `QueryCondition` API to filter query on attributes [#576](https://github.com/TileDB-Inc/TileDB-Py/pull/576)
+
 # TileDB-Py 0.8.11 Release Notes
 
 ## Bug fixes
@@ -37,7 +40,6 @@
 * Dataframe creation uses Zstd default compression level (-1) [#552](https://github.com/TileDB-Inc/TileDB-Py/pull/552)
 * Rename Fragment Info API's `non_empty_domain` attribute to `nonempty_domain` [#553](https://github.com/TileDB-Inc/TileDB-Py/pull/553)
 * Added configuration option `py.alloc_max_bytes` to control maximum initial buffer allocation [#557](https://github.com/TileDB-Inc/TileDB-Py/pull/557)
-* Addition of `QueryCondition` API to filter query on attributes [#576](https://github.com/TileDB-Inc/TileDB-Py/pull/576)
 
 ## Bug fixes
 * Fixed incorrected error raised in .df[] indexer when pyarrow not installed [#554](https://github.com/TileDB-Inc/TileDB-Py/pull/554)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,11 +4,20 @@
 * TileDB-Py 0.9.0 includes TileDB Embedded [TileDB 2.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.3) with a significant
   number of new features and improvements.
 
+## Packaging Notes
+* Windows wheels are now built with TileDB Cloud REST support enabled [#541](https://github.com/TileDB-Inc/TileDB-Py/pull/541)
+
 ## Improvements
 * Addition of `QueryCondition` API to filter query on attributes [#576](https://github.com/TileDB-Inc/TileDB-Py/pull/576)
 
+## Bug Fixes
+* Fixed `from_pandas` append error for sparse arrayse: no need to specify 'row_start_idx' [#593](https://github.com/TileDB-Inc/TileDB-Py/pull/593)
+* Fixed 'index_dims' kwarg handling for `from_pandas` [#590](https://github.com/TileDB-Inc/TileDB-Py/pull/590)
+
 ## API Changes
 * `from_dataframe` function has been removed; deprecated in TileDB-Py 0.6 and replaced by `from_pandas`.
+
+---
 
 # TileDB-Py 0.8.11 Release Notes
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# TileDB-Py 0.9.0 Release Notes
+
+## TileDB Embedded updates:
+* TileDB-Py 0.9.0 includes TileDB Embedded [TileDB 2.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.3) with a significant
+  number of new features and improvements.
+
 # TileDB-Py 0.8.11 Release Notes
 
 ## Bug fixes

--- a/doc/local-build.sh
+++ b/doc/local-build.sh
@@ -56,7 +56,8 @@ setup_venv() {
   source "${venv_dir}/bin/activate" || die "could not activate virtualenv"
   pip install 'Sphinx==1.6.7' \
        'breathe' \
-       'sphinx_rtd_theme' || die "could not install doc dependencies"
+       'sphinx_rtd_theme' \
+       -r ../requirements_dev.txt || die "could not install doc dependencies"
 }
 
 build_ext() {

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -1,9 +1,9 @@
 stages:
 - stage: Release
   variables:
-    TILEDBPY_VERSION: 0.8.10
-    LIBTILEDB_VERSION: 2.2.9
-    LIBTILEDB_SHA: dc3bb54adc9bb0d99cb3f56ede2ab5b14e62ab76
+    TILEDBPY_VERSION: 0.9.0
+    LIBTILEDB_VERSION: 2.3.0
+    LIBTILEDB_SHA: a87da7fa4293698f02473e5d0757a92bfdcc85a8
     LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
     SDKROOT: '/Applications/Xcode_10.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk'
     TILEDB_SRC: '$(Build.Repository.Localpath)/tiledb_src'

--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -1,15 +1,13 @@
-setuptools
-contextvars ;python_version<"3.7"
-dataclasses ;python_version<"3.7"
-
 # numpy pinning for ABI forward-compatibility
 numpy==1.16.5 ; python_version < "3.9"
 numpy==1.19.4 ; python_version >= "3.9"
 
-# note: cmake 3.13 is the last manylinux1 release on pypi
-cmake >= 3.13
-
-cython
-pybind11
-wheel
-setuptools-scm
+#-------------------------------
+# sync with requirements_dev.txt
+cython >= 0.27
+pybind11 >= 2.6.2
+setuptools >= 18.0
+setuptools_scm >= 1.5.4
+wheel >= 0.30
+contextvars ;python_version<"3.7"
+dataclasses ;python_version<"3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy>=1.16.*
-setuptools
+numpy>=1.16.5
 contextvars ;python_version<"3.7"
 dataclasses ;python_version<"3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,10 +1,13 @@
 # note: cmake 3.13 is the last manylinux1 release on pypi
 cmake >= 3.13
-cython
-pybind11
-wheel
-setuptools-scm
-tox
-# numpy 1.20 dropped python 3.6 support
-numpy<1.20 ; python_version < "3.7"
--r requirements.txt
+numpy >= 1.16.5
+
+# -------------------------------------
+# sync with misc/requirements_wheel.txt
+cython >= 0.27
+pybind11 >= 2.6.2
+setuptools >= 18.0
+setuptools_scm >= 1.5.4
+wheel >= 0.30
+contextvars ;python_version<"3.7"
+dataclasses ;python_version<"3.7"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import Extension, find_packages, setup
 print("setup.py sys.argv is: ", sys.argv)
 
 # Target branch
-TILEDB_VERSION = "dev"
+TILEDB_VERSION = "2.3.0"
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION
 

--- a/setup.py
+++ b/setup.py
@@ -495,7 +495,9 @@ def cmake_available():
 def setup_requires():
     req = [
         "cython>=0.27",
-        "numpy>=1.16",
+        "numpy==1.16.* ; python_version < '3.9' and 'arm' not in platform_machine",
+        "numpy ; python_version >= '3.9' and 'arm' not in platform_machine",
+        "numpy ; 'arm' in platform_machine",
         "setuptools>=18.0",
         "setuptools_scm>=1.5.4",
         "wheel>=0.30",

--- a/setup.py
+++ b/setup.py
@@ -487,6 +487,8 @@ def cmake_available():
     Checks whether CMake command is available and >= version 3.3.
     :return:
     """
+    CMAKE_MINIMUM_MAJOR = 3
+    CMAKE_MINIMUM_MINOR = 3
     try:
         output = subprocess.check_output(["cmake", "--version"]).split()
         version = output[2].decode("utf-8").split(".")
@@ -509,6 +511,10 @@ def setup_requires():
     else:
         req = parse_requirements("requirements_dev.txt")
         req = list(filter(lambda r: not r.startswith("-r"), req))
+
+    # Add cmake requirement if libtiledb is not found and cmake is not available.
+    if not libtiledb_exists(LIB_DIRS) and not cmake_available():
+        req.append("cmake>=3.11.0")
 
     return req
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ if sys.platform == "darwin":
         if python_target < "10.9" and current_system >= "10.9":
             os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
 
+# Is this process building a wheel?
+WHEEL_BUILD = ("bdist_wheel" in sys.argv) or ("TILEDB_WHEEL_BUILD" in os.environ)
+
 
 def is_windows():
     return os.name == "nt"
@@ -487,25 +490,26 @@ def cmake_available():
     try:
         output = subprocess.check_output(["cmake", "--version"]).split()
         version = output[2].decode("utf-8").split(".")
-        return int(version[0]) >= 3 and int(version[1]) >= 3
+        return (
+            int(version[0]) >= CMAKE_MINIMUM_MAJOR
+            and int(version[1]) >= CMAKE_MINIMUM_MINOR
+        )
     except:
         return False
 
 
+def parse_requirements(req_file):
+    with open(req_file) as f:
+        return f.read().strip().split("\n")
+
+
 def setup_requires():
-    req = [
-        "cython>=0.27",
-        "numpy==1.16.* ; python_version < '3.9' and 'arm' not in platform_machine",
-        "numpy ; python_version >= '3.9' and 'arm' not in platform_machine",
-        "numpy ; 'arm' in platform_machine",
-        "setuptools>=18.0",
-        "setuptools_scm>=1.5.4",
-        "wheel>=0.30",
-        "pybind11>=2.6.2",
-    ]
-    # Add cmake requirement if libtiledb is not found and cmake is not available.
-    if not libtiledb_exists(LIB_DIRS) and not cmake_available():
-        req.append("cmake>=3.11.0")
+    if WHEEL_BUILD:
+        req = parse_requirements("misc/requirements_wheel.txt")
+    else:
+        req = parse_requirements("requirements_dev.txt")
+        req = list(filter(lambda r: not r.startswith("-r"), req))
+
     return req
 
 
@@ -664,7 +668,7 @@ def ext_attr_update(attr, value):
 # some of these will error out if passed directly
 # to Extension(..) above
 
-if ("bdist_wheel" in sys.argv) or ("TILEDB_WHEEL_BUILD" in os.environ):
+if WHEEL_BUILD:
     ext_attr_update("tiledb_wheel_build", True)
 
 
@@ -709,12 +713,7 @@ setup(
     },
     ext_modules=__extensions,
     setup_requires=setup_requires(),
-    install_requires=[
-        "numpy>=1.16",
-        "wheel>=0.30",
-        "contextvars ;python_version<'3.7'",
-        "dataclasses ;python_version<'3.7'",
-    ],
+    install_requires=parse_requirements("requirements.txt"),
     packages=find_packages(),
     cmdclass=LazyCommandClass(),
     zip_safe=False,

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -84,7 +84,7 @@ from .highlevel import open, save, from_numpy, empty_like, array_exists, array_f
 from .query_condition import QueryCondition
 
 # TODO restricted imports
-from .dataframe_ import from_csv, from_pandas, from_dataframe, open_dataframe
+from .dataframe_ import from_csv, from_pandas, open_dataframe
 from .multirange_indexing import EmptyRange
 from .parquet_ import from_parquet
 

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1093,7 +1093,6 @@ public:
     if (g_stats) {
       g_stats.get()->counters["py.query_retries_count"] += TimerType(retries_);
     }
-    std::cout << "retries: " << retries_ << std::endl;
 
     resize_output_buffers();
 

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -384,16 +384,6 @@ def _df_to_np_arrays(df, column_infos, fillna):
     return ret, nullmaps
 
 
-def from_dataframe(uri, dataframe, **kwargs):
-    # deprecated in 0.6.3
-    warnings.warn(
-        "tiledb.from_dataframe is deprecated; please use .from_pandas",
-        DeprecationWarning,
-    )
-
-    from_pandas(uri, dataframe, **kwargs)
-
-
 def from_pandas(uri, dataframe, **kwargs):
     """Create TileDB array at given URI from a Pandas dataframe
 

--- a/tiledb/debug.cc
+++ b/tiledb/debug.cc
@@ -1,5 +1,8 @@
 #include <pybind11/embed.h>
 
+#ifndef TILEDBPY_DEBUGCC
+#define TILEDBPY_DEBUGCC
+
 namespace {
 extern "C" {
 
@@ -68,3 +71,5 @@ __attribute__((used)) static void pyerror() {
 }
 }
 }; // namespace
+
+#endif

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -4682,8 +4682,11 @@ cdef class DenseArrayImpl(Array):
         :param order: 'C', 'F', 'U', or 'G' (row-major, col-major, unordered, TileDB global order)
         :param use_arrow: if True, return dataframes via PyArrow if applicable.
         :param return_arrow: if True, return results as a PyArrow Table if applicable.
-        :param return_incomplete: if True, initialize and return a query which will return
-            iterable objects over the indexed range. See usage example in 'examples/incomplete_iteration.py'.
+        :param return_incomplete: if True, initialize and return an iterable Query object over the indexed range.
+            Consuming this iterable returns a result set for each TileDB incomplete query.
+            See usage example in 'examples/incomplete_iteration.py'.
+            To retrieve the estimated result sizes for the query ranges, use:
+                `A.query(..., return_incomplete=True)[...].est_result_size()`
             If False (default False), queries will be internally run to completion by resizing buffers and
             resubmitting until query is complete.
         :return: A proxy Query object that can be used for indexing into the DenseArray

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -390,13 +390,13 @@ class AttributeTest(DiskTestCase):
             # (str, "defg"),
             (np.float32, np.float32(0.4023573667780681)),
             (np.float64, np.float64(0.0560602549760851)),
-            (np.datetime64("", "ns"), np.timedelta64(11, "ns")),
+            (np.dtype("M8[ns]"), np.timedelta64(11, "ns")),
             (np.dtype([("f0", "<i4"), ("f1", "<i4"), ("f2", "<i4")]), (1, 2, 3)),
         ],
     )
     def test_attribute_fill(self, dtype, fill):
         attr = tiledb.Attr("", dtype=dtype, fill=fill)
-        assert np.array(attr.fill).item() == fill
+        assert np.array(attr.fill, dtype=dtype) == np.array(fill, dtype=dtype)
 
         path = self.path()
         dom = tiledb.Domain(tiledb.Dim(domain=(0, 0), tile=1, dtype=np.int64))
@@ -404,11 +404,11 @@ class AttributeTest(DiskTestCase):
         tiledb.DenseArray.create(path, schema)
 
         with tiledb.open(path) as R:
-            assert R.multi_index[0][""].item() == fill
-            assert R[0].item() == fill
+            assert R.multi_index[0][""] == np.array(fill, dtype=dtype)
+            assert R[0] == np.array(fill, dtype=dtype)
             if not hasattr(dtype, "fields"):
                 # record type unsupported for .df
-                assert R.df[0][""].values.item() == fill
+                assert R.df[0][""].values == np.array(fill, dtype=dtype)
 
     def test_full_attribute(self):
         filter_list = tiledb.FilterList([tiledb.ZstdFilter(10)])


### PR DESCRIPTION
- Bump version to 0.9; libtiledb target to 2.3.0
- Remove deprecated function `from_dataframe`
- Improve `requirements{,_dev/_wheel}.txt` setup.py handling to allow single source of truth
- Add doc for `est_result_size` with Query(return_incomplete=True)
- Misc other fixes