### PR TITLE
Release 0.16.0 Against 2.10.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,13 @@
-# In Progress
+# TileDB-Py 0.16.0 Release Notes
+
+## TileDB Embedded updates:
+* TileDB-Py 0.16.0 includes TileDB Embedded [TileDB 2.10.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.10.0)
 
 ## API Changes
 * Addition of Filestore API [#1070](https://github.com/TileDB-Inc/TileDB-Py/pull/1070)
+* Use `bool` instead of `uint8` for Boolean dtype in `dataframe_.py` [#1154](https://github.com/TileDB-Inc/TileDB-Py/pull/1154)
+* Support QueryCondition OR operator [#1146](https://github.com/TileDB-Inc/TileDB-Py/pull/1146)
+
 # TileDB-Py 0.15.6 Release Notes
 
 ## TileDB Embedded updates:

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,9 +6,9 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.15.6
-        LIBTILEDB_VERSION: 2.9.5
-        LIBTILEDB_SHA: 81e3fd10e7da582967e13650ebabb942402f65ce
+        TILEDBPY_VERSION: 0.16.0
+        LIBTILEDB_VERSION: 2.10.0
+        LIBTILEDB_SHA: 0b54e51a08e1a4208e73cdd26aa2e41f67a6840f
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"


### PR DESCRIPTION
(The `TILEDB_VERSION` in `setup.py` is already set to `2.10.0`.)