### PR TITLE
Don't set nonempty domain for whole-dimension slices

### DIFF
--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -86,6 +86,7 @@ class TestMultiRangeAuxiliary(DiskTestCase):
             arr.schema = Obj()
             arr.schema.domain = Obj()
             arr.schema.domain.ndim = ndim
+            arr.schema.sparse = False
             arr.array = Obj()
             # place-holder for attribute that is not used in these tests
             arr.nonempty_domain = lambda: [()] * ndim


### PR DESCRIPTION
Don't set nonempty domain for whole-dimension slices of sparse array. (leaving ranges unset is a significant performance improvement for full-array slicing; ~50% in my test case, and confirmed that this is expected)