### PR TITLE
Building docs need to mention --enable-serialization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,9 @@ Thanks for your interest in TileDB-Py. The notes below give some pointers for fi
     - from [conda-forge](): `mamba install tiledb`
       - `--tiledb=$CONDA_PREFIX`
     - from source: https://docs.tiledb.com/main/how-to/installation/building-from-source/c-cpp
-      - use `--tiledb=/path/to/tiledb/dist`
+      - use `--tiledb=/path/to/tiledb/dist` option when running ``setup.py`` in the step below
+      - also please note that libtiledb needs to be built with serialization enabled for TileDB-Py build to succeed
+        (pass the ``--enable-serialization`` option to the ``bootstrap`` script before compiling)
             
   - build TileDB-Py
   ```


### PR DESCRIPTION
When I followed the building instructions step by step,
I got a compile error during setup.py execution saying
tiledb_serialization.h can't be found (libtiledb was also
built from sources)
Turns out, according to @ypatia, libtiledb needs to be built
with --enable-serialization so the header is made available in the
libtiledb dist/ directory.
I updated the CONTRIBUTING.md file to let the users know about this.