### PR TITLE
Explicitly Set Daily Test Build Version to Python 3.9

### DIFF
--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
     - name: Set up Python
       uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
 
     - name: Print Python version
       run: |


### PR DESCRIPTION
- Because the `setup-python` step was not explicitly set to use a specific version of Python, it used the current latest release, 3.10 which we currently do not support yet