### PR TITLE
Remove Unused/Extraneous `Filestore.uri_import`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,13 @@
 # In Progress
 
+## Improvements
+* `setup.py` revert back to retrieving core version by using `ctypes` by parsing `tiledb_version.h`; the tiledb shared object lib now returns back a full path [#1226](https://github.com/TileDB-Inc/TileDB-Py/pull/1226)
+
 ## API Changes
 * Addition of `in` operator for `QueryCondition` [#1214](https://github.com/TileDB-Inc/TileDB-Py/pull/1214)
+
+## Bug Fixes
+* Deprecate `Filestore.import_uri` in lieu of `Filestore.copy_from` [#1226](https://github.com/TileDB-Inc/TileDB-Py/pull/1226)
 
 # TileDB-Py 0.16.3 Release Notes
 

--- a/tiledb/cc/filestore.cc
+++ b/tiledb/cc/filestore.cc
@@ -83,12 +83,15 @@ public:
 
 void init_filestore(py::module &m) {
   py::class_<Filestore>(m, "Filestore")
-      .def_static("_schema_create", &Filestore::schema_create)
-      .def_static("_uri_import", &Filestore::uri_import)
-      .def_static("_uri_export", &Filestore::uri_export)
-      .def_static("_buffer_import", &Filestore::buffer_import)
-      .def_static("_buffer_export", &Filestore::buffer_export)
-      .def_static("_size", &Filestore::size)
+      .def_static("_schema_create", &Filestore::schema_create,
+                  py::keep_alive<1, 2>())
+      .def_static("_uri_import", &Filestore::uri_import, py::keep_alive<1, 2>())
+      .def_static("_uri_export", &Filestore::uri_export, py::keep_alive<1, 2>())
+      .def_static("_buffer_import", &Filestore::buffer_import,
+                  py::keep_alive<1, 2>())
+      .def_static("_buffer_export", &Filestore::buffer_export,
+                  py::keep_alive<1, 2>())
+      .def_static("_size", &Filestore::size, py::keep_alive<1, 2>())
       .def_static("_mime_type_to_str", &Filestore::mime_type_to_str)
       .def_static("_mime_type_from_str", &Filestore::mime_type_from_str);
   ;

--- a/tiledb/filestore.py
+++ b/tiledb/filestore.py
@@ -1,4 +1,5 @@
-from typing import ByteString, Optional, overload, TYPE_CHECKING
+from typing import ByteString, TYPE_CHECKING
+import warnings
 
 import tiledb.cc as lt
 from .ctx import default_ctx
@@ -138,78 +139,11 @@ class Filestore:
 
         lt.Filestore._uri_export(lt.Context(ctx, False), filestore_array_uri, file_uri)
 
-    def uri_import(self, uri: str, mime_type: str = "AUTODETECT") -> None:
-        """
-        :param int offset: Byte position to begin reading. Defaults to beginning of filestore.
-        :param int size: Total number of bytes to read. Defaults to -1 which reads the entire filestore.
-        :rtype: bytes
-        :return: Data from the Filestore Array
-
-        """
-        try:
-            buffer = memoryview(buffer)
-        except TypeError:
-            raise TypeError(
-                f"Unexpected buffer type: buffer must support buffer protocol"
-            )
-
-        if not isinstance(mime_type, str):
-            raise TypeError(
-                f"Unexpected mime_type type '{type(mime_type)}': expected str"
-            )
-
-        lt.Filestore._buffer_import(
-            lt.Context(self._ctx, False),
-            self._filestore_uri,
-            offset,
-            size,
+    def uri_import(self, file_uri: str, mime_type: str = "AUTODETECT") -> None:
+        warnings.warn(
+            "Filestore.uri_import is deprecated; please use Filestore.copy_from",
+            DeprecationWarning,
         )
-
-    def read(self, offset: int = 0, size: int = -1) -> bytes:
-        """
-        :param int offset: Byte position to begin reading. Defaults to beginning of filestore.
-        :param int size: Total number of bytes to read. Defaults to -1 which reads the entire filestore.
-        :rtype: bytes
-        :return: Data from the Filestore Array
-
-        """
-        if not isinstance(offset, int):
-            raise TypeError(f"Unexpected offset type '{type(offset)}': expected int")
-
-        if not isinstance(size, int):
-            raise TypeError(f"Unexpected size type '{type(size)}': expected int")
-
-        if size == -1:
-            size = len(self)
-        size = max(size - offset, 0)
-
-        return lt.Filestore._buffer_export(
-            lt.Context(self._ctx, False),
-            self._filestore_uri,
-            offset,
-            size,
-        )
-
-    @staticmethod
-    def copy_from(
-        filestore_array_uri: str,
-        file_uri: str,
-        mime_type: str = "AUTODETECT",
-        ctx: "Ctx" = None,
-    ) -> None:
-        """
-        Copy data from a file to a Filestore Array.
-
-        :param str filestore_array_uri: The URI to the TileDB Fileshare Array
-        :param str file_uri: URI of file to export
-        :param str mime_type: MIME types are "AUTODETECT" (default), "image/tiff", "application/pdf"
-        :param tiledb.Ctx ctx: A TileDB context
-
-        """
-        if not isinstance(filestore_array_uri, str):
-            raise TypeError(
-                f"Unexpected filestore_array_uri type '{type(filestore_array_uri)}': expected str"
-            )
 
         if not isinstance(file_uri, str):
             raise TypeError(
@@ -220,90 +154,12 @@ class Filestore:
             raise TypeError(
                 f"Unexpected mime_type type '{type(mime_type)}': expected str"
             )
-
-        ctx = ctx or default_ctx()
 
         lt.Filestore._uri_import(
-            lt.Context(ctx, False),
-            filestore_array_uri,
+            lt.Context(self._ctx, False),
+            self._filestore_uri,
             file_uri,
             lt.Filestore._mime_type_from_str(mime_type),
-        )
-
-    @staticmethod
-    def copy_to(filestore_array_uri: str, file_uri: str, ctx: "Ctx" = None) -> None:
-        """
-        Copy data from a Filestore Array to a file.
-
-        :param str filestore_array_uri: The URI to the TileDB Fileshare Array
-        :param str file_uri: The URI to the TileDB Fileshare Array
-        :param tiledb.Ctx ctx: A TileDB context
-
-        """
-        if not isinstance(filestore_array_uri, str):
-            raise TypeError(
-                f"Unexpected filestore_array_uri type '{type(filestore_array_uri)}': expected str"
-            )
-
-        if not isinstance(file_uri, str):
-            raise TypeError(
-                f"Unexpected file_uri type '{type(file_uri)}': expected str"
-            )
-
-        ctx = ctx or default_ctx()
-
-        lt.Filestore._uri_export(lt.Context(ctx, False), filestore_array_uri, file_uri)
-
-    def uri_import(self, uri: str, mime_type: str = "AUTODETECT") -> None:
-        """
-        Import data from an object that supports the buffer protocol to a Filestore Array.
-
-        :param buffer ByteString: Data of type bytes, bytearray, memoryview, etc.
-        :param str mime_type: MIME types are "AUTODETECT" (default), "image/tiff", "application/pdf"
-
-        """
-        try:
-            buffer = memoryview(buffer)
-        except TypeError:
-            raise TypeError(
-                f"Unexpected buffer type: buffer must support buffer protocol"
-            )
-
-        if not isinstance(mime_type, str):
-            raise TypeError(
-                f"Unexpected mime_type type '{type(mime_type)}': expected str"
-            )
-
-        lt.Filestore._buffer_import(
-            lt.Context(self._ctx, False),
-            self._filestore_uri,
-            buffer,
-            lt.Filestore._mime_type_from_str(mime_type),
-        )
-
-    def read(self, offset: int = 0, size: int = -1) -> bytes:
-        """
-        :param int offset: Byte position to begin reading. Defaults to beginning of filestore.
-        :param int size: Total number of bytes to read. Defaults to -1 which reads the entire filestore.
-        :rtype: bytes
-        :return: Data from the Filestore Array
-
-        """
-        if not isinstance(offset, int):
-            raise TypeError(f"Unexpected offset type '{type(offset)}': expected int")
-
-        if not isinstance(size, int):
-            raise TypeError(f"Unexpected size type '{type(size)}': expected int")
-
-        if size == -1:
-            size = len(self)
-        size = max(size - offset, 0)
-
-        return lt.Filestore._buffer_export(
-            lt.Context(self._ctx, False),
-            self._filestore_uri,
-            offset,
-            size,
         )
 
     def __len__(self) -> int:

--- a/tiledb/tests/test_filestore.py
+++ b/tiledb/tests/test_filestore.py
@@ -52,6 +52,22 @@ class FilestoreTest(DiskTestCase):
             assert data == fs.read(0, len(data))
             assert len(fs) == len(data)
 
+    def test_deprecated_uri(self, text_fname):
+        path = self.path("test_uri")
+        schema = tiledb.ArraySchema.from_file(text_fname)
+        tiledb.Array.create(path, schema)
+
+        fs = tiledb.Filestore(path)
+        with pytest.warns(
+            DeprecationWarning, match="Filestore.uri_import is deprecated"
+        ):
+            fs.uri_import(text_fname)
+
+        with open(text_fname, "rb") as text:
+            data = text.read()
+            assert data == fs.read(0, len(data))
+            assert len(fs) == len(data)
+
     def test_multiple_writes(self):
         path = self.path("test_buffer")
         schema = tiledb.ArraySchema.from_file()


### PR DESCRIPTION
* This function was accidentally left in; it does not work
* The function to write a file located at URI to a filestore array is
  already correctly implemented by `Filestore.copy_from`