### PR TITLE
Bump `manylinux2010` Images to `2022-04-24-d28e73e`

### DIFF
--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -34,7 +34,7 @@ stages:
       - job: build1_libtiledb_on_linux
         pool:
           vmImage: "ubuntu-latest"
-        container: quay.io/pypa/manylinux2010_x86_64:2021-11-07-28723f3
+        container: quay.io/pypa/manylinux2010_x86_64:2022-04-24-d28e73e
         variables:
           CXXFLAGS: "-Wno-unused-parameter -lrt -DKJ_USE_EPOLL10 -D__BIONIC__=1"
           CFLAGS: "-Wno-unused-parameter -lrt -DKJ_USE_EPOLL=0 -D__BIONIC__=1"

--- a/misc/pypi_linux/Dockerfile2010
+++ b/misc/pypi_linux/Dockerfile2010
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2010_x86_64:latest
+FROM quay.io/pypa/manylinux2010_x86_64:2022-04-24-d28e73e
 
 ###############################################
 # version args


### PR DESCRIPTION
* Note that this is pinned to the same version in core: https://github.com/TileDB-Inc/TileDB/pull/3111