### PR TITLE
Remove 'size > 0' assertions in reader path

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -823,14 +823,12 @@ public:
 
       if (b.isvar) {
         size_t offsets_size = b.offsets.size() - offsets_read;
-        assert(offsets_size > 0);
         uint64_t *offsets_ptr = (uint64_t *)b.offsets.data() + offsets_read;
 
         query_->set_buffer(b.name, (uint64_t *)(offsets_ptr), offsets_size,
                            data_ptr, data_nelem);
       } else if (b.isnullable) {
         uint64_t validity_size = b.validity.size() - validity_vals_read;
-        assert(validity_size > 0);
 
         uint8_t *validity_ptr =
             (uint8_t *)b.validity.data() + validity_vals_read;


### PR DESCRIPTION
Reading an empty result is supported. This path is already tested in
test_pandas_dataframe:test_dataframe_empty, so remove the asserts
which fail in debug build.

Also x-ref sc-10191 and TileDB core PR 2505