### PR TITLE
Addition of MBRs to `FragmentInfo` API

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+# TileDB-Py 0.11.0 Release Notes
+
+## TileDB Embedded updates:
+* TileDB-Py 0.11.0 includes TileDB Embedded [TileDB 2.5.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.5.0)
+
+## API Changes
+* Addition of MBRs to `FragmentInfo` API [#760](https://github.com/TileDB-Inc/TileDB-Py/pull/760)
+
 # TileDB-Py 0.10.5 Release Notes
 
 ## API Changes

--- a/examples/fragment_info.py
+++ b/examples/fragment_info.py
@@ -45,21 +45,21 @@ def create_array():
     )
 
     # Create the (empty) array on disk.
-    tiledb.DenseArray.create(array_name, schema)
+    tiledb.Array.create(array_name, schema)
 
 
 def write_array_1():
-    with tiledb.DenseArray(array_name, mode="w") as A:
+    with tiledb.open(array_name, mode="w") as A:
         A[1:3, 1:5] = np.array(([1, 2, 3, 4, 5, 6, 7, 8]))
 
 
 def write_array_2():
-    with tiledb.DenseArray(array_name, mode="w") as A:
+    with tiledb.open(array_name, mode="w") as A:
         A[2:4, 2:4] = np.array(([101, 102, 103, 104]))
 
 
 def write_array_3():
-    with tiledb.DenseArray(array_name, mode="w") as A:
+    with tiledb.open(array_name, mode="w") as A:
         A[3:4, 4:5] = np.array(([202]))
 
 
@@ -88,7 +88,6 @@ for fragment in fragments_info:
     print()
     print("===== FRAGMENT NUMBER {} =====".format(fragment.num))
     print("fragment uri: {}".format(fragment.uri))
-    print("is dense: {}".format(fragment.dense))
     print("is sparse: {}".format(fragment.sparse))
     print("cell num: {}".format(fragment.cell_num))
     print("has consolidated metadata: {}".format(fragment.has_consolidated_metadata))

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from pkg_resources import resource_filename
 from setuptools import Extension, find_packages, setup
 
 # Target branch
-TILEDB_VERSION = "2.4.3"
+TILEDB_VERSION = "2.5.0"
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION
 

--- a/tiledb/fragment.cc
+++ b/tiledb/fragment.cc
@@ -31,18 +31,29 @@ private:
   Context ctx_;
   unique_ptr<FragmentInfo> fi_;
 
+  py::object schema_;
+
+  uint32_t num_fragments_;
+  py::tuple uri_;
+  py::tuple version_;
+  py::tuple nonempty_domain_;
+  py::tuple cell_num_;
+  py::tuple timestamp_range_;
+  py::tuple sparse_;
+  uint32_t unconsolidated_metadata_num_;
+  py::tuple has_consolidated_metadata_;
+  py::tuple to_vacuum_;
+  py::tuple mbrs_;
+
 public:
   tiledb_ctx_t *c_ctx_;
 
 public:
   PyFragmentInfo() = delete;
 
