### PR TITLE
Check `filter` Argument When Appending to `FilterList`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 * Correct listing of consolidated fragments to vacuum in the Fragment Info API by deprecating `FragmentInfoList.to_vacuum_uri`, `FragmentInfoList.to_vacuum_num`, `FragmentInfo.to_vacuum_uri`, and `FragmentInfo.to_vacuum_num` and replacing with `FragmentInfoList.to_vacuum` [#650](https://github.com/TileDB-Inc/TileDB-Py/pull/650)
+* Correct issue where appending `None` to `FilterList` causes segfault by checking the `filter` argument [#653](https://github.com/TileDB-Inc/TileDB-Py/pull/653)
 
 # TileDB-Py 0.9.5 Release Notes
 

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2139,6 +2139,9 @@ cdef class FilterList(object):
         cdef tiledb_filter_list_t* filter_list_ptr = self.ptr
         assert(filter_list_ptr != NULL)
 
+        if not isinstance(filter, Filter):
+            raise ValueError("filter argument must be a TileDB filter objects")
+
         cdef tiledb_filter_t* filter_ptr = filter.ptr
 
         cdef int rc = TILEDB_OK

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -688,6 +688,14 @@ class ArraySchemaTest(DiskTestCase):
         self.assertEqual(len(schema2.coords_filters), 1)
         self.assertEqual(len(schema2.offsets_filters), 1)
 
+    def test_none_filter_list(self):
+        with self.assertRaises(ValueError):
+            tiledb.FilterList([None])
+
+        with self.assertRaises(ValueError):
+            fl = tiledb.FilterList()
+            fl.append(None)
+
     def test_mixed_string_schema(self):
         dims = [
             tiledb.Dim(name="dpos", domain=(-100.0, 100.0), tile=10, dtype=np.float64),


### PR DESCRIPTION
* This fixes a bug where appending `None` causes a segfault