### PR TITLE
Use new instance for each multi_index/df invocation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,10 @@
 ## Improvements
 * Print a warning about ContextVar bug when running under ipykernel < 6.0. [#665](https://github.com/TileDB-Inc/TileDB-Py/pull/665)
   Please see https://github.com/TileDB-Inc/TileDB-Py/issues/667 for more information.
-* `tiledb.Dim` representation now displays `var=True` for dimensions with `bytes` datatype, consistent with `tiledb.Attr` [#669](https://github.com/TileDB-Inc/TileDB-Py/pull/662)
+* `tiledb.Dim` representation now displays `var=True` for dimensions with `bytes` datatype, consistent with `tiledb.Attr` [#669](https://github.com/TileDB-Inc/TileDB-Py/pull/669)
+
+## Bug fixes
+* Fix concurrent use of `Array.multi_index` and `.df` by using new instance for each invocation [#672](https://github.com/TileDB-Inc/TileDB-Py/pull/672)
 
 ## Bug Fixes
 * For attributes, if `var=False` but the bytestring is fixed-width or if `var=True` but the bytestring is variable length, error out [#663](https://github.com/TileDB-Inc/TileDB-Py/pull/663)

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3909,10 +3909,6 @@ cdef class Array(object):
         self.key = key
         self.domain_index = DomainIndexer(self)
 
-        # Delayed to avoid circular import
-        from .multirange_indexing import DataFrameIndexer, MultiRangeIndexer
-        self.multi_index = MultiRangeIndexer(self)
-        self.df = DataFrameIndexer(self, use_arrow=None)
         self.last_fragment_info = dict()
         self.meta = Metadata(self)
 
@@ -4416,7 +4412,9 @@ cdef class Array(object):
         OrderedDict([('', array([[1., 0., 0.], [0., 2., 0.], [0., 0., 3.]]))])
 
         """
-        return self.multi_index
+        # Delayed to avoid circular import
+        from .multirange_indexing import MultiRangeIndexer
+        return MultiRangeIndexer(self)
 
     @property
     def df(self):
@@ -4457,9 +4455,9 @@ cdef class Array(object):
            5     0.5         5
 
         """
-
-        return self.df
-
+        # Delayed to avoid circular import
+        from .multirange_indexing import DataFrameIndexer
+        return DataFrameIndexer(self, use_arrow=None)
 
     @property
     def last_write_info(self):


### PR DESCRIPTION
Fixes correctness bugs, especially for concurrent use of indexers from the same Array
object.