### PR TITLE
Remove duplicated TILEDB_BLOB

### DIFF
--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -83,7 +83,6 @@ cdef extern from "tiledb/tiledb.h":
         TILEDB_DATETIME_PS
         TILEDB_DATETIME_FS
         TILEDB_DATETIME_AS
-        TILEDB_BLOB
         TILEDB_BOOL
 
     ctypedef enum tiledb_array_type_t:


### PR DESCRIPTION
Building locally ends on a 

> warning: tiledb/libtiledb.pxd:86:8: 'TILEDB_BLOB' redeclared

which this micro-PR improves upon.  No other code changes.