### PR TITLE
JSON Dump Python Stats

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@
 * Addition of `tiledb.DictionaryFilter` [#1074](https://github.com/TileDB-Inc/TileDB-Py/pull/1074)
 * Add support for `Datatype::TILEDB_BOOL` [#1110](https://github.com/TileDB-Inc/TileDB-Py/pull/1110)
 
+# Bug Fixes
+* Correcting `stats_dump` issues: Python stats now also in JSON form if `json=True`, resolve name mangling of `json` argument and `json` module, and pulling "timer" and "counter" stats from `stats_json_core` for `libtiledb`>=2.3  [#1140](https://github.com/TileDB-Inc/TileDB-Py/pull/1140)
+
 # TileDB-Py 0.15.1 Release Notes
 
 ## TileDB Embedded updates:

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1557,19 +1557,19 @@ py::object python_internal_stats(bool dict = false) {
   auto rq_time = counters["py.core_read_query_initial_submit_time"].count();
 
   if (dict) {
-    py::dict stats_json;
+    py::dict stats;
 
     // core.cc is only tracking read time right now; don't output if we
     // have no query submission time
     if (rq_time == 0) {
-      return std::move(stats_json);
+      return std::move(stats);
     }
 
     for (auto &stat : counters) {
-      stats_json[py::str(stat.first)] = stat.second.count();
+      stats[py::str(stat.first)] = stat.second.count();
     }
 
-    return std::move(stats_json);
+    return std::move(stats);
   } else {
     std::ostringstream os;
 
@@ -1634,7 +1634,7 @@ void init_core(py::module &m) {
   m.def("init_stats", &init_stats);
   m.def("disable_stats", &init_stats);
   m.def("python_internal_stats", &python_internal_stats,
-        py::arg("json") = false);
+        py::arg("dict") = false);
   m.def("increment_stat", &increment_stat);
   m.def("get_stats", &get_stats);
   m.def("use_stats", &use_stats);

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1562,14 +1562,14 @@ py::object python_internal_stats(bool dict = false) {
     // core.cc is only tracking read time right now; don't output if we
     // have no query submission time
     if (rq_time == 0) {
-      return stats_json;
+      return std::move(stats_json);
     }
 
     for (auto &stat : counters) {
       stats_json[py::str(stat.first)] = stat.second.count();
     }
 
-    return stats_json;
+    return std::move(stats_json);
   } else {
     std::ostringstream os;
 

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1548,29 +1548,46 @@ py::object get_stats() {
   return std::move(res);
 }
 
-std::string python_internal_stats() {
+py::object python_internal_stats(bool dict = false) {
   if (!g_stats) {
     TPY_ERROR_LOC("Stats counters are not uninitialized!")
   }
 
   auto counters = g_stats.get()->counters;
-
-  std::ostringstream os;
-
-  // core.cc is only tracking read time right now; don't print if we
-  // have no query submission time
   auto rq_time = counters["py.core_read_query_initial_submit_time"].count();
-  if (rq_time == 0)
-    return os.str();
 
-  os << std::endl;
-  os << "==== Python Stats ====" << std::endl << std::endl;
+  if (dict) {
+    py::dict stats_json;
 
-  for (auto &stat : counters) {
-    os << "  " << stat.first << " : " << stat.second.count() << std::endl;
+    // core.cc is only tracking read time right now; don't output if we
+    // have no query submission time
+    if (rq_time == 0) {
+      return stats_json;
+    }
+
+    for (auto &stat : counters) {
+      stats_json[py::str(stat.first)] = stat.second.count();
+    }
+
+    return stats_json;
+  } else {
+    std::ostringstream os;
+
+    // core.cc is only tracking read time right now; don't output if we
+    // have no query submission time
+    if (rq_time == 0) {
+      return py::str(os.str());
+    }
+
+    os << std::endl;
+    os << "==== Python Stats ====" << std::endl << std::endl;
+
+    for (auto &stat : counters) {
+      os << "  " << stat.first << " : " << stat.second.count() << std::endl;
+    }
+
+    return py::str(os.str());
   }
-
-  return os.str();
 }
 
 void init_core(py::module &m) {
@@ -1616,7 +1633,8 @@ void init_core(py::module &m) {
 
   m.def("init_stats", &init_stats);
   m.def("disable_stats", &init_stats);
-  m.def("python_internal_stats", &python_internal_stats);
+  m.def("python_internal_stats", &python_internal_stats,
+        py::arg("json") = false);
   m.def("increment_stat", &increment_stat);
   m.def("get_stats", &get_stats);
   m.def("use_stats", &use_stats);

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -598,38 +598,65 @@ def stats_dump(version=True, print_out=True, include_python=True, json=False, ve
         stats_str += f"TileDB-Py Version: {tiledb.version.version}\n"
 
     if not verbose:
+        stats_str += "\n==== READ ====\n\n"
+
         import tiledb
-        if tiledb.libtiledb.version() < (2,3):
-            stats_str += "\n==== READ ====\n\n"
+
+        if tiledb.libtiledb.version() < (2, 3):
             stats_str += "- Number of read queries: {}\n".format(
-                stats_json_core["READ_NUM"])
+                stats_json_core["READ_NUM"]
+            )
             stats_str += "- Number of attributes read: {}\n".format(
                 stats_json_core["READ_ATTR_FIXED_NUM"]
-                + stats_json_core["READ_ATTR_VAR_NUM"])
+                + stats_json_core["READ_ATTR_VAR_NUM"]
+            )
             stats_str += "- Time to compute estimated result size: {}\n".format(
-                stats_json_core["READ_COMPUTE_EST_RESULT_SIZE"])
+                stats_json_core["READ_COMPUTE_EST_RESULT_SIZE"]
+            )
             stats_str += "- Read time: {}\n".format(stats_json_core["READ"])
-            stats_str += "- Total read query time (array open + init state + read): {}\n".format(
-                stats_json_core["READ"] + stats_json_core["READ_INIT_STATE"])
+            stats_str += (
+                "- Total read query time (array open + init state + read): {}\n".format(
+                    stats_json_core["READ"] + stats_json_core["READ_INIT_STATE"]
+                )
+            )
         else:
-            stats_str += "\n==== READ ====\n\n"
-            subheader = "Context.StorageManager.Query.Reader"
-
-            loop_num = stats_json_core["counters"][f"{subheader}.loop_num"]
+            loop_num = stats_json_core["counters"][
+                "Context.StorageManager.Query.Reader.loop_num"
+            ]
             stats_str += f"- Number of read queries: {loop_num}\n"
 
-            attr_num = stats_json_core["counters"][f"{subheader}.attr_num"]
-            attr_fixed_num = stats_json_core["counters"][f"{subheader}.attr_fixed_num"]
-            stats_str += f"- Number of attributes read: {attr_num + attr_fixed_num}\n"
+            attr_num = (
+                stats_json_core["counters"]["Context.StorageManager.Query.Reader.attr_num"]
+                + stats_json_core["counters"][
+                    "Context.StorageManager.Query.Reader.attr_fixed_num"
+                ]
+            )
+            stats_str += f"- Number of attributes read: {attr_num}\n"
 
-            read_compute_est_result_size = stats_json_core["timers"]["Context.StorageManager.Query.Subarray.read_compute_est_result_size.sum"]
-            stats_str += f"- Time to compute estimated result size: {read_compute_est_result_size}\n"
+            read_compute_est_result_size = stats_json_core["timers"][
+                "Context.StorageManager.Query.Subarray.read_compute_est_result_size.sum"
+            ]
+            stats_str += (
+                f"- Time to compute estimated result size: {read_compute_est_result_size}\n"
+            )
 
-            read_tiles = stats_json_core["timers"][f"{subheader}.read_tiles.sum"]
+            read_tiles = stats_json_core["timers"][
+                "Context.StorageManager.Query.Reader.read_tiles.sum"
+            ]
             stats_str += f"- Read time: {read_tiles}\n"
 
-            stats_str += "- Total read query time (array open + init state + read): {}\n".format(
-                stats_json_core["timers"]["Context.StorageManager.array_open_for_reads.sum"] + stats_json_core["timers"][f"{subheader}.init_state.sum"] + stats_json_core["timers"][f"{subheader}.read_tiles.sum"])
+            total_read = (
+                stats_json_core["timers"]["Context.StorageManager.array_open_for_reads.sum"]
+                + stats_json_core["timers"][
+                    "Context.StorageManager.Query.Reader.init_state.sum"
+                ]
+                + stats_json_core["timers"][
+                    "Context.StorageManager.Query.Reader.read_tiles.sum"
+                ]
+            )
+            stats_str += (
+                f"- Total read query time (array open + init state + read): {total_read}\n"
+            )
     else:
         stats_str += "\n"
         stats_str += stats_str_core

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -577,9 +577,13 @@ def stats_dump(version=True, print_out=True, include_python=True, json=False, ve
     stats_str_core = stats_str_ptr.decode("UTF-8", "strict").strip()
 
     if json or not verbose:
-        import json
-        stats_json_core = json.loads(stats_str_core)
+        from json import loads as json_loads
+        stats_json_core = json_loads(stats_str_core)[0]
 
+        if include_python:
+            from json import dumps as json_dumps
+            import tiledb.main
+            stats_json_core["python"] = json_dumps(tiledb.main.python_internal_stats(True))
         if json:
             return stats_json_core
 
@@ -595,16 +599,23 @@ def stats_dump(version=True, print_out=True, include_python=True, json=False, ve
 
     if not verbose:
         stats_str += "\n==== READ ====\n\n"
-        stats_str += "- Number of read queries: {}\n".format(
-            stats_json_core["READ_NUM"])
-        stats_str += "- Number of attributes read: {}\n".format(
-            stats_json_core["READ_ATTR_FIXED_NUM"]
-            + stats_json_core["READ_ATTR_VAR_NUM"])
-        stats_str += "- Time to compute estimated result size: {}\n".format(
-            stats_json_core["READ_COMPUTE_EST_RESULT_SIZE"])
-        stats_str += "- Read time: {}\n".format(stats_json_core["READ"])
+        subheader = "Context.StorageManager.Query.Reader"
+
+        loop_num = stats_json_core["counters"][f"{subheader}.loop_num"]
+        stats_str += f"- Number of read queries: {loop_num}\n"
+
+        attr_num = stats_json_core["counters"][f"{subheader}.attr_num"]
+        attr_fixed_num = stats_json_core["counters"][f"{subheader}.attr_fixed_num"]
+        stats_str += f"- Number of attributes read: {attr_num + attr_fixed_num}\n"
+
+        read_compute_est_result_size = stats_json_core["timers"]["Context.StorageManager.Query.Subarray.read_compute_est_result_size.sum"]
+        stats_str += f"- Time to compute estimated result size: {read_compute_est_result_size}\n"
+
+        read_tiles = stats_json_core["timers"][f"{subheader}.read_tiles.sum"]
+        stats_str += f"- Read time: {read_tiles}\n"
+
         stats_str += "- Total read query time (array open + init state + read): {}\n".format(
-            stats_json_core["READ"] + stats_json_core["READ_INIT_STATE"])
+            stats_json_core["timers"]["Context.StorageManager.array_open_for_reads.sum"] + stats_json_core["timers"][f"{subheader}.init_state.sum"] + stats_json_core["timers"][f"{subheader}.read_tiles.sum"])
     else:
         stats_str += "\n"
         stats_str += stats_str_core

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -598,24 +598,38 @@ def stats_dump(version=True, print_out=True, include_python=True, json=False, ve
         stats_str += f"TileDB-Py Version: {tiledb.version.version}\n"
 
     if not verbose:
-        stats_str += "\n==== READ ====\n\n"
-        subheader = "Context.StorageManager.Query.Reader"
+        import tiledb
+        if tiledb.libtiledb.version() < (2,3):
+            stats_str += "\n==== READ ====\n\n"
+            stats_str += "- Number of read queries: {}\n".format(
+                stats_json_core["READ_NUM"])
+            stats_str += "- Number of attributes read: {}\n".format(
+                stats_json_core["READ_ATTR_FIXED_NUM"]
+                + stats_json_core["READ_ATTR_VAR_NUM"])
+            stats_str += "- Time to compute estimated result size: {}\n".format(
+                stats_json_core["READ_COMPUTE_EST_RESULT_SIZE"])
+            stats_str += "- Read time: {}\n".format(stats_json_core["READ"])
+            stats_str += "- Total read query time (array open + init state + read): {}\n".format(
+                stats_json_core["READ"] + stats_json_core["READ_INIT_STATE"])
+        else:
+            stats_str += "\n==== READ ====\n\n"
+            subheader = "Context.StorageManager.Query.Reader"
 
-        loop_num = stats_json_core["counters"][f"{subheader}.loop_num"]
-        stats_str += f"- Number of read queries: {loop_num}\n"
+            loop_num = stats_json_core["counters"][f"{subheader}.loop_num"]
+            stats_str += f"- Number of read queries: {loop_num}\n"
 
-        attr_num = stats_json_core["counters"][f"{subheader}.attr_num"]
-        attr_fixed_num = stats_json_core["counters"][f"{subheader}.attr_fixed_num"]
-        stats_str += f"- Number of attributes read: {attr_num + attr_fixed_num}\n"
+            attr_num = stats_json_core["counters"][f"{subheader}.attr_num"]
+            attr_fixed_num = stats_json_core["counters"][f"{subheader}.attr_fixed_num"]
+            stats_str += f"- Number of attributes read: {attr_num + attr_fixed_num}\n"
 
-        read_compute_est_result_size = stats_json_core["timers"]["Context.StorageManager.Query.Subarray.read_compute_est_result_size.sum"]
-        stats_str += f"- Time to compute estimated result size: {read_compute_est_result_size}\n"
+            read_compute_est_result_size = stats_json_core["timers"]["Context.StorageManager.Query.Subarray.read_compute_est_result_size.sum"]
+            stats_str += f"- Time to compute estimated result size: {read_compute_est_result_size}\n"
 
-        read_tiles = stats_json_core["timers"][f"{subheader}.read_tiles.sum"]
-        stats_str += f"- Read time: {read_tiles}\n"
+            read_tiles = stats_json_core["timers"][f"{subheader}.read_tiles.sum"]
+            stats_str += f"- Read time: {read_tiles}\n"
 
-        stats_str += "- Total read query time (array open + init state + read): {}\n".format(
-            stats_json_core["timers"]["Context.StorageManager.array_open_for_reads.sum"] + stats_json_core["timers"][f"{subheader}.init_state.sum"] + stats_json_core["timers"][f"{subheader}.read_tiles.sum"])
+            stats_str += "- Total read query time (array open + init state + read): {}\n".format(
+                stats_json_core["timers"]["Context.StorageManager.array_open_for_reads.sum"] + stats_json_core["timers"][f"{subheader}.init_state.sum"] + stats_json_core["timers"][f"{subheader}.read_tiles.sum"])
     else:
         stats_str += "\n"
         stats_str += stats_str_core

--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -14,7 +14,6 @@ from tiledb.tests.common import DiskTestCase, has_pandas
 class AttrDataTest(DiskTestCase):
     @hypothesis.settings(deadline=1000)
     @given(st.binary())
-    @hypothesis.reproduce_failure("6.46.9", b"AAEWBwIA")
     def test_bytes_numpy(self, data):
         # TODO this test is slow. might be nice to run with in-memory
         #      VFS (if faster) but need to figure out correct setup

--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -14,6 +14,7 @@ from tiledb.tests.common import DiskTestCase, has_pandas
 class AttrDataTest(DiskTestCase):
     @hypothesis.settings(deadline=1000)
     @given(st.binary())
+    @hypothesis.reproduce_failure("6.46.9", b"AAEWBwIA")
     def test_bytes_numpy(self, data):
         # TODO this test is slow. might be nice to run with in-memory
         #      VFS (if faster) but need to figure out correct setup

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -64,12 +64,15 @@ class StatsTest(DiskTestCase):
         tiledb.libtiledb.stats_disable()
 
         tiledb.libtiledb.stats_enable()
-        with tiledb.from_numpy(self.path("test_stats"), np.arange(10)) as T:
+
+        path = self.path("test_stats")
+
+        with tiledb.from_numpy(path, np.arange(10)) as T:
             pass
 
         # basic output check for read stats
         tiledb.libtiledb.stats_reset()
-        with tiledb.open(self.path("test_stats")) as T:
+        with tiledb.open(path) as T:
             tiledb.libtiledb.stats_enable()
             assert_array_equal(T, np.arange(10))
 
@@ -85,14 +88,34 @@ class StatsTest(DiskTestCase):
                 self.assertTrue('"timers": {' in stats_v)
             self.assertTrue("==== Python Stats ====" in stats_v)
 
+            stats_quiet = tiledb.stats_dump(print_out=False, verbose=False)
             if tiledb.libtiledb.version() < (2, 3):
-                stats_quiet = tiledb.stats_dump(print_out=False, verbose=False)
                 self.assertTrue("Time to load array schema" not in stats_quiet)
 
                 # TODO seems to be a regression, no JSON
                 stats_json = tiledb.stats_dump(json=True)
                 self.assertTrue(isinstance(stats_json, dict))
                 self.assertTrue("CONSOLIDATE_COPY_ARRAY" in stats_json)
+            else:
+                self.assertTrue("==== READ ====" in stats_quiet)
+
+    def test_stats_include_python_json(self):
+        tiledb.libtiledb.stats_enable()
+
+        path = self.path("test_stats")
+
+        with tiledb.from_numpy(path, np.arange(10)) as T:
+            pass
+
+        tiledb.libtiledb.stats_reset()
+        with tiledb.open(path) as T:
+            tiledb.libtiledb.stats_enable()
+            assert_array_equal(T, np.arange(10))
+            json_stats = tiledb.stats_dump(print_out=False, json=True)
+            assert isinstance(json_stats, dict)
+            assert "python" in json_stats
+            assert "timers" in json_stats
+            assert "counters" in json_stats
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
* Correcting `stats_dump` issues: Python stats now also in JSON form if `json=True`, resolve name mangling of `json` argument and `json` module, and pulling "timer" and "counter" stats from `stats_json_core` for `libtiledb`>=2.3