### PR TITLE
Fix readthedocs build

### DIFF
--- a/doc/local-build.sh
+++ b/doc/local-build.sh
@@ -57,7 +57,7 @@ setup_venv() {
   pip install 'Sphinx==1.6.7' \
        'breathe' \
        'sphinx_rtd_theme' \
-       -r ../requirements_dev.txt || die "could not install doc dependencies"
+       -r requirements_doc.txt || die "could not install doc dependencies"
 }
 
 build_ext() {

--- a/doc/requirements_doc.txt
+++ b/doc/requirements_doc.txt
@@ -1,0 +1,4 @@
+# note: cmake 3.13 is the last manylinux1 release on pypi
+cmake >= 3.13
+
+-r ../requirements_dev.txt


### PR DESCRIPTION
I forgot that readthedocs requires cmake to be installed manually because it (currently) builds libtiledb from source.
Add a new doc/requirements_doc.txt file to make pip install cmake as part of the rtd build.

(cmake from pip was just removed in commit 30c60fcbe74)