### PR TITLE
Cast Dimension Dtype to String Prior to Apply HTML Escape

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# TileDB-Py 0.12.1 Release Notes
+
+## Bug fixes
+* Cast 'dim`'s dtype in `Domain` to `str` prior to applying `html.escape` [#883](https://github.com/TileDB-Inc/TileDB-Py/pull/883)
+
 # TileDB-Py 0.12.0 Release Notes
 
 ## TileDB Embedded updates:

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3151,7 +3151,7 @@ cdef class Domain(object):
             output.write(f"<td>{html.escape(dim.name)}</td>\n")
             output.write(f"<td>{dim.domain}</td>\n")
             output.write(f"<td>{dim.tile}</td>\n")
-            output.write(f"<td>{html.escape(dim.dtype)}</td>\n")
+            output.write(f"<td>{html.escape(str(dim.dtype))}</td>\n")
             output.write(f"<td>{dim.dtype in (np.str_, np.bytes_) }</td>\n")
             output.write(f"<td>{dim.filters._repr_html_()}</td>\n")
             output.write("</tr>\n")


### PR DESCRIPTION
![htmldimfix](https://user-images.githubusercontent.com/3269006/149992105-87cfdf4c-09a5-420e-b736-c77404b73031.png)
