### PR TITLE
Use `sm.compute_concurrency_level` For `libtiledb`>=2.10

### DIFF
--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -3684,7 +3684,12 @@ class TestHighlevel(DiskTestCase):
         # This test checks that contexts are destroyed correctly.
         # It creates new contexts repeatedly, in-process, and
         # checks that the total number of threads stays stable.
-        config = {"sm.num_reader_threads": 128}
+        threads = (
+            "sm.num_reader_threads"
+            if tiledb.libtiledb.version() < (2, 10)
+            else "sm.compute_concurrency_level"
+        )
+        config = {threads: 128}
         ll = list()
         uri = self.path("test_ctx_thread_cleanup")
         with tiledb.from_numpy(uri, np.random.rand(100)) as A:


### PR DESCRIPTION
Fixes deprecation error

`[2022-05-04 11:44:18.984] [Process: 5350] [error] [Context: 20] Config parameter "sm.num_reader_threads" has been removed; use config parameter "sm.compute_concurrency_level".`