### PR TITLE
[2.12] Migrate CI To Run On macOS 11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.15
+      MACOSX_DEPLOYMENT_TARGET: "10.15"
     steps:
       - name: Checkout TileDB-Py `dev`
         uses: actions/checkout@v2
@@ -33,8 +33,16 @@ jobs:
       - name: Print env
         run: printenv
 
+      - name: Print pip debug info
+        run: pip debug --verbose
+
       - name: "Install dependencies"
-        run: python -m pip install --upgrade -r misc/requirements_ci.txt
+        run: |
+          python -m pip install --upgrade -r misc/requirements_ci.txt
+
+      - name: "Check build directory"
+        run: |
+            ls -Rl
 
       - name: "Build TileDB and TileDB-Py extension (Windows)"
         run: |
@@ -47,7 +55,7 @@ jobs:
           set -xeo pipefail
           python setup.py build_ext --inplace --werror
           python setup.py install
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-10.15'
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-11'
 
       - name: "Run tests"
         run: |
@@ -61,7 +69,7 @@ jobs:
           cp dist/*.whl /tmp/wheel_test
           pushd /tmp/wheel_test
           ls
-          pip install *.whl
+          python -m pip install *.whl
           python -c 'import tiledb ; tiledb.libtiledb.version()'
 
       - name: "Print log files (failed build only)"

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         include:
           # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
@@ -29,7 +29,7 @@ jobs:
             numpy-version: "1.16.5"
       fail-fast: false
     env:
-      MACOSX_DEPLOYMENT_TARGET: 10.15
+      MACOSX_DEPLOYMENT_TARGET: "10.15"
     steps:
       - name: Checkout TileDB-Py `dev`
         uses: actions/checkout@v2

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
         libtiledb_version: ["dev", "release-2.11"]
         uninstall_pandas: [true, false]
       fail-fast: false
@@ -38,7 +38,7 @@ jobs:
       issues: write
     env:
       TILEDB_VERSION: ${{ matrix.libtiledb_version }}
-      MACOSX_DEPLOYMENT_TARGET: 10.15
+      MACOSX_DEPLOYMENT_TARGET: "10.15"
 
     steps:
       - name: Set up Python

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -1,94 +1,94 @@
 stages:
-- stage: CI
-  condition: not(or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranchName'], 'release-')))
-  jobs:
-  - job:
-    pool:
-      vmImage: $(imageName)
-    strategy:
-      matrix:
-        mac:
-          imageName: 'macOS-10.15'
-          python.version: '3.10'
-          MACOSX_DEPLOYMENT_TARGET: 10.15
-        windows:
-          imageName: 'windows-latest'
-          python.version: '3.10'
-        linux_py3:
-          imageName: 'ubuntu-latest'
-          python.version: '3.10'
-      maxParallel: 4
-    timeoutInMinutes: 120
+  - stage: CI
+    condition: not(or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranchName'], 'release-')))
+    jobs:
+      - job:
+        pool:
+          vmImage: $(imageName)
+        strategy:
+          matrix:
+            mac:
+              imageName: "macOS-11"
+              python.version: "3.10"
+              MACOSX_DEPLOYMENT_TARGET: 10.15
+            windows:
+              imageName: "windows-latest"
+              python.version: "3.10"
+            linux_py3:
+              imageName: "ubuntu-latest"
+              python.version: "3.10"
+          maxParallel: 4
+        timeoutInMinutes: 120
 
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '$(python.version)'
-        architecture: 'x64'
+        steps:
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: "$(python.version)"
+              architecture: "x64"
 
-    # Print python and pip version information for debugging.
-    # Azure pipelines windows images have been unstable or out of sync, causing
-    # build failures in the pip step below when the 'bash' task uses the wrong
-    # python or has issue that causes un-corrected cygwin-style paths to be
-    # passed to pip.
-    - bash: |
-        echo "==== Python information ===="
-        which python
-        which pip
-        python --version
-        echo "============================"
-      displayName: 'Print python version in bash task'
+          # Print python and pip version information for debugging.
+          # Azure pipelines windows images have been unstable or out of sync, causing
+          # build failures in the pip step below when the 'bash' task uses the wrong
+          # python or has issue that causes un-corrected cygwin-style paths to be
+          # passed to pip.
+          - bash: |
+              echo "==== Python information ===="
+              which python
+              which pip
+              python --version
+              echo "============================"
+            displayName: "Print python version in bash task"
 
-    - script: |
-        printenv
-      displayName: 'Print env'
+          - script: |
+              printenv
+            displayName: "Print env"
 
-    - script: |
-        python -m pip install --upgrade -r misc/requirements_ci.txt
-      displayName: 'Install dependencies'
+          - script: |
+              python -m pip install --upgrade -r misc/requirements_ci.txt
+            displayName: "Install dependencies"
 
-    - script: |
-        # vcvarsall is necessary so that numpy uses the correct compiler
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-        python setup.py build_ext --inplace
-        python setup.py install
-      displayName: 'Build TileDB and TileDB-Py extension (Windows)'
-      condition: eq(variables['Agent.OS'], 'Windows_NT')
+          - script: |
+              # vcvarsall is necessary so that numpy uses the correct compiler
+              call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+              python setup.py build_ext --inplace
+              python setup.py install
+            displayName: "Build TileDB and TileDB-Py extension (Windows)"
+            condition: eq(variables['Agent.OS'], 'Windows_NT')
 
-    - bash: |
-        unset SYSTEM
-        set -xeo pipefail
-        python setup.py build_ext --inplace --werror
-        python setup.py install
-      displayName: 'Build TileDB and TileDB-Py extension (POSIX)'
-      condition: ne(variables['Agent.OS'], 'Windows_NT')
+          - bash: |
+              unset SYSTEM
+              set -xeo pipefail
+              python setup.py build_ext --inplace --werror
+              python setup.py install
+            displayName: "Build TileDB and TileDB-Py extension (POSIX)"
+            condition: ne(variables['Agent.OS'], 'Windows_NT')
 
-    - bash: |
-        set -xeo pipefail
+          - bash: |
+              set -xeo pipefail
 
-        pytest -vv
+              pytest -vv
 
-        # Test wheel build, install, and run
-        python setup.py bdist_wheel
-        #whl_file=`pwd`/dist/`ls dist/*.whl`
-        mkdir /tmp/wheel_test
-        cp dist/*.whl /tmp/wheel_test
-        pushd /tmp/wheel_test
-        ls
-        pip install *.whl
-        python -c "import tiledb ; tiledb.libtiledb.version()"
-      displayName: 'Run tests'
+              # Test wheel build, install, and run
+              python setup.py bdist_wheel
+              #whl_file=`pwd`/dist/`ls dist/*.whl`
+              mkdir /tmp/wheel_test
+              cp dist/*.whl /tmp/wheel_test
+              pushd /tmp/wheel_test
+              ls
+              pip install *.whl
+              python -c "import tiledb ; tiledb.libtiledb.version()"
+            displayName: "Run tests"
 
-    - bash: |
-        set -xeo pipefail
-        # Display log files if the build failed
-        echo "Dumping log files for failed build"
-        echo "----------------------------------"
-        for f in $(find $BUILD_REPOSITORY_LOCALPATH/build -name *.log);
-          do echo "------"
-             echo $f
-             echo "======"
-             cat $f
-          done;
-      condition: failed() # only run this job if the build step failed
-      displayName: "Print log files (failed build only)"
+          - bash: |
+              set -xeo pipefail
+              # Display log files if the build failed
+              echo "Dumping log files for failed build"
+              echo "----------------------------------"
+              for f in $(find $BUILD_REPOSITORY_LOCALPATH/build -name *.log);
+                do echo "------"
+                   echo $f
+                   echo "======"
+                   cat $f
+                done;
+            condition: failed() # only run this job if the build step failed
+            displayName: "Print log files (failed build only)"

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ TILEDB_PKG_DIR = os.path.join(CONTAINING_DIR, "tiledb")
 #   set MACOSX_DEPLOYMENT_TARGET before calling setup.py
 if sys.platform == "darwin":
     if "MACOSX_DEPLOYMENT_TARGET" not in os.environ:
-        os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.14"
+        os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"
 
 # Is this process building a wheel?
 WHEEL_BUILD = ("bdist_wheel" in sys.argv) or ("TILEDB_WHEEL_BUILD" in os.environ)


### PR DESCRIPTION
- Microsoft is currently issuing brownouts for macOS 10.15. Support in GitHub Actions will cease at the end of August and in Azure at the end of September. Our minimum supported version will need to be bumped to macOS 11 Big Sur.