### PR TITLE
Use TILEDB_WHEEL_BUILD inside CIBW_ENVIRONMENT & other wheel fixes

### DIFF
--- a/misc/azure-libtiledb-darwin.yml
+++ b/misc/azure-libtiledb-darwin.yml
@@ -1,10 +1,9 @@
 steps:
 - task: Cache@2
   inputs:
-    key: 'libtiledb | "$(Agent.OS)" | "$(imageName)" | "$(LIBTILEDB_SHA)" | v2'
+    key: 'libtiledb v0 | "$(Agent.OS)" | "$(imageName)" | "$(LIBTILEDB_SHA)" | setup.py | **/azure-*.yml, !tiledb_src/**, !tiledb_build/**'
     path: $(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)
     cacheHitVar: LIBTILEDB_CACHE_RESTORED
-  condition: not(startsWith(variables['Build.SourceBranchName'], 'release-'))
 
 - bash: |
     find $PIPELINE_WORKSPACE/.libtiledb_dist/${LIBTILEDB_SHA}

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -101,6 +101,7 @@ stages:
         mv ${TILEDB_INSTALL} .libtiledb
         export TILEDB_INSTALL=.libtiledb
         export CIBW_ENVIRONMENT="TILEDB_PATH=${TILEDB_INSTALL} TILEDB_WHEEL_BUILD=1"
+        export CIBW_TEST_COMMAND="python -c 'import tiledb'"
         # copy libtiledb into usr/local for audithweel to find
         export CIBW_BEFORE_BUILD="cp -R .libtiledb/* /usr/local"
         ls -lR "${TILEDB_INSTALL}"
@@ -118,6 +119,7 @@ stages:
         set -xe pipefail
 
         export TILEDB_WHEEL_BUILD=1
+        export CIBW_TEST_COMMAND="python -c 'import tiledb'"
         echo "${TILEDB_INSTALL}"
 
         python -c "import os; print(os.environ.get('CIBW_ENVIRONMENT', None))"
@@ -132,6 +134,7 @@ stages:
     - script: |
         echo ON
         set "TILEDB_WHEEL_BUILD=1"
+        set "CIBW_TEST_COMMAND=python -c 'import tiledb'"
         echo "cibw env: "
         echo "%CIBW_ENVIRONMENT%"
         echo "tiledb_install: "

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -100,8 +100,7 @@ stages:
 
         mv ${TILEDB_INSTALL} .libtiledb
         export TILEDB_INSTALL=.libtiledb
-        export TILEDB_WHEEL_BUILD=1
-        export CIBW_ENVIRONMENT="TILEDB_PATH=${TILEDB_INSTALL}"
+        export CIBW_ENVIRONMENT="TILEDB_PATH=${TILEDB_INSTALL} TILEDB_WHEEL_BUILD=1"
         # copy libtiledb into usr/local for audithweel to find
         export CIBW_BEFORE_BUILD="cp -R .libtiledb/* /usr/local"
         ls -lR "${TILEDB_INSTALL}"

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -101,6 +101,8 @@ stages:
         mv ${TILEDB_INSTALL} .libtiledb
         export TILEDB_INSTALL=.libtiledb
         export CIBW_ENVIRONMENT="TILEDB_PATH=${TILEDB_INSTALL} TILEDB_WHEEL_BUILD=1"
+        # use the requirements_wheel.txt with numpy pins to ensure ABI compatibility
+        export CIBW_BEFORE_TEST="pip install -r misc/requirements_wheel.txt"
         export CIBW_TEST_COMMAND="python -c 'import tiledb'"
         # copy libtiledb into usr/local for audithweel to find
         export CIBW_BEFORE_BUILD="cp -R .libtiledb/* /usr/local"
@@ -119,6 +121,8 @@ stages:
         set -xe pipefail
 
         export TILEDB_WHEEL_BUILD=1
+        # use the requirements_wheel.txt with numpy pins to ensure ABI compatibility
+        export CIBW_BEFORE_TEST="pip install -r misc/requirements_wheel.txt"
         export CIBW_TEST_COMMAND="python -c 'import tiledb'"
         echo "${TILEDB_INSTALL}"
 

--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -1,5 +1,6 @@
 # numpy pinning for ABI forward-compatibility
-numpy==1.16.5 ; python_version < "3.9"
+numpy==1.16.5 ; python_version < "3.8"
+numpy==1.17.* ; python_version == "3.8"
 numpy==1.19.4 ; python_version >= "3.9"
 
 #-------------------------------


### PR DESCRIPTION
The test I added doesn't seem to do what I had hoped for (I think it installs newer numpy despite the CIBW_BEFORE_TEST), but I manually tested all of the linux wheels here against the oldest supported numpy versions: https://dev.azure.com/isaiahnorton/isaiahnorton/_build/results?buildId=636&view=artifacts&pathAsName=false&type=publishedArtifacts