### PR TITLE
Fix misstated type in metadata error message.

### DIFF
--- a/tiledb/libmetadata.pyx
+++ b/tiledb/libmetadata.pyx
@@ -46,7 +46,7 @@ cdef PackedBuffer pack_metadata_val(value):
 
     val0 = value[0]
     if not isinstance(val0, (int, float)):
-        raise TypeError(f"Unsupported item type '{type(value)}'")
+        raise TypeError(f"Unsupported item type '{type(val0)}'")
 
     cdef:
         uint32_t value_num = len(value)


### PR DESCRIPTION
Previously, passing an unsupported value into pack_metadata_val would
always result in `Unsupported item type '<class 'tuple'>'`.
This change reports the actual type that was passed in.