### PR TITLE
Shorten Build Directory Name in `setup.py` By Truncating `TILEDB_VERSION`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout TileDB-Py `dev`
+      uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,8 @@ def download_libtiledb():
     """
     dest_name = "TileDB-{}".format(TILEDB_VERSION)
     dest = os.path.join(BUILD_DIR, dest_name)
-    if not os.path.exists(dest):
+    build_dir = os.path.join(BUILD_DIR, f"TileDB-{TILEDB_VERSION[:8]}")
+    if not os.path.exists(build_dir):
         url = "https://github.com/TileDB-Inc/TileDB/archive/{}.zip".format(
             TILEDB_VERSION
         )
@@ -152,7 +153,9 @@ def download_libtiledb():
             subprocess.check_call(["wget", url], shell=True)
             with zipfile.ZipFile("{}.zip".format(TILEDB_VERSION)) as z:
                 z.extractall(BUILD_DIR)
-    return dest
+        shutil.move(dest, build_dir)
+
+    return build_dir
 
 
 def build_libtiledb(src_dir):


### PR DESCRIPTION
- This fixes an issue encountered when file paths exceed the maximum limit when using CMake on GHA Windows CI