### PR TITLE
Return Empty Result With Empty Nonempty Domain With Multi-Index

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # TileDB-Py 0.9.6 Release Notes
 
+## API Changes
+* When using the multi-indexer, an empty result is returned if the nonempty domain is empty [#656](https://github.com/TileDB-Inc/TileDB-Py/pull/656)
+
 ## Improvements
 * Support numeric column names in `from_pandas` by casting to str dtype [#652](https://github.com/TileDB-Inc/TileDB-Py/pull/652)
 

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -104,9 +104,9 @@ def iter_ranges(
             rend = nonempty_domain[1]
 
         if rstart is None or rend is None:
-            raise TileDBError("Open-ended slicing requires a valid nonempty_domain")
-
-        yield to_scalar(rstart), to_scalar(rend)
+            pass
+        else:
+            yield to_scalar(rstart), to_scalar(rend)
 
     elif isinstance(sel, tuple):
         assert len(sel) == 2

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -641,9 +641,7 @@ class TestMultiRange(DiskTestCase):
             data = A.multi_index[slice_index]
 
             assert_array_equal(data["a"], np.array([], dtype=np.uint64))
-
-            with self.assertRaises(tiledb.TileDBError):
-                A.multi_index[:]
+            assert_array_equal(A.multi_index[:], [])
 
         with tiledb.open(uri, mode="w") as A:
             A[[10]] = {"a": [10]}
@@ -760,3 +758,20 @@ class TestMultiRange(DiskTestCase):
 
             assert_array_equal(A[0][""], A.multi_index[0][""])
             assert_array_equal(A.multi_index[0][""], A.multi_index[0, :][""])
+
+    def test_multi_index_open_timestamp_with_empty_nonempty_domain(self):
+        uri = self.path("test_multi_index_open_timestamp_with_empty_nonempty_domain")
+        dom = tiledb.Domain(tiledb.Dim(domain=(1, 3)))
+        attr = tiledb.Attr(name="", dtype=np.int32)
+        schema = tiledb.ArraySchema(domain=dom, sparse=True, attrs=[attr])
+        tiledb.Array.create(uri, schema)
+
+        with tiledb.open(uri, mode="w", timestamp=2) as A:
+            d1 = np.array(np.random.randint(1, 11, size=3, dtype=np.int32))
+            A[np.arange(1, 4)] = d1
+
+        with tiledb.open(uri, mode="r", timestamp=1) as A:
+            assert A.nonempty_domain() is None
+            assert_array_equal(A.multi_index[:][""], A[:][""])
+            # assert_array_equal(A.multi_index[[]][""], A[:][""])
+            # assert_array_equal(A.multi_index[()][""], A[:][""])

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -773,5 +773,3 @@ class TestMultiRange(DiskTestCase):
         with tiledb.open(uri, mode="r", timestamp=1) as A:
             assert A.nonempty_domain() is None
             assert_array_equal(A.multi_index[:][""], A[:][""])
-            # assert_array_equal(A.multi_index[[]][""], A[:][""])
-            # assert_array_equal(A.multi_index[()][""], A[:][""])


### PR DESCRIPTION
* Previously, this operation would error out.