### PR TITLE
Add `filterwarning` For `test_dask_multiattr_2d` 

### DIFF
--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -54,6 +54,7 @@ class TestDaskSupport(DiskTestCase):
         ),
     )
     @pytest.mark.filterwarnings("ignore:There is no current event loop")
+    @pytest.mark.filterwarnings("ignore:make_current is deprecated")
     def test_dask_multiattr_2d(self):
         uri = self.path("multiattr")
 


### PR DESCRIPTION
* Allow warning message `make_current is deprecated`
* This warning message is emitted from the Hurricane library via Dask in Python 3.7 on POSIX