### PR TITLE
Check test output

### DIFF
--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -5,6 +5,7 @@ import os
 import random
 import shutil
 import subprocess
+import sys
 import tempfile
 import traceback
 import tiledb
@@ -337,11 +338,14 @@ def assert_all_arrays_equal(*arrays):
 
 
 def assert_captured(cap, expected):
-    import ctypes
+    if sys.platform == "win32":
+        return
+    else:
+        import ctypes
 
-    libc = ctypes.CDLL(None)
-    libc.fflush(None)
+        libc = ctypes.CDLL(None)
+        libc.fflush(None)
 
-    out, err = cap.readouterr()
-    assert not err
-    assert expected in out
+        out, err = cap.readouterr()
+        assert not err
+        assert expected in out

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -121,6 +121,12 @@ class DiskTestCase:
         assert args[0] == args[1]
 
     @contextlib.contextmanager
+    def assertNotEqual(self, *args):
+        if not len(args) == 2:
+            raise Exception("Unexpected input len > 2 to assertEquals")
+        assert args[0] != args[1]
+
+    @contextlib.contextmanager
     def assertTrue(self, a, msg=None):
         if msg:
             assert a, msg

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -334,3 +334,14 @@ def assert_all_arrays_equal(*arrays):
 
     for a1, a2 in zip(arrays[0::2], arrays[1::2]):
         assert_array_equal(a1, a2)
+
+
+def assert_captured(cap, expected):
+    import ctypes
+
+    libc = ctypes.CDLL(None)
+    libc.fflush(None)
+
+    out, err = cap.readouterr()
+    assert not err
+    assert expected in out

--- a/tiledb/tests/conftest.py
+++ b/tiledb/tests/conftest.py
@@ -1,16 +1,17 @@
+import ctypes
 import pytest
+import sys
 
+if sys.platform != "win32":
 
-@pytest.fixture(scope="function", autouse=True)
-def no_output(capfd):
-    yield
+    @pytest.fixture(scope="function", autouse=True)
+    def no_output(capfd):
+        yield
 
-    # flush stdout
-    import ctypes
+        # flush stdout
+        libc = ctypes.CDLL(None)
+        libc.fflush(None)
 
-    libc = ctypes.CDLL(None)
-    libc.fflush(None)
-
-    out, err = capfd.readouterr()
-    if out or err:
-        pytest.fail(f"Output captured: {out + err}")
+        out, err = capfd.readouterr()
+        if out or err:
+            pytest.fail(f"Output captured: {out + err}")

--- a/tiledb/tests/conftest.py
+++ b/tiledb/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def no_output(capfd):
+    yield
+
+    # flush stdout
+    import ctypes
+
+    libc = ctypes.CDLL(None)
+    libc.fflush(None)
+
+    out, err = capfd.readouterr()
+    if out or err:
+        pytest.fail(f"Output captured: {out + err}")

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -9,6 +9,12 @@ from tiledb.tests.common import DiskTestCase
 import numpy as np
 from numpy.testing import assert_array_equal, assert_approx_equal
 
+# override the no_output fixture because it conflicts with these tests
+#   eg: "ResourceWarning: unclosed event loop"
+@pytest.fixture(scope="function", autouse=True)
+def no_output():
+    pass
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 class TestDaskSupport(DiskTestCase):

--- a/tiledb/tests/test_examples.py
+++ b/tiledb/tests/test_examples.py
@@ -7,6 +7,11 @@ import tempfile
 
 import pytest
 
+# override locally to avoid conflict with capsys used below
+@pytest.fixture(scope="function", autouse=True)
+def no_output():
+    pass
+
 
 class ExamplesTest:
     """Test runnability of scripts in examples/"""
@@ -41,7 +46,7 @@ class ExamplesTest:
     @pytest.mark.parametrize(
         "path", [os.path.join(PROJECT_DIR, "tiledb", "libtiledb.pyx")]
     )
-    def test_docs(self, path, capfd):
+    def test_docs(self, path, capsys):
         failures, _ = doctest.testfile(
             path,
             module_relative=False,
@@ -49,4 +54,4 @@ class ExamplesTest:
             optionflags=doctest.NORMALIZE_WHITESPACE,
         )
         if failures:
-            pytest.fail(capfd.readouterr().out)
+            pytest.fail(capsys.readouterr().out)

--- a/tiledb/tests/test_examples.py
+++ b/tiledb/tests/test_examples.py
@@ -41,7 +41,7 @@ class ExamplesTest:
     @pytest.mark.parametrize(
         "path", [os.path.join(PROJECT_DIR, "tiledb", "libtiledb.pyx")]
     )
-    def test_docs(self, path, capsys):
+    def test_docs(self, path, capfd):
         failures, _ = doctest.testfile(
             path,
             module_relative=False,
@@ -49,4 +49,4 @@ class ExamplesTest:
             optionflags=doctest.NORMALIZE_WHITESPACE,
         )
         if failures:
-            pytest.fail(capsys.readouterr().out)
+            pytest.fail(capfd.readouterr().out)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -3954,6 +3954,15 @@ class TestTest(DiskTestCase):
         if pytestconfig.getoption("vfs") == "s3":
             assert path.startswith("s3://")
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="no_output fixture disabled on Windows"
+    )
+    @pytest.mark.xfail(
+        True, reason="This test prints, and should fail because of no_output fixture!"
+    )
+    def test_no_output(self):
+        print("this test should fail")
+
 
 # if __name__ == '__main__':
 #    # run a single example for in-process debugging


### PR DESCRIPTION
This PR adds a fixture to use pytest capturing in order capture all stdout, for two
use-cases:

  (1) by default assert that no output is written
  (2) if capfd is manually requested for test, we can get
      override the no_output assertion and check
      for expected output (when using functions that are expected
      to write to stdout)

Important details:
  - capfd does not flush, so we use libc.fflush to ensure that capfd
    actually gets all output
  - for test_examples, we need to add a no-op `no_output` signature
    which does not take capfd; otherwise, there will be a conflict
    with the usage of capsys in test_docs