### PR TITLE
Release 0.12.3 against 2.6.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,6 @@
 ## Bug Fixes
 * Enable building with serialization disabled [#924](https://github.com/TileDB-Inc/TileDB-Py/pull/924)
 * Do not print out `FragmentInfo_frags` for `repr` [#925](https://github.com/TileDB-Inc/TileDB-Py/pull/925)
-## Bug Fixes
 * Error out with `IndexError` when attempting to use a step in the regular indexer [#911](https://github.com/TileDB-Inc/TileDB-Py/pull/911)
 
 # TileDB-Py 0.12.2 Release Notes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,11 +1,11 @@
-# TileDB-Py 0.13.0 Release Notes
+# TileDB-Py 0.12.3 Release Notes
+
+## TileDB Embedded updates:
+* TileDB-Py 0.12.3 includes TileDB Embedded [TileDB 2.6.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.6.3)
 
 ## Bug Fixes
 * Enable building with serialization disabled [#924](https://github.com/TileDB-Inc/TileDB-Py/pull/924)
 * Do not print out `FragmentInfo_frags` for `repr` [#925](https://github.com/TileDB-Inc/TileDB-Py/pull/925)
-
-# TileDB-Py 0.12.3 Release Notes
-
 ## Bug Fixes
 * Error out with `IndexError` when attempting to use a step in the regular indexer [#911](https://github.com/TileDB-Inc/TileDB-Py/pull/911)
 

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,9 +6,9 @@ stages:
       LIBTILEDB_VERSION: dev
       LIBTILEDB_SHA: dev
     ${{ else }}:
-      TILEDBPY_VERSION: 0.12.2
-      LIBTILEDB_VERSION: 2.6.2
-      LIBTILEDB_SHA: bf10e49b29ac51a6c6f0caa1cdac7c6d1154d670
+      TILEDBPY_VERSION: 0.12.3
+      LIBTILEDB_VERSION: 2.6.3
+      LIBTILEDB_SHA: 534ca7cbc65298cc1ec3184fb0fcafd2a2305a57
     LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
     TILEDB_SRC: '$(Build.Repository.Localpath)/tiledb_src'
     TILEDB_BUILD: '$(Build.Repository.Localpath)/tiledb_build'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from pkg_resources import resource_filename
 from setuptools import Extension, find_packages, setup
 
 # Target branch
-TILEDB_VERSION = "2.6.2"
+TILEDB_VERSION = "2.6.3"
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION
 

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -304,8 +304,8 @@ class QueryConditionTest(DiskTestCase):
             assert list(result["dim"]) == [b"a", b"c"]
 
     @pytest.mark.skipif(
-        tiledb.libtiledb.version() < (2, 6, 3),
-        reason="var-length np.bytes_ query condition support introduced in 2.6.3",
+        tiledb.libtiledb.version() < (2, 7, 0),
+        reason="var-length np.bytes_ query condition support introduced in 2.7.0",
     )
     def test_var_length_str(self):
         path = self.path("test_var_length_str")


### PR DESCRIPTION
```
(tiledb-clean-3.10) vivian@mangonada:~/drop$ python
Python 3.10.0 (default, Dec 21 2021, 13:36:04) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tiledb
>>> tiledb.version()
(0, 12, 3)
>>> tiledb.libtiledb.version()
(2, 6, 3)
>>>
```