### PR TITLE
Return dict from debug function get_buffers

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -857,13 +857,16 @@ public:
   }
 
   py::object get_buffers() {
-    py::list result;
+    py::dict rmap;
     for (auto &bp : buffers_) {
+      py::list result;
+      const auto name = bp.first;
       const BufferInfo b = bp.second;
       result.append(b.data);
       result.append(b.offsets);
+      rmap[py::str{name}] = result;
     }
-    return std::move(result);
+    return std::move(rmap);
   }
 
   void set_buffers() {

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -33,8 +33,8 @@ class FixesTest(DiskTestCase):
         # result array size, and asserts that the allocated buffers match
         # the expected result size rather than py.alloc_max_bytes.
         uri = self.path()
-        max = 1024**2 + 1
-        with tiledb.from_numpy(uri, np.uint8(range(max))):
+        max_val = 1024**2 + 1
+        with tiledb.from_numpy(uri, np.uint8(range(max_val))):
             pass
         with tiledb.scope_ctx(
             {"py.init_buffer_bytes": 2 * 1024**2, "py.alloc_max_bytes": 1024**2}
@@ -42,10 +42,10 @@ class FixesTest(DiskTestCase):
             with tiledb.open(uri) as b:
                 q = tiledb.main.PyQuery(ctx3, b, ("",), (), 0, False)
                 q._return_incomplete = True
-                q.set_ranges([[(0, max)]])
+                q.set_ranges([[(0, max_val)]])
                 q._allocate_buffers()
-                buffers = q._get_buffers()
-                assert buffers[0].nbytes == max
+                buffers = list(*q._get_buffers().values())
+                assert buffers[0].nbytes == max_val
 
     @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_ch10282_concurrent_multi_index(self):


### PR DESCRIPTION
This function is not used in any active codepath, only for debugging/testing.

(needed this locally, might as well change it for next time)