### PR TITLE
[Merge 2.11] Addition of `test_from_numpy_empty_str`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ from pybind11.setup_helpers import Pybind11Extension
 ### DO NOT USE ON CI
 
 # Target branch: Note that this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.10.4"
+TILEDB_VERSION = "2.11.0"
+
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION
 


### PR DESCRIPTION
* Remove `\x00` for `test_varlen_sparse_all_empty_strings`