### PR TITLE
Remove temporary xfail for test_incomplete_df

### DIFF
--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -1191,10 +1191,6 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             data[2] = ""
             assert_array_equal(A.multi_index[:]["data"], data)
 
-    @pytest.mark.xfail(
-        date.today() <= date(2021, 12, 6),
-        reason="Temporary error residing from libtiledb that will be fixed soon",
-    )
     def test_incomplete_df(self):
         ncells = 1000
         null_count = round(0.56 * ncells)


### PR DESCRIPTION
Fixed by https://github.com/TileDB-Inc/TileDB/commit/e40aba3eaf6783fbec290e44ed5e177513e4dc8a -- Thanks @KiterLuc.