### PR TITLE
Fix SC-13800: properly initialize query in order to retrieve estimated results

### DIFF
--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -4361,17 +4361,17 @@ class IncompleteTest(DiskTestCase):
         idx = 0
         with tiledb.open(path, ctx=tiledb.Ctx(cfg)) as A:
             query = A.query(return_incomplete=True, return_arrow=return_arrow)
-            iterable = getattr(query, indexer)
+            iterable = getattr(query, indexer)[:]
 
-            for result in iterable[:]:
+            est_results = iterable.estimated_result_sizes()
+            assert isinstance(est_results[""], EstimatedResultSize)
+            assert isinstance(est_results["__dim_0"], EstimatedResultSize)
+            assert est_results["__dim_0"].offsets_bytes == 0
+            assert est_results["__dim_0"].data_bytes > 0
+            assert est_results[""].offsets_bytes > 0
+            assert est_results[""].data_bytes > 0
 
-                est_results = iterable.estimated_result_sizes()
-                assert isinstance(est_results[""], EstimatedResultSize)
-                assert isinstance(est_results["__dim_0"], EstimatedResultSize)
-                assert est_results["__dim_0"].offsets_bytes == 0
-                assert est_results["__dim_0"].data_bytes > 0
-                assert est_results[""].offsets_bytes > 0
-                assert est_results[""].data_bytes > 0
+            for result in iterable:
 
                 if return_arrow:
                     assert isinstance(result, pa.Table)


### PR DESCRIPTION
In return_incomplete mode, prior to this PR the multi_index and df indexer
estimated_result_sizes function would error out until iteration was started,
because the underlying query object was not initialized. In this PR we
fix this issue by initializing the query and updating iteration logic
using a state enum.