### PR TITLE
Create Separate Job for Posting Failing Issue

### DIFF
--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -60,8 +60,10 @@ jobs:
 
     - name: Test TileDB-Py
       run: pytest -vv
-  
+
+  create_issue_on_fail:
     - name: Create Issue if Build Fails
+      needs: test
       if: failure() || cancelled()
       uses: JasonEtco/create-an-issue@v2
       env:


### PR DESCRIPTION
* The nightly run for Fri, October 15th 2021 posted two issues. This occured
  because of a previous change where we now post an issue for if the test either
  fails or is cancelled. In this particular case, the Windows test failed which
  triggered GHA to cancel the macOSX test. Since the create issue step was placed
  within the same "test" job, it triggered the create issue step twice.
* Moving the step into a separate job will ensure that the issue is only posted once.