### PR TITLE
`tiledb.version.version` Returns Version As Tuple

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
 ## Impovements
 * Support for Python 3.10 [#808](https://github.com/TileDB-Inc/TileDB-Py/pull/808)
 
+## API Changes
+* Addition of `tiledb.version()` to return verison as a tuple [#801](https://github.com/TileDB-Inc/TileDB-Py/pull/801)
+
 # TileDB-Py 0.11.2 Release Notes
 
 ## TileDB Embedded updates:

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 * Support for Python 3.10 [#808](https://github.com/TileDB-Inc/TileDB-Py/pull/808)
 
 ## API Changes
-* Addition of `tiledb.version()` to return verison as a tuple [#801](https://github.com/TileDB-Inc/TileDB-Py/pull/801)
+* Addition of `tiledb.version()` to return version as a tuple [#801](https://github.com/TileDB-Inc/TileDB-Py/pull/801)
 
 # TileDB-Py 0.11.2 Release Notes
 

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -101,6 +101,10 @@ from .parquet_ import from_parquet
 
 from .version import version as __version__
 
+from .version_ import VersionHelper
+
+version = VersionHelper()
+
 # Note: we use a modified namespace packaging to allow continuity of existing TileDB-Py imports.
 #       Therefore, 'tiledb/__init__.py' must *only* exist in this package.
 #       Furthermore, in sub-packages, the `find_packages` helper will not work at the

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -40,11 +40,19 @@ from tiledb.util import schema_from_dict
 
 
 class VersionTest(DiskTestCase):
-    def test_version(self):
+    def test_libtiledb_version(self):
         v = tiledb.libtiledb.version()
         self.assertIsInstance(v, tuple)
         self.assertTrue(len(v) == 3)
         self.assertTrue(v[0] >= 1, "TileDB major version must be >= 1")
+
+    def test_tiledbpy_version(self):
+        v = tiledb.version.version
+        self.assertIsInstance(v, str)
+
+        v = tiledb.version()
+        self.assertIsInstance(v, tuple)
+        self.assertTrue(3 <= len(v) <= 5)
 
 
 class StatsTest(DiskTestCase):

--- a/tiledb/version_.py
+++ b/tiledb/version_.py
@@ -1,0 +1,12 @@
+from .version import version, version_tuple
+
+
+class VersionHelper:
+    def __getattr__(self, name):
+        if name == "version":
+            return version
+        else:
+            raise AttributeError
+
+    def __call__(self):
+        return version_tuple


### PR DESCRIPTION
- Modified to synchronize with `tiledb.libtiledb.version()`