### PR TITLE
Avoid np.str runtime deprecation warning

### DIFF
--- a/examples/parallel_csv_ingestion.py
+++ b/examples/parallel_csv_ingestion.py
@@ -274,7 +274,8 @@ def test_parallel_csv_ingestion():
         "column_int64": np.int64,
         "column_uint32": np.uint32,
         "column_float64": np.float64,
-        "column_utf8": np.str,
+        # Avoid this runtime warning: "DeprecationWarning: `np.str` is a deprecated alias for the builtin `str`."
+        "column_utf8": str,
     }
 
     # read dataframe from CSV list, set index, and sort


### PR DESCRIPTION
Running straight-from-wiki code samples I see

```
$ python examples/parallel_csv_ingestion.py
Finished generating CSVs in path:  /var/folders/kq/s93hr1xxxftknc0000gn/T/tmpdcd7e5cp
Writing output array to:  /var/folders/kq/s93hr1r15sd47nmw2p4ftknc0000gn/T/tmpaykazzyo
/Users/kerl/git/TileDB-Inc/TileDB-Py/examples/parallel_csv_ingestion.py:222: DeprecationWarning: `np.str` is a deprecated alias for the builtin `str`. To silence this warning, use `str` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.str_` here.
...
```

On this PR I am replacing `np.str` with `str`.

Plusses and minuses:

* Having fewer warnings at runtime is (all else being equal) a cleaner and more reassuring experience for the user
* However, we don't want to break this code for people using older versions of NumPy.

My current setup:

```
$ python --version
Python 3.9.6

$ python
Python 3.9.6 (default, Jun 29 2021, 05:25:02)
[Clang 12.0.5 (clang-1205.0.22.9)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> np.__version__
'1.21.2'
```

Note this deprecation happened in NumPy 1.20: https://numpy.org/devdocs/release/1.20.0-notes.html

... on further reading I think we're OK:
https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated

> For a long time, `np.int` has been an alias of the builtin `int`. This is repeatedly a cause of confusion for newcomers, and existed mainly for historic reasons.