### PR TITLE
Correct `QueryCondition` Typing Against pyright

### DIFF
--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -143,11 +143,11 @@ class QueryConditionTree(ast.NodeVisitor):
 
     def aux_visit_Compare(
         self,
-        att_node: QueryConditionNodeElem,
+        lhs: QueryConditionNodeElem,
         op_node: qc.tiledb_query_condition_op_t,
-        val_node: QueryConditionNodeElem,
+        rhs: QueryConditionNodeElem,
     ) -> PyQueryCondition:
-        att, val, op = self.order_nodes(att_node, val_node, op_node)
+        att, val, op = self.order_nodes(lhs, rhs, op_node)
 
         att = self.get_att_from_node(att)
         val = self.get_val_from_node(val)


### PR DESCRIPTION
Most errors have been fixed except the following.

```
(tiledb-3.10) vivian@mangonada:~/TileDB-Py$ pyright tiledb/query_condition.py
No configuration file found.
pyproject.toml file found at /home/vivian/TileDB-Py.
Loading pyproject.toml file at /home/vivian/TileDB-Py/pyproject.toml
Pyproject file "/home/vivian/TileDB-Py/pyproject.toml" is missing "[tool.pyright]" section.
stubPath /home/vivian/TileDB-Py/typings is not a valid directory.
Assuming Python platform Linux
Searching for source files
Found 1 source file
/home/vivian/TileDB-Py/tiledb/query_condition.py
  /home/vivian/TileDB-Py/tiledb/query_condition.py:296:18 - error: Argument of type "Type[operator]" cannot be assigned to parameter "__k" of type "Type[BitAnd]" in function "__getitem__"
    "Type[operator]" is incompatible with "Type[BitAnd]"
    Type "Type[operator]" cannot be assigned to type "Type[BitAnd]" (reportGeneralTypeIssues)
  /home/vivian/TileDB-Py/tiledb/query_condition.py:316:18 - error: Argument of type "Type[boolop]" cannot be assigned to parameter "__k" of type "Type[And]" in function "__getitem__"
    "Type[boolop]" is incompatible with "Type[And]"
    Type "Type[boolop]" cannot be assigned to type "Type[And]" (reportGeneralTypeIssues)
2 errors, 0 warnings, 0 informations
Completed in 0.992sec
```