### PR TITLE
Set `fail-fast` To `false`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-10.15, windows-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
+      fail-fast: false
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.14
     steps:

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-10.15, windows-latest]
         uninstall_pandas: [true, false]
+      fail-fast: false
 
     permissions:
       issues: write


### PR DESCRIPTION
* By default on GitHub actions, all jobs are cancelled when a job fails. 
  This setting makes it so that other jobs will continue to run.