### PR TITLE
Release 0.14.1 against TileDB 2.8.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# TileDB-Py 0.14.1 Release Notes
+
+## TileDB Embedded updates:
+* TileDB-Py 0.14.1 includes TileDB Embedded [TileDB 2.8.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.8.1)
+
 # TileDB-Py 0.14.0 Release Notes
 
 ## TileDB Embedded updates:

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,9 +6,9 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.14.0
-        LIBTILEDB_VERSION: 2.8.0
-        LIBTILEDB_SHA: f8efd39240b2e310e3ddd91d0b482218e7086163
+        TILEDBPY_VERSION: 0.14.1
+        LIBTILEDB_VERSION: 2.8.1
+        LIBTILEDB_SHA: e9a945c4591f643ee9f183b1c9455b1eb848945f
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from pybind11.setup_helpers import Pybind11Extension
 ### DO NOT USE ON CI
 
 # Target branch
-TILEDB_VERSION = "e9a945c4591f643ee9f183b1c9455b1eb848945f"  # 2.8.1
+TILEDB_VERSION = "2.8.1"
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from pybind11.setup_helpers import Pybind11Extension
 ### DO NOT USE ON CI
 
 # Target branch
-TILEDB_VERSION = "2.8.0"
+TILEDB_VERSION = "e9a945c4591f643ee9f183b1c9455b1eb848945f"  # 2.8.1
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION
 


### PR DESCRIPTION
```
(py38) [ec2-user@ip-10-0-116-169 tmp]$ python
Python 3.8.8 | packaged by conda-forge | (default, Feb 20 2021, 16:22:27)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tiledb
>>> tiledb.version()
(0, 14, 1)
>>> tiledb.libtiledb.version()
(2, 8, 1)
```