### PR TITLE
Update minimum required `cmake` version to =>3.23

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Improvements
 * `setup.py` revert back to retrieving core version by using `ctypes` by parsing `tiledb_version.h`; the tiledb shared object lib now returns back a full path [#1226](https://github.com/TileDB-Inc/TileDB-Py/pull/1226)
+* Update minimum required cmake version to =>3.23; required for building `libtiledb` []()
 
 ## API Changes
 * Addition of `in` operator for `QueryCondition` [#1214](https://github.com/TileDB-Inc/TileDB-Py/pull/1214)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## Improvements
 * `setup.py` revert back to retrieving core version by using `ctypes` by parsing `tiledb_version.h`; the tiledb shared object lib now returns back a full path [#1226](https://github.com/TileDB-Inc/TileDB-Py/pull/1226)
-* Update minimum required cmake version to =>3.23; required for building `libtiledb` []()
+* Update minimum required cmake version to =>3.23; required for building `libtiledb` [#1260](https://github.com/TileDB-Inc/TileDB-Py/pull/1260)
 
 ## API Changes
 * Addition of `in` operator for `QueryCondition` [#1214](https://github.com/TileDB-Inc/TileDB-Py/pull/1214)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,8 +3,7 @@ numpy >= 1.16.5
 # ------------------------------------------------
 # ** MUST sync with misc/requirements_wheel.txt **
 # ------------------------------------------------
-# Note 11/23/2021: the current version of the AWS sdk does not work with cmake 3.22
-cmake >= 3.21, < 3.22
+cmake >= 3.23
 cython >= 0.27
 pybind11 >= 2.6.2
 setuptools >= 18.0, <= 59.5.0


### PR DESCRIPTION
* Fixes issue #1258
* Required for building `libtiledb` as of TileDB-Inc/TileDB#3306