### PR TITLE
Index out of bounds when nonempty domain is empty string

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
 ## Improvements
 * `setup.py` retrieves core version by using `ctypes` to call `tiledb_version` rather than parsing `tiledb_version.h` [#1191](https://github.com/TileDB-Inc/TileDB-Py/pull/1191)
 
+## Bug Fixes
+* Set nonempty domain to `(None, None)` for empty string [#1182](https://github.com/TileDB-Inc/TileDB-Py/pull/1182)
+
 # TileDB-Py 0.16.1 Release Notes
 
 ## TileDB Embedded updates:

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3828,7 +3828,7 @@ cdef class Array(object):
                     continue
 
                 buf_dtype = 'S'
-                start_buf = np.empty(end_size, 'S' + str(start_size))
+                start_buf = np.empty(start_size, 'S' + str(start_size))
                 end_buf = np.empty(end_size, 'S' + str(end_size))
                 start_buf_ptr = np.PyArray_DATA(start_buf)
                 end_buf_ptr = np.PyArray_DATA(end_buf)
@@ -3845,7 +3845,11 @@ cdef class Array(object):
                     _raise_ctx_err(ctx_ptr, rc)
                 if is_empty:
                     return None
-                results.append((start_buf.item(0), end_buf.item(0)))
+
+                if start_size > 0 and end_size > 0:
+                    results.append((start_buf.item(0), end_buf.item(0)))
+                else:
+                    results.append((None, None))
             else:
                 rc = tiledb_array_get_non_empty_domain_from_index(
                         ctx_ptr, array_ptr, dim_idx, start_buf_ptr, &is_empty

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import random
 import re
+from tkinter import NONE
 import urllib
 import subprocess
 import sys
@@ -1021,6 +1022,21 @@ class ArrayTest(DiskTestCase):
             assert_array_equal(ned, ((-1, 1),))
             assert isinstance(ned[0][0], int)
             assert isinstance(ned[0][1], int)
+
+    def test_nonempty_domain_empty_string(self):
+        uri = self.path("test_nonempty_domain_empty_string")
+        dims = [tiledb.Dim(dtype="ascii")]
+        schema = tiledb.ArraySchema(tiledb.Domain(dims), sparse=True)
+        tiledb.Array.create(uri, schema)
+
+        with tiledb.open(uri, "r") as A:
+            assert_array_equal(A.nonempty_domain(), ((None, None),))
+
+        with tiledb.open(uri, "w") as A:
+            A[""] = None
+
+        with tiledb.open(uri, "r") as A:
+            assert_array_equal(A.nonempty_domain(), ((b"", b""),))
 
     def test_create_array_overwrite(self):
         uri = self.path("test_create_array_overwrite")


### PR DESCRIPTION
The nonempty domain for the `clinvar-annotations` array turns out to be the empty string for the third dimension.
This was discovered whilst debugging ch18654 when queries to this array resulted in `Index out of bounds` exceptions.
This is unrelated though unfortunately with the original problem described in ch1865.