### PR TITLE
Revert "Dense Array `[:]` Returns Nonempty Domain Only (#1199)"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 
 ## API Changes
 * Addition of `in` operator for `QueryCondition` [#1214](https://github.com/TileDB-Inc/TileDB-Py/pull/1214)
+* Revert `.df[:]` to return entire domain rather than nonempty domain []()
 
 ## Bug Fixes
 * Deprecate `Filestore.import_uri` in lieu of `Filestore.copy_from` [#1226](https://github.com/TileDB-Inc/TileDB-Py/pull/1226)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@
 
 ## API Changes
 * Addition of `in` operator for `QueryCondition` [#1214](https://github.com/TileDB-Inc/TileDB-Py/pull/1214)
-* Revert `.df[:]` to return entire domain rather than nonempty domain []()
+* Revert `.df[:]` to return entire array rather than nonempty domain [#1261](https://github.com/TileDB-Inc/TileDB-Py/pull/1261)
 
 ## Bug Fixes
 * Deprecate `Filestore.import_uri` in lieu of `Filestore.copy_from` [#1226](https://github.com/TileDB-Inc/TileDB-Py/pull/1226)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@
 
 ## API Changes
 * Addition of `in` operator for `QueryCondition` [#1214](https://github.com/TileDB-Inc/TileDB-Py/pull/1214)
-* Revert `.df[:]` to return entire array rather than nonempty domain [#1261](https://github.com/TileDB-Inc/TileDB-Py/pull/1261)
+* Revert the regular indexer `[:]` to return entire array rather than nonempty domain in order to maintain NumPy semantics [#1261](https://github.com/TileDB-Inc/TileDB-Py/pull/1261)
 
 ## Bug Fixes
 * Deprecate `Filestore.import_uri` in lieu of `Filestore.copy_from` [#1226](https://github.com/TileDB-Inc/TileDB-Py/pull/1226)

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2562,7 +2562,7 @@ def replace_scalars_slice(dom: Domain, idx: tuple):
     return tuple(new_idx), tuple(drop_axes)
 
 
-def index_domain_subarray(array: Array, dom: Domain, idx: tuple, read_array: bool = False):
+def index_domain_subarray(array: Array, dom: Domain, idx: tuple):
     """
     Return a numpy array representation of the tiledb subarray buffer
     for a given domain and tuple of index slices
@@ -2580,17 +2580,9 @@ def index_domain_subarray(array: Array, dom: Domain, idx: tuple, read_array: boo
 
         if np.issubdtype(dim_dtype, np.unicode_) or np.issubdtype(dim_dtype, np.bytes_):
             ned = array.nonempty_domain()
-            (dim_lb, dim_ub) = ned[r] if ned is not None else (None, None)
+            (dim_lb, dim_ub) = ned[r] if ned else (None, None)
         else:
-            if read_array:
-                ned = array.nonempty_domain()
-                (dim_lb, dim_ub) = (
-                    np.array(ned[r], dim_dtype)
-                    if ned is not None
-                    else dim.domain
-                )
-            else:
-                (dim_lb, dim_ub) = dim.domain
+            (dim_lb, dim_ub) = dim.domain
 
 
         dim_slice = idx[r]
@@ -4502,7 +4494,7 @@ cdef class DenseArrayImpl(Array):
         selection = index_as_tuple(selection)
         idx = replace_ellipsis(self.schema.domain.ndim, selection)
         idx, drop_axes = replace_scalars_slice(self.schema.domain, idx)
-        subarray = index_domain_subarray(self, self.schema.domain, idx, True)
+        subarray = index_domain_subarray(self, self.schema.domain, idx)
         # Note: we included dims (coords) above to match existing semantics
         out = self._read_dense_subarray(subarray, attr_names, attr_cond, layout,
                                         coords)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1816,21 +1816,6 @@ class DenseArrayTest(DiskTestCase):
 
         T.close()
 
-    def test_writing_partial_dense_array(self):
-        uri = self.path("test_writing_partial_dense_array")
-
-        dom = tiledb.Domain(tiledb.Dim(domain=(0, 1000), tile=1000, dtype=np.int64))
-        attr = tiledb.Attr(name="rows", dtype=np.int64)
-        schema = tiledb.ArraySchema(domain=dom, sparse=False, attrs=[attr])
-        tiledb.Array.create(uri, schema)
-
-        with tiledb.open(uri, "w") as A:
-            A[0:1000] = np.arange(1000)
-
-        with tiledb.open(uri) as A:
-            ned = A.nonempty_domain()[0]
-            assert len(A[:]["rows"]) == ned[1] - ned[0] + 1
-
 
 class TestVarlen(DiskTestCase):
     def test_varlen_write_bytes(self):


### PR DESCRIPTION
This reverts commit f7145ede9d1cdc94b42ad2ba13821417b0a190f2.

- The regular indexer should return the entire array, not just the nonempty domain, to maintain NumPy semantics