### PR TITLE
Correct `Group.__repr__` 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# In Progress
+
+## Bug Fixes
+* Correct `Group.__repr__` to call correct `_dump` function [#1038](https://github.com/TileDB-Inc/TileDB-Py/pull/1038)
+
 # TileDB-Py 0.14.0 Release Notes
 
 ## TileDB Embedded updates:

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -258,7 +258,7 @@ class Group(lt.Group):
         return iter(self[i] for i in range(len(self)))
 
     def __repr__(self):
-        return self.dump(True)
+        return self._dump(True)
 
     @property
     def meta(self) -> GroupMetadata:

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -153,7 +153,7 @@ class GroupTest(GroupTestCase):
         assert type_to_basename[grp[0].type] == os.path.basename(grp[0].uri)
         assert grp[1].type in type_to_basename
         assert type_to_basename[grp[1].type] == os.path.basename(grp[1].uri)
-        
+
         assert "test_group_members GROUP" in repr(grp)
         assert "|-- test_group_members ARRAY" in repr(grp)
         assert "|-- test_group_0 GROUP" in repr(grp)
@@ -205,5 +205,3 @@ class GroupTest(GroupTestCase):
         grp.open("r")
         assert len(grp) == 0
         grp.close()
-        
-        

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -1,7 +1,6 @@
 import os
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
 
 import tiledb
 from tiledb.tests.common import DiskTestCase
@@ -121,7 +120,7 @@ class GroupTest(GroupTestCase):
         # assert "int" not in grp.meta
         # grp.close()
 
-    def test_group_members(self):
+    def test_group_members(self, capfd):
         grp_path = self.path("test_group_members")
         tiledb.Group.create(grp_path)
 
@@ -154,6 +153,10 @@ class GroupTest(GroupTestCase):
         assert type_to_basename[grp[0].type] == os.path.basename(grp[0].uri)
         assert grp[1].type in type_to_basename
         assert type_to_basename[grp[1].type] == os.path.basename(grp[1].uri)
+        
+        assert "test_group_members GROUP" in repr(grp)
+        assert "|-- test_group_members ARRAY" in repr(grp)
+        assert "|-- test_group_0 GROUP" in repr(grp)
 
         grp.close()
 
@@ -202,3 +205,5 @@ class GroupTest(GroupTestCase):
         grp.open("r")
         assert len(grp) == 0
         grp.close()
+        
+        


### PR DESCRIPTION
* The low level pybind11 function had been renamed to `_dump` but was
  not changed in the API.
* Adding test for group repr