### PR TITLE
Change `setuptools` Pin From `<=61.0` To `<=59.5.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42,<61.0", "wheel", "pybind11>=2.6.2"]
+requires = ["setuptools>=42,<=59.5.0", "wheel", "pybind11>=2.6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
* Otherwise the MacOSX Conda build for Python 3.7 errors out with
  `AttributeError: module 'setuptools' has no attribute 'version'`