### PR TITLE
Get `nonempty_domain` Directly From `_nonempty_domain_var`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Improvements
 * Support pickling for arrays in write-mode [#626](https://github.com/TileDB-Inc/TileDB-Py/pull/626)
+* Get `nonempty_domain` directly from `_nonempty_domain_var` [#632](https://github.com/TileDB-Inc/TileDB-Py/pull/632)
 
 ## Bug Fixes
 * Fixed multi-range indexer to default to explicitly pass in the non-empty domain if dimensions are unspecified [#630](https://github.com/TileDB-Inc/TileDB-Py/pull/630) 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## Improvements
 * Support pickling for arrays in write-mode [#626](https://github.com/TileDB-Inc/TileDB-Py/pull/626)
-* Get `nonempty_domain` directly from `_nonempty_domain_var` [#632](https://github.com/TileDB-Inc/TileDB-Py/pull/632)
+* Consolidate `_nonempty_domain_var` into `nonempty_domain` [#632](https://github.com/TileDB-Inc/TileDB-Py/pull/632)
 
 ## Bug Fixes
 * Fixed multi-range indexer to default to explicitly pass in the non-empty domain if dimensions are unspecified [#630](https://github.com/TileDB-Inc/TileDB-Py/pull/630) 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -852,6 +852,27 @@ class ArrayTest(DiskTestCase):
         with self.assertRaises(ValueError):
             MySparseArray.create(uri, dense_schema)
 
+    def test_nonempty_domain_scalar(self):
+        uri = self.path("test_nonempty_domain_scalar")
+        dims = tiledb.Dim(domain=(-10, 10), dtype=np.int64, tile=1)
+        schema = tiledb.ArraySchema(
+            tiledb.Domain(dims),
+            attrs=[tiledb.Attr(dtype=np.int32)],
+            sparse=True,
+        )
+
+        tiledb.Array.create(uri, schema)
+
+        with tiledb.open(uri, "w") as A:
+            A[-1] = 10
+            A[1] = 11
+
+        with tiledb.open(uri, "r") as A:
+            ned = A.nonempty_domain()
+            assert_array_equal(ned, ((-1, 1),))
+            assert isinstance(ned[0][0], int)
+            assert isinstance(ned[0][1], int)
+
 
 class DenseArrayTest(DiskTestCase):
     def test_array_1d(self):


### PR DESCRIPTION
* This also fixes a bug where `nonempty_domain` was returning extents of dtype `np.array` instead of scalars.