### PR TITLE
Mark sparse_write_to_dense as xfail with libtiledb 2.5+

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -5002,6 +5002,7 @@ cdef class DenseArrayImpl(Array):
                 "Sparse writes to dense arrays is deprecated",
                 DeprecationWarning,
             )
+            _setitem_impl_sparse(self, selection, val, dict())
             return
 
         self._setitem_impl(selection, val, dict())

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1592,20 +1592,31 @@ class DenseArrayTest(DiskTestCase):
                 tiledb.DenseArray(uri)
 
     def test_sparse_write_to_dense(self):
-        uri = self.path("test_sparse_write_to_dense")
+        class AssignAndCheck:
+            def __init__(self, outer, *shape):
+                self.outer = outer
+                self.shape = shape
 
-        dom = tiledb.Domain(tiledb.Dim(domain=(0, 9), tile=10, dtype=np.int64))
-        att = tiledb.Attr(dtype=np.int64)
-        schema = tiledb.ArraySchema(domain=dom, attrs=(att,))
-        tiledb.DenseArray.create(uri, schema)
+            def __setitem__(self, s, v):
+                A = np.random.rand(*self.shape)
 
-        data = np.arange(0, 10, dtype=np.int64)
+                uri = self.outer.path(
+                    f"sparse_write_to_dense{random.randint(0,np.uint64(-1))}"
+                )
 
+                tiledb.from_numpy(uri, A).close()
+                with tiledb.open(uri, "w") as B:
+                    B[s] = v
+
+                A[s] = v
+                with tiledb.open(uri) as B:
+                    assert_array_equal(A, B[:])
+
+        D = AssignAndCheck(self, 5, 5)
         with pytest.warns(
             DeprecationWarning, match="Sparse writes to dense arrays is deprecated"
         ):
-            with tiledb.DenseArray(uri, mode="w") as T:
-                T[np.arange(10)] = data
+            D[np.array([1, 2]), np.array([0, 0])] = np.array([0, 2])
 
     def test_reopen_dense_array(self):
         uri = self.path("test_reopen_dense_array")

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1591,6 +1591,10 @@ class DenseArrayTest(DiskTestCase):
             with self.assertRaises(tiledb.TileDBError):
                 tiledb.DenseArray(uri)
 
+    @pytest.mark.xfail(
+        tiledb.libtiledb.version() >= (2, 5),
+        reason="Skip sparse_write_to_dense with libtiledb 2.5+",
+    )
     def test_sparse_write_to_dense(self):
         class AssignAndCheck:
             def __init__(self, outer, *shape):


### PR DESCRIPTION
Fixes #689 