### PR TITLE
Wheel build fixes for 0.9.3

### DIFF
--- a/misc/azure-libtiledb-darwin.yml
+++ b/misc/azure-libtiledb-darwin.yml
@@ -28,9 +28,6 @@ steps:
 
     $TILEDB_SRC/bootstrap --force-build-all-deps --disable-werror --enable=s3,gcs,azure,serialization --enable-static-tiledb --disable-avx2 --disable-tests --prefix=$TILEDB_INSTALL
 
-    export CXXFLAGS="-Wno-unused-parameter -lrt -DKJ_USE_EPOLL10 -D__BIONIC__=1"
-    export CFLAGS="-Wno-unused-parameter -lrt -DKJ_USE_EPOLL=0 -D__BIONIC__=1"
-
     cmake --build $TILEDB_BUILD --config Release -j3
     cmake --build $TILEDB_BUILD --target install-tiledb --config Release
 

--- a/misc/azure-libtiledb-darwin.yml
+++ b/misc/azure-libtiledb-darwin.yml
@@ -4,6 +4,7 @@ steps:
     key: 'libtiledb | "$(Agent.OS)" | "$(imageName)" | "$(LIBTILEDB_SHA)" | v2'
     path: $(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)
     cacheHitVar: LIBTILEDB_CACHE_RESTORED
+  condition: not(startsWith(variables['Build.SourceBranchName'], 'release-'))
 
 - bash: |
     find $PIPELINE_WORKSPACE/.libtiledb_dist/${LIBTILEDB_SHA}
@@ -65,7 +66,7 @@ steps:
     if [[ "$AGENT_OS" == "Windows_NT" ]]; then
       7z a ${TILEDB_INSTALL}/libtiledb-${LIBTILEDB_VERSION}-${LIBTILEDB_SHA} ${TILEDB_INSTALL}/*
     elif [[ "$AGENT_OS" == "Darwin" ]]; then
-      tar -czf ${TILEDB_INSTALL}/libtiledb-${LIBTILEDB_VERSION}-${LIBTILEDB_SHA} -C ${TILEDB_INSTALL} . 
+      tar -czf ${TILEDB_INSTALL}/libtiledb-${LIBTILEDB_VERSION}-${LIBTILEDB_SHA} -C ${TILEDB_INSTALL} .
     else
       tar -czf ${TILEDB_INSTALL}/libtiledb-${LIBTILEDB_VERSION}-${LIBTILEDB_SHA} -C ${TILEDB_INSTALL} lib64 include
     fi

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -99,6 +99,8 @@ stages:
         export TILEDB_INSTALL=.libtiledb
         export TILEDB_WHEEL_BUILD=1
         export CIBW_ENVIRONMENT="TILEDB_PATH=${TILEDB_INSTALL}"
+        # copy libtiledb into usr/local for audithweel to find
+        export CIBW_BEFORE_BUILD="cp -R .libtiledb/* /usr/local"
         ls -lR "${TILEDB_INSTALL}"
 
         python -c "import os; print(os.environ.get('CIBW_ENVIRONMENT', None))"

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -30,6 +30,9 @@ stages:
 
   - job: build1_libtiledb_on_linux
     container: quay.io/pypa/manylinux2010_x86_64:2021-06-07-00faba2
+    variables:
+      CXXFLAGS: "-Wno-unused-parameter -lrt -DKJ_USE_EPOLL10 -D__BIONIC__=1"
+      CFLAGS: "-Wno-unused-parameter -lrt -DKJ_USE_EPOLL=0 -D__BIONIC__=1"
     steps:
     - task: UsePythonVersion@0
     - template: azure-libtiledb-darwin.yml

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -27,7 +27,7 @@ stages:
     steps:
     - task: UsePythonVersion@0
     - template: azure-libtiledb-darwin.yml
-  
+
   - job: build1_libtiledb_on_linux
     container: quay.io/pypa/manylinux2010_x86_64:2021-06-07-00faba2
     steps:
@@ -43,7 +43,7 @@ stages:
       matrix:
         linux_py:
           imageName: 'ubuntu-20.04'
-          CIBW_SKIP: 'cp27-* cp35-* *_i686 pp*' 
+          CIBW_SKIP: 'cp27-* cp35-* *_i686 pp*'
           CIBW_BUILD_VERBOSITY: 3
         macOS_py:
           imageName: 'macOS-10.15'
@@ -94,11 +94,11 @@ stages:
 
     - bash: |
         set -xe pipefail
-      
+
         mv ${TILEDB_INSTALL} .libtiledb
         export TILEDB_INSTALL=.libtiledb
+        export TILEDB_WHEEL_BUILD=1
         export CIBW_ENVIRONMENT="TILEDB_PATH=${TILEDB_INSTALL}"
-        export CIBW_BEFORE_BUILD="python -m pip install -r misc/requirements_wheel.txt; cp -R .libtiledb/* /usr/local"
         ls -lR "${TILEDB_INSTALL}"
 
         python -c "import os; print(os.environ.get('CIBW_ENVIRONMENT', None))"
@@ -113,7 +113,6 @@ stages:
     - bash: |
         set -xe pipefail
 
-        export CIBW_BEFORE_BUILD="python -m pip install -r misc/requirements_wheel.txt"
         export TILEDB_WHEEL_BUILD=1
         echo "${TILEDB_INSTALL}"
 
@@ -128,7 +127,6 @@ stages:
 
     - script: |
         echo ON
-        set "CIBW_BEFORE_BUILD=python -m pip install -r misc/requirements_wheel.txt"
         set "TILEDB_WHEEL_BUILD=1"
         echo "cibw env: "
         echo "%CIBW_ENVIRONMENT%"


### PR DESCRIPTION
- set TILEDB_WHEEL_BUILD to make sure we use the correct requirements.txt file for numpy pinning
- disable libtiledb caching for release builds to ensure that all platforms/builds are strictly updated
- set CXXFLAGS/CFLAGS at the job level for linux only so they are not used on macOS