### PR TITLE
Support Writes to Zero Attribute Array

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,20 +12,12 @@ jobs:
       - name: Check Python Black Format
         # restore after https://github.com/psf/black/issues/2079
         #uses: psf/black@stable
-        uses: psf/black@20.8b1
+        uses: psf/black@21.12b0
         with:
           args: ". --check"
 
-<<<<<<< HEAD
-#      - name: Check Clang-Format
-#        uses: jidicula/clang-format-action@v4.4.0
-#        with:
-#           clang-format-version: '9'
-#           check-path: 'tiledb'
-=======
       - name: Check Clang-Format
-        uses: jidicula/clang-format-action@v4.4.0
+        uses: DoozyX/clang-format-lint-action@v0.13
         with:
-          clang-format-version: '9'
-          check-path: 'tiledb'
->>>>>>> Update HISTORY.md
+          clangFormatVersion: '10'
+          source: 'tiledb'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,8 +16,16 @@ jobs:
         with:
           args: ". --check"
 
+<<<<<<< HEAD
 #      - name: Check Clang-Format
 #        uses: jidicula/clang-format-action@v4.4.0
 #        with:
 #           clang-format-version: '9'
 #           check-path: 'tiledb'
+=======
+      - name: Check Clang-Format
+        uses: jidicula/clang-format-action@v4.4.0
+        with:
+          clang-format-version: '9'
+          check-path: 'tiledb'
+>>>>>>> Update HISTORY.md

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,10 @@
+# TileDB-Py 0.11.6 Release Notes
+
+## API Changes
+* Allow writing to a non-attribute array by setting `tiledb.Array(coords) = None` [#854](https://github.com/TileDB-Inc/TileDB-Py/pull/854)
+
 # TileDB-Py 0.11.5 Release Notes
+
 * Added missing dependency on [`packaging`](https://pypi.org/project/packaging/) in requirements.txt [#852](https://github.com/TileDB-Inc/TileDB-Py/pull/852)
 
 # TileDB-Py 0.11.4 Release Notes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # TileDB-Py 0.11.6 Release Notes
 
 ## API Changes
-* Allow writing to a non-attribute array by setting `tiledb.Array(coords) = None` [#854](https://github.com/TileDB-Inc/TileDB-Py/pull/854)
+* Allow writing to dimension-only array (zero attributes) by using assignment to `None`, for example: `A[coords] = None` (given `A: tiledb.Array`) [#854](https://github.com/TileDB-Inc/TileDB-Py/pull/854)
 
 # TileDB-Py 0.11.5 Release Notes
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2771,6 +2771,22 @@ class TestSparseArray(DiskTestCase):
             with self.assertRaises(ValueError):
                 A.unique_dim_values("dim3")
 
+    def test_sparse_write_for_zero_attrs(self):
+        uri = self.path("test_sparse_write_to_zero_attrs")
+        dim = tiledb.Dim(name="dim", domain=(0, 9), dtype=np.float64)
+        schema = tiledb.ArraySchema(domain=tiledb.Domain(dim), sparse=True)
+        tiledb.Array.create(uri, schema)
+
+        coords = [1, 2.0, 3.5]
+
+        with tiledb.open(uri, "w") as A:
+            A[coords] = None
+
+        with tiledb.open(uri, "r") as A:
+            output = A.query()[:]
+            assert list(output.keys()) == ["dim"]
+            assert_array_equal(output["dim"][:], coords)
+
 
 class TestDenseIndexing(DiskTestCase):
     def _test_index(self, A, T, idx):


### PR DESCRIPTION
* Allow writing to dimension-only array (zero attributes) by using assignment to `None`, for example: `A[coords] = None` (given `A: tiledb.Array`)