### PR TITLE
Add __enter__/__exit__ for TileDB Groups

### DIFF
--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -292,6 +292,20 @@ class Group(lt.Group):
     def __repr__(self):
         return self._dump(True)
 
+    def __enter__(self):
+        """
+        The `__enter__` and `__exit__` methods allow TileDB groups to be opened (and auto-closed)
+        using with-as syntax.
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        The `__enter__` and `__exit__` methods allow TileDB groups to be opened (and auto-closed)
+        using with-as syntax.
+        """
+        self.close()
+
     @property
     def meta(self) -> GroupMetadata:
         """

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3486,9 +3486,17 @@ cdef class Array(object):
         return new_array_typed
 
     def __enter__(self):
+        """
+        The `__enter__` and `__exit__` methods allow TileDB arrays to be opened (and auto-closed)
+        using `with tiledb.open(uri) as A:` syntax.
+        """
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        The `__enter__` and `__exit__` methods allow TileDB arrays to be opened (and auto-closed)
+        using `with tiledb.open(uri) as A:` syntax.
+        """
         self.close()
 
     def close(self):

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -197,9 +197,9 @@ class GroupTest(GroupTestCase):
         assert grp["subgroup"].type == tiledb.Group
         grp.close()
 
-        with grp.open("w") as g: # test __enter__ and __exit__
-            del g["subarray"]
-            g.remove("subgroup")
+        with tiledb.Group(grp_path, "w") as grp:  # test __enter__ and __exit__
+            del grp["subarray"]
+            grp.remove("subgroup")
 
         grp.open("r")
         assert len(grp) == 0

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -197,10 +197,9 @@ class GroupTest(GroupTestCase):
         assert grp["subgroup"].type == tiledb.Group
         grp.close()
 
-        grp.open("w")
-        del grp["subarray"]
-        grp.remove("subgroup")
-        grp.close()
+        with grp.open("w") as g: # test __enter__ and __exit__
+            del g["subarray"]
+            g.remove("subgroup")
 
         grp.open("r")
         assert len(grp) == 0


### PR DESCRIPTION
Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/113

Then this:

https://github.com/single-cell-data/TileDB-SingleCell/blob/836d02a47c6f53d6df5ca77acc081834fc323079/apis/python/src/tiledbsc/tiledb_group.py#L57-L79

will become as simple as it already is for arrays:

https://github.com/single-cell-data/TileDB-SingleCell/blob/836d02a47c6f53d6df5ca77acc081834fc323079/apis/python/src/tiledbsc/tiledb_array.py#L34-L45