### PR TITLE
Set `setuptools` to `<=59.5.0`

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ numpy >= 1.16.5
 cmake >= 3.21, < 3.22
 cython >= 0.27
 pybind11 >= 2.6.2
-setuptools >= 18.0, < 61.0
+setuptools >= 18.0, <= 59.5.0
 setuptools_scm >= 1.5.4
 wheel >= 0.30
 contextvars ;python_version<"3.7"


### PR DESCRIPTION
* This was set in `pyproject.toml` in TileDB-Inc/TileDB-Py#1032 but also
  needs to be changed in `requirements_dev.txt`
* This is necessary for the the OSX Python 3.7 Conda builds