### PR TITLE
Release 0.14.4

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,10 @@
-# In-progress
+# TileDB-Py 0.14.4 Release Notes
 
 ## Misc Updates
 * Update `MACOSX_DEPLOYMENT_TARGET` from 10.14 to 10.15 [#1080](https://github.com/TileDB-Inc/TileDB-Py/pull/1080)
+
+# Bug Fixes
+* Correct handling of Arrow cell count with all empty result [#1082](https://github.com/TileDB-Inc/TileDB-Py/pull/1082)
 
 # TileDB-Py 0.14.3 Release Notes
 

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,7 +6,7 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.14.3
+        TILEDBPY_VERSION: 0.14.4
         LIBTILEDB_VERSION: 2.8.2
         LIBTILEDB_SHA: 6f382df7798ed982aa80676035cb2ba79f7b3e77
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB


### PR DESCRIPTION
```
(tiledb-clean) vivian@mangonada:~/drop$ pip install tiledb-0.14.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
Processing ./tiledb-0.14.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
Collecting numpy>=1.21.0
  Using cached numpy-1.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.8 MB)
Collecting packaging
  Using cached packaging-21.3-py3-none-any.whl (40 kB)
Collecting pyparsing!=3.0.5,>=2.0.2
  Using cached pyparsing-3.0.8-py3-none-any.whl (98 kB)
Installing collected packages: pyparsing, packaging, numpy, tiledb
Successfully installed numpy-1.22.3 packaging-21.3 pyparsing-3.0.8 tiledb-0.14.4
(tiledb-clean) vivian@mangonada:~/drop$ python
Python 3.10.4 (main, Mar 31 2022, 08:41:55) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tiledb
>>> tiledb.version()
(0, 14, 4)
>>> tiledb.libtiledb.version()
(2, 8, 2)
>>>
```