### PR TITLE
Release 0.14.0 Against 2.8.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
-# In-Progress 
+# TileDB-Py 0.14.0 Release Notes
+
+## TileDB Embedded updates:
+* TileDB-Py 0.14.0 includes TileDB Embedded [TileDB 2.8.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.8.0)
 
 ## API Changes
 * Addition of `Group` and `Object` classes to support improved groups [#1022](https://github.com/TileDB-Inc/TileDB-Py/pull/1022)

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,9 +6,9 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.13.3
-        LIBTILEDB_VERSION: 2.7.2
-        LIBTILEDB_SHA: c0362d4892fc7c045c3290078c63ff46d4144e1a
+        TILEDBPY_VERSION: 0.14.0
+        LIBTILEDB_VERSION: 2.8.0
+        LIBTILEDB_SHA: f8efd39240b2e310e3ddd91d0b482218e7086163
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"


### PR DESCRIPTION
Note that `setup.py` is already using 2.8.0 (was modified for testing the Group API PR).