### PR TITLE
Skip `test_dask_multiattr_2d` Until 2022 July 19

### DIFF
--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -2,6 +2,7 @@ import pytest
 
 da = pytest.importorskip("dask.array")
 
+from datetime import datetime
 import sys
 import tiledb
 from tiledb.tests.common import DiskTestCase
@@ -45,6 +46,13 @@ class TestDaskSupport(DiskTestCase):
 
         tiledb.DenseArray.create(uri, schema)
 
+    @pytest.mark.skipif(
+        datetime.now() < datetime(2022, 7, 19),
+        reason=(
+            "`DeprecationWarning` being thrown by Dask but will be fixed by "
+            "https://github.com/dask/distributed/issues/6163"
+        ),
+    )
     @pytest.mark.filterwarnings("ignore:There is no current event loop")
     def test_dask_multiattr_2d(self):
         uri = self.path("multiattr")

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -46,7 +46,7 @@ class TestDaskSupport(DiskTestCase):
 
         tiledb.DenseArray.create(uri, schema)
 
-    @pytest.mark.skipif(
+    @pytest.mark.xfail(
         datetime.now() < datetime(2022, 7, 19),
         reason=(
             "`DeprecationWarning` being thrown by Dask but will be fixed by "


### PR DESCRIPTION
* `DeprecationWarning` is being thrown by Dask but should be fixed
  by https://github.com/dask/distributed/issues/6163
* Temporarily disabling this test for two weeks as to not trigger
  nightly test failures