### PR TITLE
Fix Arrow Table Incorrect Boolean Results

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@
 * Use `bool` instead of `uint8` for Boolean dtype in `dataframe_.py` [#1154](https://github.com/TileDB-Inc/TileDB-Py/pull/1154)
 * Support QueryCondition OR operator [#1146](https://github.com/TileDB-Inc/TileDB-Py/pull/1146)
 
+## Bug Fixes
+* Correct Boolean values when `use_arrow=True` []()
+
 # TileDB-Py 0.15.3 Release Notes
 
 ## TileDB Embedded updates:

--- a/tiledb/py_arrow_io_impl.h
+++ b/tiledb/py_arrow_io_impl.h
@@ -229,8 +229,9 @@ ArrowInfo tiledb_buffer_arrow_fmt(BufferInfo bufferinfo, bool use_list = true) {
     return ArrowInfo("tsn:");
 
 #if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 10
+  // TILEDB_BOOL is stored as a uint8_t but arrow::Type::BOOL is 1 bit
   case TILEDB_BOOL:
-    return ArrowInfo("b");
+    return ArrowInfo("C");
 #endif
 
   // TODO: these could potentially be rep'd w/ additional


### PR DESCRIPTION
* `TILEDB_BOOL` is represented as a `uint8_t` whereas Arrow's Boolean
  type is 1 bit
* Use Arrow's uint8 type in `tiledb_buffer_arrow_fmt` for `TILEDB_BOOL`
* Cast Boolean types in the resulting Arrow table in `_run_query` from
  uint8 to bool