### PR TITLE
Improve Checking For Byte-String Attributes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,9 @@
 * Print a warning about ContextVar bug when running under ipykernel < 6.0. [#665](https://github.com/TileDB-Inc/TileDB-Py/pull/665)
   Please see https://github.com/TileDB-Inc/TileDB-Py/issues/667 for more information.
 
+## Bug Fixes
+* For attributes, if `var=False` but the bytestring is fixed-width or if `var=True` but the bytestring is variable length, error out [#663](https://github.com/TileDB-Inc/TileDB-Py/pull/663)
+
 # TileDB-Py 0.10.0 Release Notes
 
 ## TileDB Embedded updates:

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2239,11 +2239,23 @@ cdef class Attr(object):
         
         if _dtype and _dtype.kind == 'S':
             if var and 0 < _dtype.itemsize:
-                raise TypeError("dtype is not compatible with var-length attribute")
+                warnings.warn(
+                    f"Attr given `var=True` but `dtype` `{_dtype}` is fixed; "
+                    "setting `dtype=S0`. Hint: set `var=True` with `dtype=S0`, "
+                    f"or `var=False`with `dtype={_dtype}`",
+                    DeprecationWarning,
+                )
+                _dtype = np.dtype("S0")
             
             if _dtype.itemsize == 0:
                 if var == False:
-                    raise TypeError("dtype is not compatible with fixed-length attribute")
+                    warnings.warn(
+                        f"Attr given `var=False` but `dtype` `S0` is var-length; "
+                        "setting `var=True` and `dtype=S0`. Hint: set `var=False` "
+                        "with `dtype=S0`, or `var=False` with a fixed-width "
+                        "string `dtype=S<n>` where is  n>1",
+                        DeprecationWarning,
+                    )
             
                 var = True
                 ncells = TILEDB_VAR_NUM

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2221,7 +2221,7 @@ cdef class Attr(object):
             ctx = default_ctx()
         cdef bytes bname = ustring(name).encode('UTF-8')
         cdef const char* name_ptr = PyBytes_AS_STRING(bname)
-        cdef np.dtype _dtype
+        cdef np.dtype _dtype = None
         cdef tiledb_datatype_t tiledb_dtype
         cdef uint32_t ncells
 
@@ -2236,8 +2236,8 @@ cdef class Attr(object):
         if var or _dtype.kind == 'U':
             var = True
             ncells = TILEDB_VAR_NUM
-
-        if _dtype.kind == 'S':
+        
+        if _dtype and _dtype.kind == 'S':
             if var and 0 < _dtype.itemsize:
                 raise TypeError("dtype is not compatible with var-length attribute")
             

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -461,7 +461,7 @@ class AttributeTest(DiskTestCase):
 
         with self.assertRaises(TypeError):
             tiledb.Attr("foo", var=False, dtype="S")
-        
+
         attr = tiledb.Attr("foo", var=True, dtype="S")
         self.assertEqual(attr.dtype, np.dtype("S"))
         self.assertTrue(attr.isvar)
@@ -469,7 +469,7 @@ class AttributeTest(DiskTestCase):
         attr = tiledb.Attr("foo", var=False, dtype="S1")
         self.assertEqual(attr.dtype, np.dtype("S1"))
         self.assertFalse(attr.isvar)
-        
+
         attr = tiledb.Attr("foo", dtype="S1")
         self.assertEqual(attr.dtype, np.dtype("S1"))
         self.assertFalse(attr.isvar)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -455,9 +455,27 @@ class AttributeTest(DiskTestCase):
         self.assertEqual(attr.dtype, dtype)
         self.assertEqual(attr.ncells, 10)
 
-    def test_vararg_attribute(self):
-        attr = tiledb.Attr("foo", dtype=np.bytes_)
-        self.assertEqual(attr.dtype, np.dtype(np.bytes_))
+    def test_bytes_var_attribute(self):
+        with self.assertRaises(TypeError):
+            tiledb.Attr("foo", var=True, dtype="S1")
+
+        with self.assertRaises(TypeError):
+            tiledb.Attr("foo", var=False, dtype="S")
+        
+        attr = tiledb.Attr("foo", var=True, dtype="S")
+        self.assertEqual(attr.dtype, np.dtype("S"))
+        self.assertTrue(attr.isvar)
+
+        attr = tiledb.Attr("foo", var=False, dtype="S1")
+        self.assertEqual(attr.dtype, np.dtype("S1"))
+        self.assertFalse(attr.isvar)
+        
+        attr = tiledb.Attr("foo", dtype="S1")
+        self.assertEqual(attr.dtype, np.dtype("S1"))
+        self.assertFalse(attr.isvar)
+
+        attr = tiledb.Attr("foo", dtype="S")
+        self.assertEqual(attr.dtype, np.dtype("S"))
         self.assertTrue(attr.isvar)
 
     def test_nullable_attribute(self):

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -456,11 +456,15 @@ class AttributeTest(DiskTestCase):
         self.assertEqual(attr.ncells, 10)
 
     def test_bytes_var_attribute(self):
-        with self.assertRaises(TypeError):
-            tiledb.Attr("foo", var=True, dtype="S1")
+        with pytest.warns(DeprecationWarning, match="Attr given `var=True` but"):
+            attr = tiledb.Attr("foo", var=True, dtype="S1")
+            self.assertEqual(attr.dtype, np.dtype("S"))
+            self.assertTrue(attr.isvar)
 
-        with self.assertRaises(TypeError):
-            tiledb.Attr("foo", var=False, dtype="S")
+        with pytest.warns(DeprecationWarning, match="Attr given `var=False` but"):
+            attr = tiledb.Attr("foo", var=False, dtype="S")
+            self.assertEqual(attr.dtype, np.dtype("S"))
+            self.assertTrue(attr.isvar)
 
         attr = tiledb.Attr("foo", var=True, dtype="S")
         self.assertEqual(attr.dtype, np.dtype("S"))


### PR DESCRIPTION
* Errors out when `var=True` but the string is a fixed-width type and when `var=False` but the string is a variable-length type.