### PR TITLE
Try to pre-import tiledb.cloud before tests

### DIFF
--- a/tiledb/tests/conftest.py
+++ b/tiledb/tests/conftest.py
@@ -24,6 +24,14 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    # we need to try importing here so that we don't potentially cause
+    # a slowdown in the DenseArray/SparseArray.__new__ path when
+    # running `tiledb.open`.
+    try:
+        import tiledb.cloud
+    except ImportError:
+        pass
+
     # default must be set here rather than globally
     pytest.tiledb_vfs = "file"
 

--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -14,13 +14,12 @@ from tiledb.tests.common import DiskTestCase
 class AttrDataTest(DiskTestCase):
     @hypothesis.settings(deadline=1000)
     @given(st.binary())
-    def test_bytes_df(self, data):
+    def test_bytes_numpy(self, data):
         # TODO this test is slow. might be nice to run with in-memory
         #      VFS (if faster) but need to figure out correct setup
         # uri = "mem://" + str(uri_int)
 
         uri = self.path()
-        uri_df = self.path()
 
         if data == b"" or data.count(b"\x00") == len(data):
             # single-cell empty writes are not supported; TileDB PR 1646
@@ -46,12 +45,11 @@ class AttrDataTest(DiskTestCase):
 
     @hypothesis.settings(deadline=1000)
     @given(st.binary())
-    def test_bytes_numpy(self, data):
+    def test_bytes_df(self, data):
         # TODO this test is slow. might be nice to run with in-memory
         #      VFS (if faster) but need to figure out correct setup
         # uri = "mem://" + str(uri_int)
 
-        uri = self.path()
         uri_df = self.path()
 
         if data == b"" or data.count(b"\x00") == len(data):


### PR DESCRIPTION
I am hoping this will address the CI failures in sc-8256 by avoiding variance in the timing of initial calls to `tiledb.open`, but not 100% sure if this is the main issue; see commit message for full explanation.