-  PyFragmentInfo(const string &uri, py::object ctx) {
-    if (ctx.is(py::none())) {
-      auto tiledblib = py::module::import("tiledb");
-      auto default_ctx = tiledblib.attr("default_ctx");
-      ctx = default_ctx();
-    }
+  PyFragmentInfo(const string &uri, py::object schema, py::bool_ include_mbrs,
+                 py::object ctx) {
+    schema_ = schema;
 
     tiledb_ctx_t *c_ctx_ = (py::capsule)ctx.attr("__capsule__")();
 
@@ -52,8 +63,45 @@ public:
     ctx_ = Context(c_ctx_, false);
 
     fi_ = unique_ptr<tiledb::FragmentInfo>(new FragmentInfo(ctx_, uri));
+
+    load();
+
+    num_fragments_ = fragment_num();
+    uri_ = fill_uri();
+    version_ = fill_version();
+    nonempty_domain_ = fill_non_empty_domain();
+    cell_num_ = fill_cell_num();
+    timestamp_range_ = fill_timestamp_range();
+    sparse_ = fill_sparse();
+    unconsolidated_metadata_num_ = unconsolidated_metadata_num();
+    has_consolidated_metadata_ = fill_has_consolidated_metadata();
+    to_vacuum_ = fill_to_vacuum_uri();
+
+    if (include_mbrs)
+      mbrs_ = fill_mbr();
+
+    close();
   }
 
+  uint32_t get_num_fragments() { return num_fragments_; };
+  py::tuple get_uri() { return uri_; };
+  py::tuple get_version() { return version_; };
+  py::tuple get_nonempty_domain() { return nonempty_domain_; };
+  py::tuple get_cell_num() { return cell_num_; };
+  py::tuple get_timestamp_range() { return timestamp_range_; };
+  py::tuple get_sparse() { return sparse_; };
+  uint32_t get_unconsolidated_metadata_num() {
+    return unconsolidated_metadata_num_;
+  };
+  py::tuple get_has_consolidated_metadata() {
+    return has_consolidated_metadata_;
+  };
+  py::tuple get_to_vacuum() { return to_vacuum_; };
+  py::tuple get_mbrs() { return mbrs_; };
+
+  void dump() const { return fi_->dump(stdout); }
+
+private:
   template <typename T>
   py::object for_all_fid(T (FragmentInfo::*fn)(uint32_t) const) const {
     py::list l;
@@ -83,42 +131,40 @@ public:
 
   void close() { fi_.reset(); }
 
-  py::object fragment_uri(py::object fid) const {
-    return fid.is(py::none())
-               ? for_all_fid(&FragmentInfo::fragment_uri)
-               : py::str(fi_->fragment_uri(py::cast<uint32_t>(fid)));
+  py::tuple fill_uri() const {
+    return for_all_fid(&FragmentInfo::fragment_uri);
   }
 
-  py::tuple get_non_empty_domain(py::object schema) const {
+  py::tuple fill_non_empty_domain() const {
     py::list all_frags;
     uint32_t nfrag = fragment_num();
 
     for (uint32_t fid = 0; fid < nfrag; ++fid)
-      all_frags.append(get_non_empty_domain(schema, fid));
+      all_frags.append(fill_non_empty_domain(fid));
 
     return std::move(all_frags);
   }
 
-  py::tuple get_non_empty_domain(py::object schema, uint32_t fid) const {
+  py::tuple fill_non_empty_domain(uint32_t fid) const {
     py::list all_dims;
-    int ndim = (schema.attr("domain").attr("ndim")).cast<int>();
+    int ndim = (schema_.attr("domain").attr("ndim")).cast<int>();
 
     for (int did = 0; did < ndim; ++did)
-      all_dims.append(get_non_empty_domain(schema, fid, did));
+      all_dims.append(fill_non_empty_domain(fid, did));
 
     return std::move(all_dims);
   }
 
   template <typename T>
-  py::tuple get_non_empty_domain(py::object schema, uint32_t fid, T did) const {
-    py::bool_ isvar = get_dim_isvar(schema.attr("domain"), did);
+  py::tuple fill_non_empty_domain(uint32_t fid, T did) const {
+    py::bool_ isvar = get_dim_isvar(schema_.attr("domain"), did);
 
     if (isvar) {
       pair<string, string> lims = fi_->non_empty_domain_var(fid, did);
       return py::make_tuple(lims.first, lims.second);
     }
 
-    py::dtype type = get_dim_type(schema.attr("domain"), did);
+    py::dtype type = get_dim_type(schema_.attr("domain"), did);
     py::dtype array_type =
         type.kind() == 'M' ? pybind11::dtype::of<uint64_t>() : type;
 
@@ -163,42 +209,22 @@ public:
     return (dom.attr("dim")(did).attr("dtype")).cast<py::dtype>();
   }
 
-  py::object timestamp_range(py::object fid) const {
-    if (fid.is(py::none()))
-      return for_all_fid(&FragmentInfo::timestamp_range);
-
-    auto p = fi_->timestamp_range(py::cast<uint32_t>(fid));
-    return py::make_tuple(p.first, p.second);
+  py::tuple fill_timestamp_range() const {
+    return for_all_fid(&FragmentInfo::timestamp_range);
   }
 
   uint32_t fragment_num() const { return fi_->fragment_num(); }
 
-  py::object dense(py::object fid) const {
-    return fid.is(py::none()) ? for_all_fid(&FragmentInfo::dense)
-                              : py::bool_(fi_->dense(py::cast<uint32_t>(fid)));
+  py::tuple fill_sparse() const { return for_all_fid(&FragmentInfo::sparse); }
+
+  py::tuple fill_cell_num() const {
+    return for_all_fid(&FragmentInfo::cell_num);
   }
 
-  py::object sparse(py::object fid) const {
-    return fid.is(py::none()) ? for_all_fid(&FragmentInfo::sparse)
-                              : py::bool_(fi_->sparse(py::cast<uint32_t>(fid)));
-  }
+  py::tuple fill_version() const { return for_all_fid(&FragmentInfo::version); }
 
-  py::object cell_num(py::object fid) const {
-    return fid.is(py::none())
-               ? for_all_fid(&FragmentInfo::cell_num)
-               : py::int_(fi_->cell_num(py::cast<uint32_t>(fid)));
-  }
-
-  py::object version(py::object fid) const {
-    return fid.is(py::none()) ? for_all_fid(&FragmentInfo::version)
-                              : py::int_(fi_->version(py::cast<uint32_t>(fid)));
-  }
-
-  py::object has_consolidated_metadata(py::object fid) const {
-    return fid.is(py::none())
-               ? for_all_fid(&FragmentInfo::has_consolidated_metadata)
-               : py::bool_(
-                     fi_->has_consolidated_metadata(py::cast<uint32_t>(fid)));
+  py::tuple fill_has_consolidated_metadata() const {
+    return for_all_fid(&FragmentInfo::has_consolidated_metadata);
   }
 
   uint32_t unconsolidated_metadata_num() const {
@@ -207,66 +233,72 @@ public:
 
   uint32_t to_vacuum_num() const { return fi_->to_vacuum_num(); }
 
-  py::object to_vacuum_uri(py::object fid) const {
-    if (fid.is(py::none())) {
-      py::list l;
-      uint32_t nfrag = to_vacuum_num();
+  py::tuple fill_to_vacuum_uri() const {
+    py::list l;
+    uint32_t nfrag = to_vacuum_num();
 
-      for (uint32_t i = 0; i < nfrag; ++i)
-        l.append((fi_->to_vacuum_uri(i)));
-      return py::tuple(l);
-    }
-
-    return py::str(fi_->to_vacuum_uri(py::cast<uint32_t>(fid)));
+    for (uint32_t i = 0; i < nfrag; ++i)
+      l.append((fi_->to_vacuum_uri(i)));
+    return py::tuple(l);
   }
 
-  void dump() const { return fi_->dump(stdout); }
+  py::tuple fill_mbr() const {
+    py::list all_frags;
+    uint32_t nfrag = fragment_num();
+
+    for (uint32_t fid = 0; fid < nfrag; ++fid)
+      all_frags.append(fill_mbr(fid));
+
+    return std::move(all_frags);
+  }
+
+  py::tuple fill_mbr(uint32_t fid) const {
+    py::list all_mbrs;
+    uint64_t nmbr = fi_->mbr_num(fid);
+
+    for (uint32_t mid = 0; mid < nmbr; ++mid)
+      all_mbrs.append(fill_mbr(fid, mid));
+
+    return std::move(all_mbrs);
+  }
+
+  py::tuple fill_mbr(uint32_t fid, uint32_t mid) const {
+    py::list all_dims;
+    int ndim = (schema_.attr("domain").attr("ndim")).cast<int>();
+
+    for (int did = 0; did < ndim; ++did)
+      all_dims.append(fill_mbr(fid, mid, did));
+
+    return std::move(all_dims);
+  }
+
+  py::tuple fill_mbr(uint32_t fid, uint32_t mid, uint32_t did) const {
+    py::dtype type = get_dim_type(schema_.attr("domain"), did);
+    py::dtype array_type =
+        type.kind() == 'M' ? pybind11::dtype::of<uint64_t>() : type;
+    py::array limits = py::array(array_type, 2);
+    py::buffer_info buffer = limits.request();
+    fi_->get_mbr(fid, mid, did, buffer.ptr);
+    return std::move(limits);
+  }
 };
 
 void init_fragment(py::module &m) {
   py::class_<PyFragmentInfo>(m, "PyFragmentInfo")
-      .def(py::init<const string &, py::object>(), py::arg("uri"),
-           py::arg("ctx") = py::none())
-
-      .def("load",
-           static_cast<void (PyFragmentInfo::*)() const>(&PyFragmentInfo::load))
-      .def("load", static_cast<void (PyFragmentInfo::*)(
-                       tiledb_encryption_type_t, const string &) const>(
-                       &PyFragmentInfo::load))
-
-      .def("close", &PyFragmentInfo::close)
-
-      .def("get_non_empty_domain",
-           static_cast<py::tuple (PyFragmentInfo::*)(py::object) const>(
-               &PyFragmentInfo::get_non_empty_domain))
-      .def("get_non_empty_domain",
-           static_cast<py::tuple (PyFragmentInfo::*)(py::object, uint32_t)
-                           const>(&PyFragmentInfo::get_non_empty_domain))
-      .def("get_non_empty_domain", static_cast<py::tuple (PyFragmentInfo::*)(
-                                       py::object, uint32_t, uint32_t) const>(
-                                       &PyFragmentInfo::get_non_empty_domain))
-      .def("get_non_empty_domain",
-           static_cast<py::tuple (PyFragmentInfo::*)(py::object, uint32_t,
-                                                     const string &) const>(
-               &PyFragmentInfo::get_non_empty_domain))
-
-      .def("fragment_uri", &PyFragmentInfo::fragment_uri,
-           py::arg("fid") = py::none())
-      .def("timestamp_range", &PyFragmentInfo::timestamp_range,
-           py::arg("fid") = py::none())
-      .def("fragment_num", &PyFragmentInfo::fragment_num)
-      .def("dense", &PyFragmentInfo::dense, py::arg("fid") = py::none())
-      .def("sparse", &PyFragmentInfo::sparse, py::arg("fid") = py::none())
-      .def("cell_num", &PyFragmentInfo::cell_num, py::arg("fid") = py::none())
-      .def("version", &PyFragmentInfo::version, py::arg("fid") = py::none())
-      .def("has_consolidated_metadata",
-           &PyFragmentInfo::has_consolidated_metadata,
-           py::arg("fid") = py::none())
-      .def("unconsolidated_metadata_num",
-           &PyFragmentInfo::unconsolidated_metadata_num)
-      .def("to_vacuum_num", &PyFragmentInfo::to_vacuum_num)
-      .def("to_vacuum_uri", &PyFragmentInfo::to_vacuum_uri,
-           py::arg("fid") = py::none())
+      .def(py::init<const string &, py::object, py::bool_, py::object>())
+      .def("get_num_fragments", &PyFragmentInfo::get_num_fragments)
+      .def("get_uri", &PyFragmentInfo::get_uri)
+      .def("get_version", &PyFragmentInfo::get_version)
+      .def("get_nonempty_domain", &PyFragmentInfo::get_nonempty_domain)
+      .def("get_cell_num", &PyFragmentInfo::get_cell_num)
+      .def("get_timestamp_range", &PyFragmentInfo::get_timestamp_range)
+      .def("get_sparse", &PyFragmentInfo::get_sparse)
+      .def("get_unconsolidated_metadata_num",
+           &PyFragmentInfo::get_unconsolidated_metadata_num)
+      .def("get_has_consolidated_metadata",
+           &PyFragmentInfo::get_has_consolidated_metadata)
+      .def("get_to_vacuum", &PyFragmentInfo::get_to_vacuum)
+      .def("get_mbrs", &PyFragmentInfo::get_mbrs)
       .def("dump", &PyFragmentInfo::dump);
 }
 

--- a/tiledb/fragment.cc
+++ b/tiledb/fragment.cc
@@ -77,8 +77,10 @@ public:
     has_consolidated_metadata_ = fill_has_consolidated_metadata();
     to_vacuum_ = fill_to_vacuum_uri();
 
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 5
     if (include_mbrs)
       mbrs_ = fill_mbr();
+#endif
 
     close();
   }
@@ -242,6 +244,7 @@ private:
     return py::tuple(l);
   }
 
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 5
   py::tuple fill_mbr() const {
     py::list all_frags;
     uint32_t nfrag = fragment_num();
@@ -281,6 +284,7 @@ private:
     fi_->get_mbr(fid, mid, did, buffer.ptr);
     return std::move(limits);
   }
+#endif
 };
 
 void init_fragment(py::module &m) {
@@ -298,7 +302,9 @@ void init_fragment(py::module &m) {
       .def("get_has_consolidated_metadata",
            &PyFragmentInfo::get_has_consolidated_metadata)
       .def("get_to_vacuum", &PyFragmentInfo::get_to_vacuum)
+#if TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 5
       .def("get_mbrs", &PyFragmentInfo::get_mbrs)
+#endif
       .def("dump", &PyFragmentInfo::dump);
 }
 

--- a/tiledb/fragment.py
+++ b/tiledb/fragment.py
@@ -116,7 +116,14 @@ class FragmentInfoList:
         self.to_vacuum = fi.get_to_vacuum()
 
         if include_mbrs:
-            self.mbrs = fi.get_mbrs()
+            if tiledb.libtiledb.version() <= (2, 5, 0):
+                self.mbrs = fi.get_mbrs()
+            else:
+                warnings.warn(
+                    "MBRs for fragments not available; "
+                    "please install libtiledb 2.5.0+",
+                    UserWarning,
+                )
 
     @property
     def non_empty_domain(self):

--- a/tiledb/fragment.py
+++ b/tiledb/fragment.py
@@ -21,17 +21,16 @@ class FragmentInfoList:
     :param include_mbrs: (default False) include minimum bounding rectangles in FragmentInfo result
     :type include_mbrs: bool
 
-    Class attributes:
-        - `uri`: URIs of fragments
-        - `version`: Fragment version of each fragment
-        - `nonempty_domain`: Non-empty domain of each fragment
-        - `cell_num`: Number of cells in each fragment
-        - `timestamp_range`: Timestamp range of when each fragment was written
-        - `sparse`: For each fragment, True if fragment is sparse, else False
-        - `has_consolidated_metadata`: For each fragment, True if fragment has consolidated fragment metadata, else False
-        - `unconsolidated_metadata_num`: Number of unconsolidated metadata fragments in each fragment
-        - `to_vacuum`: URIs of already consolidated fragments to vacuum
-        - `mbrs`: The mimimum bounding rectangle of each fragment; only present when `include_mbrs=True`
+    :ivar uri: URIs of fragments
+    :ivar version: Fragment version of each fragment
+    :ivar nonempty_domain: Non-empty domain of each fragment
+    :ivar cell_num: Number of cells in each fragment
+    :ivar timestamp_range: Timestamp range of when each fragment was written
+    :ivar sparse: For each fragment, True if fragment is sparse, else False
+    :ivar has_consolidated_metadata: For each fragment, True if fragment has consolidated fragment metadata, else False
+    :ivar unconsolidated_metadata_num: Number of unconsolidated metadata fragments in each fragment
+    :ivar to_vacuum: URIs of already consolidated fragments to vacuum
+    :ivar mbrs: The mimimum bounding rectangle of each fragment; only present when `include_mbrs=True`
 
     **Example:**
 
@@ -210,17 +209,16 @@ class FragmentInfo:
     """
     Class representing the metadata for a single fragment. See :py:class:`tiledb.FragmentInfoList` for example of usage.
 
-    Class attributes:
-        - `uri`: URIs of fragments
-        - `version`: Fragment version of each fragment
-        - `nonempty_domain`: Non-empty domain of each fragment
-        - `cell_num`: Number of cells in each fragment
-        - `timestamp_range`: Timestamp range of when each fragment was written
-        - `sparse`: For each fragment, True if fragment is sparse, else False
-        - `has_consolidated_metadata`: For each fragment, True if fragment has consolidated fragment metadata, else False
-        - `unconsolidated_metadata_num`: Number of unconsolidated metadata fragments in each fragment
-        - `to_vacuum`: URIs of already consolidated fragments to vacuum
-        - `mbrs`: The mimimum bounding rectangle of each fragment; only present when `include_mbrs=True`
+    :ivar uri: URIs of fragments
+    :ivar version: Fragment version of each fragment
+    :ivar nonempty_domain: Non-empty domain of each fragment
+    :ivar cell_num: Number of cells in each fragment
+    :ivar timestamp_range: Timestamp range of when each fragment was written
+    :ivar sparse: For each fragment, True if fragment is sparse, else False
+    :ivar has_consolidated_metadata: For each fragment, True if fragment has consolidated fragment metadata, else False
+    :ivar unconsolidated_metadata_num: Number of unconsolidated metadata fragments in each fragment
+    :ivar to_vacuum: URIs of already consolidated fragments to vacuum
+    :ivar mbrs: The mimimum bounding rectangle of each fragment; only present when `include_mbrs=True`
     """
 
     def __init__(self, fragments: FragmentInfoList, num):

--- a/tiledb/fragment.py
+++ b/tiledb/fragment.py
@@ -14,12 +14,12 @@ class FragmentInfoList:
     """
     Class representing an ordered list of FragmentInfo objects.
 
-    :param array_uri: The URI of the TileDB array.
+    :param array_uri: URI for the TileDB array (any supported TileDB URI)
     :type array_uri: str
-    :param ctx: A TileDB context
-    :type ctx: tiledb.Ctx
     :param include_mbrs: (default False) include minimum bounding rectangles in FragmentInfo result
     :type include_mbrs: bool
+    :param ctx: A TileDB context
+    :type ctx: tiledb.Ctx
 
     :ivar uri: URIs of fragments
     :ivar version: Fragment version of each fragment

--- a/tiledb/highlevel.py
+++ b/tiledb/highlevel.py
@@ -105,19 +105,29 @@ def array_exists(uri, isdense=False, issparse=False):
         return False
 
 
-def array_fragments(uri, ctx=None):
+def array_fragments(uri, include_mbrs=False, ctx=None):
     """
-    Creates a FragmentInfoList object, which is an ordered list of FragmentInfo
-    objects, representing all fragments in the array at the URI.
+    Creates a `FragmentInfoList` object, which is an ordered list of `FragmentInfo`
+    objects, representing all fragments in the array at the given URI.
 
-    FragmentInfo objects contain fragment metadata such as the fragment URI,
-    whether it is sparse or dense, timestamp, number of cells, etc.
+    The returned object contain the following attributes:
+        - `uri`: URIs of fragments
+        - `version`: Fragment version of each fragment
+        - `nonempty_domain`: Non-empty domain of each fragment
+        - `cell_num`: Number of cells in each fragment
+        - `timestamp_range`: Timestamp range of when each fragment was written
+        - `sparse`: For each fragment, True if fragment is sparse, else False
+        - `has_consolidated_metadata`: For each fragment, True if fragment has consolidated fragment metadata, else False
+        - `unconsolidated_metadata_num`: Number of unconsolidated metadata fragments in each fragment
+        - `to_vacuum`: URIs of already consolidated fragments to vacuum
+        - `mbrs`: The mimimum bounding rectangle of each fragment; only present when `include_mbrs=True`
 
     :param str uri: URI for the TileDB array (any supported TileDB URI)
+    :param bool include_mbrs: Include minimum bouding rectangles in result; this is disabled by default for optimize time and space
     :param ctx: (optional) TileDB Ctx
-    :return: FragmentsInfo object
+    :return: FragmentInfoList
     """
-    return tiledb.FragmentInfoList(uri, ctx)
+    return tiledb.FragmentInfoList(uri, include_mbrs, ctx)
 
 
 def delete_fragments(

--- a/tiledb/tests/test_fragment_info.py
+++ b/tiledb/tests/test_fragment_info.py
@@ -420,6 +420,10 @@ class FragmentInfoTest(DiskTestCase):
 
         assert len(fragment_info.get_to_vacuum()) == 0
 
+    @pytest.mark.skipif(
+        tiledb.libtiledb.version() < (2, 5, 0),
+        reason="MBRs in FragmentInfo only availabe in ilbtiledb<=2.5.0",
+    )
     def test_get_mbr(self):
         fragments = 3
 


### PR DESCRIPTION
* Retrieve the minimum bounding rectangle for each fragment
* Correct parameter and class attribute documentation for `FragmentInfo{,List}`
* Refactor `PyFragmentInfo` to call `load()` and `close()` in constructor
* Refactor `PyFragmentInfo` to use getter functions to return read-only attributes instead of directly accessing public attributes