### PR TITLE
Add New Error Message To `is_boundserror`

### DIFF
--- a/tiledb/tests/test_multi_index-hp.py
+++ b/tiledb/tests/test_multi_index-hp.py
@@ -20,7 +20,11 @@ from hypothesis import strategies as st
 def is_boundserror(exc: Exception):
     assert str(exc) != ""
 
-    vals = ["out of domain bounds", "Cannot add range to dimension"]
+    vals = [
+        "out of domain bounds",
+        "Cannot add range to dimension",
+        "cannot be larger than the higher bound",
+    ]
 
     return any(x in str(exc) for x in vals)
 


### PR DESCRIPTION
* Core is throwing a new error message for ranges that are out of bounds:
        https://github.com/TileDB-Inc/TileDB/commit/563058120c01b258150dfe86faba192a475407f8#diff-cf47a61c916e49adcd1320af3c346b7e710e153118266fe0c580bed858ebba69R328-R330