### PR TITLE
Support `QueryCondition` on Dense Arrays

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
 ## Improvements
 * `setup.py` retrieves core version by using `ctypes` to call `tiledb_version` rather than parsing `tiledb_version.h` [#1191](https://github.com/TileDB-Inc/TileDB-Py/pull/1191)
 
+## API Changes
+* Support `QueryCondition` for dense arrays [#1198](https://github.com/TileDB-Inc/TileDB-Py/pull/1198)
+
 # TileDB-Py 0.16.1 Release Notes
 
 ## TileDB Embedded updates:
@@ -14,9 +17,9 @@
 * TileDB-Py 0.16.0 includes TileDB Embedded [TileDB 2.10.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.10.0)
 
 ## API Changes
-* Addition of Filestore API [#1070](https://github.com/TileDB-Inc/TileDB-Py/pull/1070)
+* Addition of `Filestore` API [#1070](https://github.com/TileDB-Inc/TileDB-Py/pull/1070)
 * Use `bool` instead of `uint8` for Boolean dtype in `dataframe_.py` [#1154](https://github.com/TileDB-Inc/TileDB-Py/pull/1154)
-* Support QueryCondition OR operator [#1146](https://github.com/TileDB-Inc/TileDB-Py/pull/1146)
+* Support `QueryCondition` OR operator [#1146](https://github.com/TileDB-Inc/TileDB-Py/pull/1146)
 
 # TileDB-Py 0.15.6 Release Notes
 

--- a/examples/query_condition_dense.py
+++ b/examples/query_condition_dense.py
@@ -79,5 +79,27 @@ def read_array(path):
 
 
 if __name__ == "__main__":
+    """Example output for `python query_condition_dense.py`:
+
+    --- without query condition:
+
+    OrderedDict([('attr1', array([4, 0, 9, 7, 6, 0, 0, 5, 7, 5], dtype=uint64)),
+                ('attr2',
+                array([0.74476144, 0.47211544, 0.99054245, 0.36640416, 0.91699594,
+        0.06216043, 0.58581863, 0.00505695, 0.7486192 , 0.87649422]))])
+
+    --- with query condition QueryCondition(expression='(2 < attr1 < 6) and (attr2 < 0.5 or attr2 > 0.85)'):
+    --- the fill value for attr1 is [18446744073709551615]
+    --- the fill value for attr1 is [nan]
+
+    OrderedDict([('attr1',
+                array([18446744073709551615, 18446744073709551615, 18446744073709551615,
+        18446744073709551615, 18446744073709551615, 18446744073709551615,
+        18446744073709551615,                    5, 18446744073709551615,
+                            5], dtype=uint64)),
+                ('attr2',
+                array([       nan,        nan,        nan,        nan,        nan,
+                nan,        nan, 0.00505695,        nan, 0.87649422]))])
+    """
     create_array(uri)
     read_array(uri)

--- a/examples/query_condition_dense.py
+++ b/examples/query_condition_dense.py
@@ -1,0 +1,83 @@
+# query_condition_dense.py
+#
+# LICENSE
+#
+# The MIT License
+#
+# Copyright (c) 2021 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# This example creates an array with one string-typed attribute,
+# writes sample data to the array, and then prints out a filtered
+# dataframe using the TileDB QueryCondition feature.
+
+import tiledb
+import numpy as np
+from pprint import pprint
+import tempfile
+import string
+
+uri = "query_condition_dense"
+
+
+def create_array(path):
+    # create a dense array
+    dom = tiledb.Domain(
+        tiledb.Dim(name="coords", domain=(1, 10), tile=1, dtype=np.uint32)
+    )
+    attrs = [
+        tiledb.Attr(name="attr1", dtype=np.uint64),
+        tiledb.Attr(name="attr2", dtype=np.float64),
+    ]
+    schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=False)
+    tiledb.Array.create(path, schema, overwrite=True)
+
+    # fill array with randomized values
+    with tiledb.open(path, "w") as arr:
+        rand = np.random.default_rng()
+        arr[:] = {
+            "attr1": rand.integers(low=0, high=10, size=10),
+            "attr2": rand.random(size=10),
+        }
+
+
+def read_array(path):
+    with tiledb.open(uri) as arr:
+        print("--- without query condition:")
+        print()
+        pprint(arr[:])
+        print()
+
+    with tiledb.open(uri) as arr:
+        qc = tiledb.QueryCondition("(2 < attr1 < 6) and (attr2 < 0.5 or attr2 > 0.85)")
+        print(f"--- with query condition {qc}:")
+
+        print(f"--- the fill value for attr1 is {arr.attr('attr1').fill}")
+        print(f"--- the fill value for attr1 is {arr.attr('attr2').fill}")
+
+        print()
+        res = arr.query(attr_cond=qc)[:]
+        pprint(res)
+
+
+if __name__ == "__main__":
+    create_array(uri)
+    read_array(uri)

--- a/examples/query_condition_sparse.py
+++ b/examples/query_condition_sparse.py
@@ -1,0 +1,79 @@
+# query_condition_sparse.py
+#
+# LICENSE
+#
+# The MIT License
+#
+# Copyright (c) 2021 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# This example creates an array with one string-typed attribute,
+# writes sample data to the array, and then prints out a filtered
+# dataframe using the TileDB QueryCondition feature.
+
+import tiledb
+import numpy as np
+from pprint import pprint
+import tempfile
+import string
+
+uri = "query_condition_sparse"
+
+
+def create_array(path):
+    # create a sparse array
+    dom = tiledb.Domain(
+        tiledb.Dim(name="coords", domain=(1, 10), tile=1, dtype=np.uint32)
+    )
+    attrs = [
+        tiledb.Attr(name="attr1", dtype=np.uint64),
+        tiledb.Attr(name="attr2", dtype=np.float64),
+    ]
+    schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=True)
+    tiledb.Array.create(path, schema, overwrite=True)
+
+    # fill array with randomized values
+    with tiledb.open(path, "w") as arr:
+        rand = np.random.default_rng()
+        arr[np.arange(1, 11)] = {
+            "attr1": rand.integers(low=0, high=10, size=10),
+            "attr2": rand.random(size=10),
+        }
+
+
+def read_array(path):
+    with tiledb.open(uri) as arr:
+        print("--- without query condition:")
+        print()
+        pprint(arr[:])
+        print()
+
+    with tiledb.open(uri) as arr:
+        qc = tiledb.QueryCondition("(2 < attr1 < 6) and (attr2 < 0.5 or attr2 > 0.85)")
+        print(f"--- with query condition {qc}:")
+        print()
+        res = arr.query(attr_cond=qc)[:]
+        pprint(res)
+
+
+if __name__ == "__main__":
+    create_array(uri)
+    read_array(uri)

--- a/examples/query_condition_sparse.py
+++ b/examples/query_condition_sparse.py
@@ -75,5 +75,22 @@ def read_array(path):
 
 
 if __name__ == "__main__":
+    """Example output for `python query_condition_sparse.py`:
+
+    --- without query condition:
+
+    OrderedDict([('attr1', array([2, 4, 4, 3, 4, 7, 5, 2, 2, 8], dtype=uint64)),
+                ('attr2',
+                array([0.62445071, 0.32415481, 0.39117764, 0.66609931, 0.48122102,
+        0.93561984, 0.70998524, 0.10322076, 0.28343041, 0.33623958])),
+                ('coords',
+                array([ 1,  2,  3,  4,  5,  6,  7,  8,  9, 10], dtype=uint32))])
+
+    --- with query condition QueryCondition(expression='(2 < attr1 < 6) and (attr2 < 0.5 or attr2 > 0.85)'):
+
+    OrderedDict([('attr1', array([4, 4, 4], dtype=uint64)),
+                ('attr2', array([0.32415481, 0.39117764, 0.48122102])),
+                ('coords', array([2, 3, 5], dtype=uint32))])
+    """
     create_array(uri)
     read_array(uri)

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -109,6 +109,7 @@ _tiledb_dtype_to_numpy_typeid_convert ={
     TILEDB_INT16: np.NPY_INT16,
     TILEDB_UINT16: np.NPY_UINT16,
     TILEDB_CHAR: np.NPY_STRING,
+    TILEDB_STRING_ASCII: np.NPY_STRING,
     TILEDB_STRING_UTF8: np.NPY_UNICODE,
 }
 IF LIBTILEDB_VERSION_MAJOR >= 2:
@@ -131,7 +132,7 @@ _tiledb_dtype_to_numpy_dtype_convert = {
     TILEDB_INT16: np.int16,
     TILEDB_UINT16: np.uint16,
     TILEDB_CHAR: np.dtype('S1'),
-    TILEDB_STRING_ASCII: np.bytes_,
+    TILEDB_STRING_ASCII: np.dtype('S'),
     TILEDB_STRING_UTF8: np.dtype('U1'),
 }
 IF LIBTILEDB_VERSION_MAJOR >= 2:
@@ -4094,8 +4095,6 @@ cdef class Query(object):
                     raise TileDBError(f"Selected attribute does not exist: '{name}'")
         self.attrs = attrs
         self.attr_cond = attr_cond
-        if attr_cond is not None and not array.schema.sparse:
-            raise TileDBError("QueryConditions may only be applied to sparse arrays")
 
         if order == None:
             if array.schema.sparse:

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -21,7 +21,18 @@ QueryConditionNodeElem = Union[
 class QueryCondition:
     """
     Class representing a TileDB query condition object for attribute filtering
-    pushdown. Set the query condition with a string representing an expression
+    pushdown.
+
+    When querying a sparse array, only the values that validate the given
+    condition are returned (coupled with their associated coordinates). An example
+    may be found in `examples/query_condition_sparse.py`.
+
+    For dense arrays, the given shape of the query matches the shape of the output
+    array. Values that DO NOT validate the given condition are filled with the
+    TileDB default fill value. Different attribute types have different default
+    fill values as outlined here (https://docs.tiledb.com/main/background/internal-mechanics/writing#default-fill-values). An example may be found in `examples/query_condition_dense.py`.
+
+    Set the query condition with a string representing an expression
     as defined by the grammar below. A more straight forward example of usage is
     given beneath.
 

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -23,12 +23,12 @@ class QueryCondition:
     Class representing a TileDB query condition object for attribute filtering
     pushdown.
 
-    When querying a sparse array, only the values that validate the given
+    When querying a sparse array, only the values that satisfy the given
     condition are returned (coupled with their associated coordinates). An example
     may be found in `examples/query_condition_sparse.py`.
 
     For dense arrays, the given shape of the query matches the shape of the output
-    array. Values that DO NOT validate the given condition are filled with the
+    array. Values that DO NOT satisfy the given condition are filled with the
     TileDB default fill value. Different attribute types have different default
     fill values as outlined here (https://docs.tiledb.com/main/background/internal-mechanics/writing#default-fill-values). An example may be found in `examples/query_condition_dense.py`.
 

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -1,20 +1,27 @@
-from cmath import atanh
 import pytest
 
+import math
 import numpy as np
 from numpy.testing import assert_array_equal
 import string
 
 import tiledb
 
-# from tiledb.main import PyQueryCondition
 from tiledb.tests.common import DiskTestCase
 
 
 class QueryConditionTest(DiskTestCase):
-    @pytest.fixture
-    def input_array_UIDS(self):
-        path = self.path("input_array_UIDS")
+    def filter_sparse(self, data, mask):
+        if isinstance(mask, np.ndarray):
+            mask = mask[0]
+
+        if isinstance(mask, float) and np.isnan(mask):
+            return data[np.invert(np.isnan(data))]
+        else:
+            return data[data != mask]
+
+    def create_input_array_UIDSA(self, sparse):
+        path = self.path("input_array_UIDSA")
 
         dom = tiledb.Domain(
             tiledb.Dim(name="d", domain=(1, 10), tile=1, dtype=np.uint32)
@@ -27,17 +34,22 @@ class QueryConditionTest(DiskTestCase):
             tiledb.Attr(name="A", dtype="ascii", var=True),
         ]
 
-        schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=True)
+        schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=sparse)
         tiledb.Array.create(path, schema)
 
-        U = np.random.randint(1, 10, 10)
-        I = np.random.randint(-5, 5, 10)
-        D = np.random.rand(10)
-        S = np.array(list(string.ascii_lowercase[:10]), dtype="|S1")
-        A = np.array(list(string.ascii_lowercase[:10]), dtype="|S1")
-
         with tiledb.open(path, "w") as arr:
-            arr[np.arange(1, 11)] = {"U": U, "I": I, "D": D, "S": S, "A": A}
+            data = {
+                "U": np.random.randint(1, 10, 10),
+                "I": np.random.randint(-5, 5, 10),
+                "D": np.random.rand(10),
+                "S": np.array(list(string.ascii_lowercase[:10]), dtype="|S1"),
+                "A": np.array(list(string.ascii_lowercase[:10]), dtype="|S1"),
+            }
+
+            if sparse:
+                arr[np.arange(1, 11)] = data
+            else:
+                arr[:] = data
 
         return path
 
@@ -46,48 +58,47 @@ class QueryConditionTest(DiskTestCase):
         if not tiledb.libtiledb.version() >= (2, 2, 3):
             pytest.skip("Only run QueryCondition test with TileDB>=2.2.3")
 
-    def test_errors(self, input_array_UIDS):
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_errors(self, sparse):
+        uri = self.create_input_array_UIDSA(sparse)
+
         with self.assertRaises(tiledb.TileDBError):
-            with tiledb.open(input_array_UIDS) as A:
+            with tiledb.open(uri) as A:
                 qc = tiledb.QueryCondition("1.324 < 1")
-                A.query(attr_cond=qc, use_arrow=False)[:]
+                A.query(attr_cond=qc)[:]
 
         with self.assertRaises(tiledb.TileDBError):
-            with tiledb.open(input_array_UIDS) as A:
+            with tiledb.open(uri) as A:
                 qc = tiledb.QueryCondition("foo >= bar")
-                A.query(attr_cond=qc, use_arrow=False)[:]
+                A.query(attr_cond=qc)[:]
 
         with self.assertRaises(tiledb.TileDBError):
-            with tiledb.open(input_array_UIDS) as A:
+            with tiledb.open(uri) as A:
                 qc = tiledb.QueryCondition("'foo' == 'bar'")
-                A.query(attr_cond=qc, use_arrow=False)[:]
+                A.query(attr_cond=qc)[:]
 
         with self.assertRaises(tiledb.TileDBError):
-            with tiledb.open(input_array_UIDS) as A:
+            with tiledb.open(uri) as A:
                 qc = tiledb.QueryCondition("U < 10000000000000000000000.0")
                 A.query(attr_cond=qc, attrs=["U"])[:]
 
         with self.assertRaises(tiledb.TileDBError):
-            with tiledb.open(input_array_UIDS) as A:
+            with tiledb.open(uri) as A:
                 qc = tiledb.QueryCondition("D")
                 A.query(attr_cond=qc, attrs=["D"])[:]
 
         with self.assertRaises(tiledb.TileDBError):
-            with tiledb.open(input_array_UIDS) as A:
+            with tiledb.open(uri) as A:
                 qc = tiledb.QueryCondition("D,")
                 A.query(attr_cond=qc, attrs=["D"])[:]
 
         with self.assertRaises(tiledb.TileDBError):
-            with tiledb.open(input_array_UIDS) as A:
+            with tiledb.open(uri) as A:
                 qc = tiledb.QueryCondition("D > ")
                 A.query(attr_cond=qc, attrs=["D"])[:]
 
-    @pytest.mark.xfail(
-        tiledb.libtiledb.version() >= (2, 5),
-        reason="Skip fail_on_dense with libtiledb >2.5",
-    )
-    def test_fail_on_dense(self):
-        path = self.path("test_fail_on_dense")
+    def test_qc_dense(self):
+        path = self.path("test_qc_dense")
 
         dom = tiledb.Domain(
             tiledb.Dim(name="d", domain=(1, 10), tile=1, dtype=np.uint8)
@@ -97,99 +108,183 @@ class QueryConditionTest(DiskTestCase):
         tiledb.Array.create(path, schema)
 
         with tiledb.open(path) as A:
-            with pytest.raises(tiledb.TileDBError) as excinfo:
-                A.query(attr_cond=tiledb.QueryCondition("a < 5"))
-            assert "QueryConditions may only be applied to sparse arrays" in str(
-                excinfo.value
-            )
+            A.query(attr_cond=tiledb.QueryCondition("a < 5"))
 
-    def test_unsigned(self, input_array_UIDS):
-        with tiledb.open(input_array_UIDS) as A:
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_unsigned(self, sparse):
+        with tiledb.open(self.create_input_array_UIDSA(sparse)) as A:
+            mask = A.attr("U").fill
+
             qc = tiledb.QueryCondition("U < 5")
             result = A.query(attr_cond=qc, attrs=["U"])[:]
-            assert all(result["U"] < 5)
+            if sparse:
+                assert all(result["U"] < 5)
+            else:
+                assert all(self.filter_sparse(result["U"], mask) < 5)
 
-    def test_signed(self, input_array_UIDS):
-        with tiledb.open(input_array_UIDS) as A:
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_signed(self, sparse):
+        uri = self.create_input_array_UIDSA(sparse)
+
+        with tiledb.open(uri) as A:
+            mask = A.attr("I").fill
+
             qc = tiledb.QueryCondition("I < 1")
             result = A.query(attr_cond=qc, attrs=["I"])[:]
-            assert all(result["I"] < 1)
+            if sparse:
+                assert all(result["I"] < 1)
+            else:
+                assert all(self.filter_sparse(result["I"], mask) < 1)
 
             qc = tiledb.QueryCondition("I < +1")
             result = A.query(attr_cond=qc, attrs=["I"])[:]
-            assert all(result["I"] < +1)
+            if sparse:
+                assert all(result["I"] < +1)
+            else:
+                assert all(self.filter_sparse(result["I"], mask) < +1)
 
             qc = tiledb.QueryCondition("I < ---1")
             result = A.query(attr_cond=qc, attrs=["I"])[:]
-            assert all(result["I"] < ---1)
+            if sparse:
+                assert all(result["I"] < ---1)
+            else:
+                assert all(self.filter_sparse(result["I"], mask) < ---1)
 
             qc = tiledb.QueryCondition("-5 < I < 5")
             result = A.query(attr_cond=qc, attrs=["I"])[:]
-            assert all(-5 < result["I"])
-            assert all(result["I"] < 5)
+            if sparse:
+                assert all(-5 < result["I"])
+                assert all(result["I"] < 5)
+            else:
+                assert all(-5 < self.filter_sparse(result["I"], mask))
+                assert all(self.filter_sparse(result["I"], mask) < 5)
 
-    def test_floats(self, input_array_UIDS):
-        with tiledb.open(input_array_UIDS) as A:
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_floats(self, sparse):
+        with tiledb.open(self.create_input_array_UIDSA(sparse)) as A:
+            mask = A.attr("D").fill
+
             qc = tiledb.QueryCondition("D > 5.0")
             result = A.query(attr_cond=qc, attrs=["D"])[:]
-            assert all(result["D"] > 5.0)
+            if sparse:
+                assert all(result["D"] > 5.0)
+            else:
+                assert all(self.filter_sparse(result["D"], mask) > 5.0)
 
             qc = tiledb.QueryCondition("(D > 0.7) & (D < 3.5)")
             result = A.query(attr_cond=qc, attrs=["D"])[:]
-            assert all((result["D"] > 0.7) & (result["D"] < 3.5))
+            if sparse:
+                assert all((result["D"] > 0.7) & (result["D"] < 3.5))
+            else:
+                assert all(self.filter_sparse(result["D"], mask) > 0.7)
+                assert all(self.filter_sparse(result["D"], mask) < 3.5)
 
             qc = tiledb.QueryCondition("0.2 < D < 0.75")
-            result = A.query(attr_cond=qc, attrs=["D", "I"])[:]
-            assert all(0.2 < result["D"])
-            assert all(result["D"] < 0.75)
+            result = A.query(attr_cond=qc, attrs=["D", "D"])[:]
+            if sparse:
+                assert all(0.2 < result["D"])
+                assert all(result["D"] < 0.75)
+            else:
+                assert all(0.2 < self.filter_sparse(result["D"], mask))
+                assert all(self.filter_sparse(result["D"], mask) < 0.75)
 
-    def test_string(self, input_array_UIDS):
-        with tiledb.open(input_array_UIDS) as A:
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_string(self, sparse):
+        with tiledb.open(self.create_input_array_UIDSA(sparse)) as A:
             qc = tiledb.QueryCondition("S == 'c'")
-            result = A.query(attr_cond=qc, attrs=["S"], use_arrow=False)[:]
-            assert len(result["S"]) == 1
-            assert result["S"][0] == b"c"
+            result = A.query(attr_cond=qc, attrs=["S"])[:]
+            if sparse:
+                assert len(result["S"]) == 1
+                assert result["S"][0] == b"c"
+            else:
+                assert all(self.filter_sparse(result["S"], A.attr("S").fill) == b"c")
 
             qc = tiledb.QueryCondition("A == 'a'")
-            result = A.query(attr_cond=qc, attrs=["A"], use_arrow=False)[:]
-            assert len(result["A"]) == 1
-            assert result["A"][0] == b"a"
+            result = A.query(attr_cond=qc, attrs=["A"])[:]
+            if sparse:
+                assert len(result["A"]) == 1
+                assert result["A"][0] == b"a"
+            else:
+                assert all(self.filter_sparse(result["A"], A.attr("A").fill) == b"a")
 
-    def test_combined_types(self, input_array_UIDS):
-        with tiledb.open(input_array_UIDS) as A:
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_combined_types(self, sparse):
+        with tiledb.open(self.create_input_array_UIDSA(sparse)) as A:
+            mask_U = A.attr("U").fill
+            mask_I = A.attr("I").fill
+            mask_D = A.attr("D").fill
+
             qc = tiledb.QueryCondition("(I > 0) & ((-3 < D) & (D < 3.0))")
             result = A.query(attr_cond=qc, attrs=["I", "D"])[:]
-            assert all((result["I"] > 0) & ((-3 < result["D"]) & (result["D"] < 3.0)))
+            if sparse:
+                assert all(
+                    (result["I"] > 0) & ((-3 < result["D"]) & (result["D"] < 3.0))
+                )
+            else:
+                res_I = self.filter_sparse(result["I"], mask_I)
+                res_D = self.filter_sparse(result["D"], mask_D)
+                assert all(res_I > 0) & all(-3 < res_D) & all(res_D < 3.0)
 
             qc = tiledb.QueryCondition("U >= 3 and 0.7 < D")
             result = A.query(attr_cond=qc, attrs=["U", "D"])[:]
-            assert all(result["U"] >= 3)
-            assert all(0.7 < result["D"])
+            if sparse:
+                assert all(result["U"] >= 3) & all(0.7 < result["D"])
+            else:
+                res_U = self.filter_sparse(result["U"], mask_U)
+                res_D = self.filter_sparse(result["D"], mask_D)
+                assert all(res_U >= 3) & all(0.7 < res_D)
 
             qc = tiledb.QueryCondition("(0.2 < D and D < 0.75) and (-5 < I < 5)")
             result = A.query(attr_cond=qc, attrs=["D", "I"])[:]
-            assert all((0.2 < result["D"]) & (result["D"] < 0.75))
-            assert all((-5 < result["I"]) & (result["I"] < 5))
+            if sparse:
+                assert all((0.2 < result["D"]) & (result["D"] < 0.75))
+                assert all((-5 < result["I"]) & (result["I"] < 5))
+            else:
+                res_D = self.filter_sparse(result["D"], mask_D)
+                res_I = self.filter_sparse(result["I"], mask_I)
+                assert all((0.2 < res_D) & (res_D < 0.75))
+                assert all((-5 < res_I) & (res_I < 5))
 
             qc = tiledb.QueryCondition("(-5 < I <= -1) and (0.2 < D < 0.75)")
             result = A.query(attr_cond=qc, attrs=["D", "I"])[:]
-            assert all((0.2 < result["D"]) & (result["D"] < 0.75))
-            assert all((-5 < result["I"]) & (result["I"] <= -1))
+            if sparse:
+                assert all((0.2 < result["D"]) & (result["D"] < 0.75))
+                assert all((-5 < result["I"]) & (result["I"] <= -1))
+            else:
+                res_D = self.filter_sparse(result["D"], mask_D)
+                res_I = self.filter_sparse(result["I"], mask_I)
+                assert all((0.2 < res_D) & (res_D < 0.75))
+                assert all((-5 < res_I) & (res_I <= -1))
 
             qc = tiledb.QueryCondition("(0.2 < D < 0.75) and (-5 < I < 5)")
             result = A.query(attr_cond=qc, attrs=["D", "I"])[:]
-            assert all((0.2 < result["D"]) & (result["D"] < 0.75))
-            assert all((-5 < result["I"]) & (result["I"] < 5))
+            if sparse:
+                assert all((0.2 < result["D"]) & (result["D"] < 0.75))
+                assert all((-5 < result["I"]) & (result["I"] < 5))
+            else:
+                res_D = self.filter_sparse(result["D"], mask_D)
+                res_I = self.filter_sparse(result["I"], mask_I)
+                assert all((0.2 < res_D) & (res_D < 0.75))
+                assert all((-5 < res_I) & (res_I < 5))
 
-    def test_check_attrs(self, input_array_UIDS):
-        with tiledb.open(input_array_UIDS) as A:
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_check_attrs(self, sparse):
+        with tiledb.open(self.create_input_array_UIDSA(sparse)) as A:
+            mask = A.attr("U").fill
+
             qc = tiledb.QueryCondition("U < 0.1")
             result = A.query(attr_cond=qc, attrs=["U"])[:]
-            assert all(result["U"] < 0.1)
+            if sparse:
+                assert all(result["U"] < 0.1)
+            else:
+                assert all(self.filter_sparse(result["U"], mask) < 0.1)
 
             qc = tiledb.QueryCondition("U < 1.0")
             result = A.query(attr_cond=qc, attrs=["U"])[:]
-            assert all(result["U"] < 1.0)
+            if sparse:
+                assert all(result["U"] < 1.0)
+            else:
+                assert all(self.filter_sparse(result["U"], mask) < 1.0)
 
             with self.assertRaises(tiledb.TileDBError):
                 qc = tiledb.QueryCondition("U < '1'")
@@ -203,8 +298,9 @@ class QueryConditionTest(DiskTestCase):
                 qc = tiledb.QueryCondition("U < 1")
                 A.query(attr_cond=qc, attrs=["D"])[:]
 
-    def test_error_when_using_dim(self, input_array_UIDS):
-        with tiledb.open(input_array_UIDS) as A:
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_error_when_using_dim(self, sparse):
+        with tiledb.open(self.create_input_array_UIDSA(sparse)) as A:
             with pytest.raises(tiledb.TileDBError) as excinfo:
                 qc = tiledb.QueryCondition("d < 5")
                 A.query(attr_cond=qc)[:]
@@ -284,13 +380,13 @@ class QueryConditionTest(DiskTestCase):
             qc = tiledb.QueryCondition(
                 "attr('attr with spaces') == 'value with spaces'"
             )
-            result = arr.query(attr_cond=qc, use_arrow=False)[:]
+            result = arr.query(attr_cond=qc)[:]
             assert list(result["dim"]) == [b"a", b"c"]
 
             qc = tiledb.QueryCondition(
                 "attr('attr with spaces') == val('value with spaces')"
             )
-            result = arr.query(attr_cond=qc, use_arrow=False)[:]
+            result = arr.query(attr_cond=qc)[:]
             assert list(result["dim"]) == [b"a", b"c"]
 
     @pytest.mark.skipif(
@@ -322,27 +418,38 @@ class QueryConditionTest(DiskTestCase):
         with tiledb.open(path, "r") as arr:
             for s in ascii_data:
                 qc = tiledb.QueryCondition(f"ascii == '{s.decode()}'")
-                result = arr.query(attr_cond=qc, use_arrow=False)[:]
+                result = arr.query(attr_cond=qc)[:]
                 assert result["ascii"][0] == s
 
             for s in bytes_data:
                 qc = tiledb.QueryCondition(f"bytes == '{s.decode()}'")
-                result = arr.query(attr_cond=qc, use_arrow=False)[:]
+                result = arr.query(attr_cond=qc)[:]
                 assert result["bytes"][0] == s
 
     @pytest.mark.skipif(
         tiledb.libtiledb.version() < (2, 10, 0),
         reason="OR query condition operator introduced in libtiledb 2.10",
     )
-    def test_or(self, input_array_UIDS):
-        with tiledb.open(input_array_UIDS) as A:
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_or(self, sparse):
+        with tiledb.open(self.create_input_array_UIDSA(sparse)) as A:
+            mask = A.attr("D").fill
+
             qc = tiledb.QueryCondition("(D < 0.25) | (D > 0.75)")
             result = A.query(attr_cond=qc, attrs=["D"])[:]
-            assert all((result["D"] < 0.25) | (result["D"] > 0.75))
+            if sparse:
+                assert all((result["D"] < 0.25) | (result["D"] > 0.75))
+            else:
+                res = self.filter_sparse(result["D"], mask)
+                assert all((res < 0.25) | (res > 0.75))
 
             qc = tiledb.QueryCondition("(D < 0.25) or (D > 0.75)")
             result = A.query(attr_cond=qc, attrs=["D"])[:]
-            assert all((result["D"] < 0.25) | (result["D"] > 0.75))
+            if sparse:
+                assert all((result["D"] < 0.25) | (result["D"] > 0.75))
+            else:
+                result = self.filter_sparse(result["D"], mask)
+                assert all((res < 0.25) | (res > 0.75))
 
     @pytest.mark.skipif(
         tiledb.libtiledb.version() < (2, 10, 0),


### PR DESCRIPTION
* Remove error for applying `QueryCondition` on dense arrays
* Add testing, documentation, and examples of `QueryCondition` usage on both sparse and dense arrays
* Add missing `TILEDB_STRING_ASCII` to `_tiledb_dtype_to_numpy_typeid_convert`
* Closes [sc-17776]