### PR TITLE
Increase Azure Devops Timeout To 120 Minutes

### DIFF
--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -18,6 +18,7 @@ stages:
           imageName: 'ubuntu-latest'
           python.version: '3.10'
       maxParallel: 4
+    timeoutInMinutes: 120
 
     steps:
     - task: UsePythonVersion@0


### PR DESCRIPTION
* The macOS build frequently takes more than 60 minutes