### PR TITLE
Fix delete_fragments and remove xfail

### DIFF
--- a/tiledb/fragment.py
+++ b/tiledb/fragment.py
@@ -390,7 +390,8 @@ def delete_fragments(
     # relevant to check if we need to delete new style schemas. we will need to
     # check both in the future.
     array_fragments = tiledb.array_fragments(uri)
-    deleted_fragment_schema = set()
+    live_fragment_schemas = set()
+    deleted_fragment_schemas = set()
     for frag in array_fragments:
         if (
             timestamp_range[0] <= frag.timestamp_range[0]
@@ -410,10 +411,11 @@ def delete_fragments(
                 vfs.remove_dir(frag.uri)
                 vfs.remove_file(ok_or_wrt)
 
-            deleted_fragment_schema.add(frag.array_schema_name)
+            deleted_fragment_schemas.add(frag.array_schema_name)
+        else:
+            live_fragment_schemas.add(frag.array_schema_name)
 
-    schemas_in_array = set(array_fragments.array_schema_name)
-    schemas_to_remove_on_disk = list(schemas_in_array - deleted_fragment_schema)
+    schemas_to_remove_on_disk = list(deleted_fragment_schemas - live_fragment_schemas)
     if schemas_to_remove_on_disk and (verbose or dry_run):
         print("Deleting schemas:")
 

--- a/tiledb/tests/test_fragments.py
+++ b/tiledb/tests/test_fragments.py
@@ -598,10 +598,6 @@ class DeleteFragmentsTest(DiskTestCase):
         assert len(frags) == 6
         assert frags.timestamp_range == ts[:2] + ts[6:]
 
-    @pytest.mark.xfail(
-        date.today() <= date(2022, 3, 16),
-        reason="need to modify delete_fragments() to work with schema evolution",
-    )
     def test_delete_fragments_with_schema_evolution(self):
         path = self.path("test_delete_fragments_with_schema_evolution")
         dshape = (1, 3)


### PR DESCRIPTION
The root cause of SC-15271 was deleting the wrong schema, because
we were removing the _deleted_ schema from the target set when
generating the set difference, leaving only the live schema.