### PR TITLE
Support `datetime64` For `QueryCondition`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# In Progress
+
+## API Changes
+* Support `datetime64` for `QueryCondition` [#1279](https://github.com/TileDB-Inc/TileDB-Py/pull/1279)
+
 # TileDB-Py 0.17.0 Release Notes
 
 ## TileDB Embedded updates:

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -84,7 +84,7 @@ class QueryCondition:
         ``attr ::= <variable> | attr(<str>)``
 
     Values are any Python-valid number or string. datetime64 values should first be
-    casted to UNIX seconds. Vales may also be casted with ``val()``.
+    cast to UNIX seconds. Values may also be casted with ``val()``.
 
         ``val ::= <num> | <str> | val(val)``
 
@@ -364,7 +364,7 @@ class QueryConditionTree(ast.NodeVisitor):
                 if isinstance(val, str):
                     raise tiledb.TileDBError(f"Cannot cast `{val}` to {dtype}.")
                 if np.issubdtype(dtype, np.datetime64):
-                    cast = getattr(np, "uint64")
+                    cast = getattr(np, "int64")
                 else:
                     cast = getattr(np, dtype)
                 val = cast(val)
@@ -374,8 +374,8 @@ class QueryConditionTree(ast.NodeVisitor):
         return val
 
     def init_pyqc(self, pyqc: PyQueryCondition, dtype: str) -> Callable:
-        if np.issubdtype(dtype, np.datetime64):
-            dtype = "uint64"
+        if dtype != "string" and np.issubdtype(dtype, np.datetime64):
+            dtype = "int64"
 
         init_fn_name = f"init_{dtype}"
 

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -46,15 +46,13 @@ class TestDaskSupport(DiskTestCase):
 
         tiledb.DenseArray.create(uri, schema)
 
-    @pytest.mark.xfail(
-        datetime.now() < datetime(2022, 8, 8),
-        reason=(
-            "`DeprecationWarning` being thrown by Dask but will be fixed by "
-            "https://github.com/dask/distributed/issues/6163"
-        ),
-    )
     @pytest.mark.filterwarnings("ignore:There is no current event loop")
-    @pytest.mark.filterwarnings("ignore:make_current is deprecated")
+    @pytest.mark.filterwarnings(
+        # In Python 3.7 on POSIX systems, Hurricane outputs a warning message
+        # that "make_current is deprecated." This should be fixed by Dask in
+        # future releases.
+        "ignore:make_current is deprecated"
+    )
     def test_dask_multiattr_2d(self):
         uri = self.path("multiattr")
 

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -16,12 +16,13 @@ class QueryConditionTest(DiskTestCase):
         if isinstance(mask, np.ndarray):
             mask = mask[0]
 
-        if isinstance(mask, float) and np.isnan(mask):
+        if isinstance(mask, float):
             return data[np.invert(np.isnan(data))]
-        elif np.isnat(mask):
+
+        if isinstance(mask, np.timedelta64):
             return data[np.invert(np.isnat(data))]
-        else:
-            return data[data != mask]
+
+        return data[data != mask]
 
     def create_input_array_UIDSA(self, sparse):
         path = self.path("input_array_UIDSA")

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -616,7 +616,7 @@ class QueryConditionTest(DiskTestCase):
         uri = self.path("query-filter-dense-datetime.tdb")
 
         data = pd.DataFrame(
-            np.random.randint(438923600, 243892360000, 20),
+            np.random.randint(438923600, 243892360000, 20, dtype=np.int64),
             columns=["dates"],
         )
 


### PR DESCRIPTION
* Currently, `datetime64` values in `QueryCondition`s should be casted to UNIX seconds