### PR TITLE
Create Issue if GHA Daily Test Is "Cancelled"

### DIFF
--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -62,7 +62,7 @@ jobs:
       run: pytest -vv
   
     - name: Create Issue if Build Fails
-      if: failure()
+      if: failure() || cancelled()
       uses: JasonEtco/create-an-issue@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* The following daily run was cancelled by GitHub due to exceeding the time limit:
	https://github.com/TileDB-Inc/TileDB-Py/runs/3890774602?check_suite_focus=true#step:8:73
* Since this cancellation was done by GH and not by the user, it should really count
  as a failure. There will very unlikely be an instance in which we purposely go in to cancel
  a nightly test ourselves.