### PR TITLE
Release 0.16.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# TileDB-Py 0.16.3 Release Notes
+
+## Packaging Notes
+* This removes `import tkinter` from `test_libtiledb.py` which was preventing the conda package from building properly
+
 # TileDB-Py 0.16.2 Release Notes
 
 ## TileDB Embedded updates:

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,7 +6,7 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.16.2
+        TILEDBPY_VERSION: 0.16.3
         LIBTILEDB_VERSION: 2.10.2
         LIBTILEDB_SHA: 9ab84f907fa5bbbc22099df220ac86f1391509f1
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -5,7 +5,6 @@ import os
 import pickle
 import random
 import re
-from tkinter import NONE
 import urllib
 import subprocess
 import sys


### PR DESCRIPTION
* This removes `import tkinter` which was preventing the conda
  package from building properly