### PR TITLE
Cast Operands in `QueryCondition` Using attr() or val()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 * Cast 'dim`'s dtype in `Domain` to `str` prior to applying `html.escape` [#883](https://github.com/TileDB-Inc/TileDB-Py/pull/883)
+* Support attributes with spaces in `QueryCondition` by casting with attr(); values may be casted with val() [#886](https://github.com/TileDB-Inc/TileDB-Py/pull/886)
 
 # TileDB-Py 0.12.0 Release Notes
 

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -992,8 +992,12 @@ public:
         if ((buf.data_vals_read == 0) ||
             (int64_t)(buf.data_vals_read * buf.elem_nbytes) >
                 (buf.data.nbytes() + 1) / 2) {
+          std::cout << "buf.data_vals_read: " << buf.data_vals_read
+                    << std::endl;
           size_t new_size = buf.data.size() * 2;
           buf.data.resize({new_size}, false);
+          std::cout << "buf.data.size() resized to " << buf.data.size()
+                    << std::endl;
         }
 
         // Check if offset buffer should be resized

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -687,7 +687,7 @@ public:
         TPY_ERROR_LOC(e.what());
       }
 
-      auto pyqc = (attr_cond.attr("_c_obj")).cast<PyQueryCondition>();
+      auto pyqc = (attr_cond.attr("c_obj")).cast<PyQueryCondition>();
       auto qc = pyqc.ptr().get();
       query_->set_condition(*qc);
     }

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -992,12 +992,8 @@ public:
         if ((buf.data_vals_read == 0) ||
             (int64_t)(buf.data_vals_read * buf.elem_nbytes) >
                 (buf.data.nbytes() + 1) / 2) {
-          std::cout << "buf.data_vals_read: " << buf.data_vals_read
-                    << std::endl;
           size_t new_size = buf.data.size() * 2;
           buf.data.resize({new_size}, false);
-          std::cout << "buf.data.size() resized to " << buf.data.size()
-                    << std::endl;
         }
 
         // Check if offset buffer should be resized

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -128,7 +128,15 @@ class QueryConditionTree(ast.NodeVisitor):
             raise tiledb.TileDBError("Unsupported comparison operator.")
 
         is_att = lambda a: isinstance(a, ast.Name) or (
-            isinstance(a, ast.Constant) and hasattr(a, "qc_type")
+            (
+                (
+                    isinstance(a, ast.Constant)
+                    or isinstance(a, ast.Num)
+                    or isinstance(a, ast.Str)
+                    or isinstance(a, ast.Bytes)
+                )
+                and hasattr(a, "qc_type")
+            )
         )
 
         if not is_att(att):
@@ -149,6 +157,9 @@ class QueryConditionTree(ast.NodeVisitor):
                 att = att.id
             elif isinstance(att, ast.Constant):
                 att = att.value
+            elif isinstance(att, ast.Str) or isinstance(att, ast.Bytes):
+                # deprecated in 3.8
+                att = att.s
         else:
             raise tiledb.TileDBError("Incorrect type for attribute name.")
 

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -117,11 +117,11 @@ class QueryCondition(ast.NodeVisitor):
         except KeyError:
             raise tiledb.TileDBError("Unsupported comparison operator.")
 
-        is_attr = isinstance(att, ast.Name) or (
-            isinstance(att, ast.Constant) and hasattr(att, "qc_type")
+        is_att = lambda a: isinstance(a, ast.Name) or (
+            isinstance(a, ast.Constant) and hasattr(a, "qc_type")
         )
 
-        if not is_attr:
+        if not is_att(att):
             REVERSE_OP = {
                 qc.TILEDB_GT: qc.TILEDB_LT,
                 qc.TILEDB_GE: qc.TILEDB_LE,
@@ -134,7 +134,7 @@ class QueryCondition(ast.NodeVisitor):
             op = REVERSE_OP[op]
             att, val = val, att
 
-        if is_attr:
+        if is_att(att):
             if isinstance(att, ast.Name):
                 att = att.id
             elif isinstance(att, ast.Constant):

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -60,7 +60,7 @@ class QueryCondition:
     """
 
     expression: str
-    ctx: tiledb.Ctx = field(default=tiledb.default_ctx(), repr=False)
+    ctx: tiledb.Ctx = field(default_factory=tiledb.default_ctx, repr=False)
     tree: ast.AST = field(default=None, repr=False)
     c_obj: PyQueryCondition = field(init=False, repr=False)
 


### PR DESCRIPTION
* Previously, there was no way to apply query conditions to attributes
  with spaces. With the addition of the attr() cast, it is now possible to
  do `tiledb.QueryCondition("attr('attributes with spaces') == 'val'))`