### PR TITLE
Use Arrow Type Fixed-Width Binary ("w:") For Fixed-Width `TILEDB_CHAR`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 * Fix issue where querying an array with a Boolean type when `arrow=True`, but is unselected in `.query(attr=...)`, results in an error `pyarrow.lib.ArrowInvalid: Invalid column index to set field.` []()
+* Use Arrow type fixed-width binary ("w:") for non-variable TILEDB_CHAR []()
 
 # TileDB-Py 0.17.1 Release Notes
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 * Fix issue where querying an array with a Boolean type when `arrow=True`, but is unselected in `.query(attr=...)`, results in an error `pyarrow.lib.ArrowInvalid: Invalid column index to set field.` []()
-* Use Arrow type fixed-width binary ("w:") for non-variable TILEDB_CHAR []()
+* Use Arrow type fixed-width binary ("w:") for non-variable TILEDB_CHAR [#1286](https://github.com/TileDB-Inc/TileDB-Py/pull/1286)
 
 # TileDB-Py 0.17.1 Release Notes
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # In Progress
 
 ## Bug Fixes
-* Fix issue where querying an array with a Boolean type when `arrow=True`, but is unselected in `.query(attr=...)`, results in an error `pyarrow.lib.ArrowInvalid: Invalid column index to set field.` []()
+* Fix issue where querying an array with a Boolean type when `arrow=True`, but is unselected in `.query(attr=...)`, results in an error `pyarrow.lib.ArrowInvalid: Invalid column index to set field.` [#1291](https://github.com/TileDB-Inc/TileDB-Py/pull/1291)
 * Use Arrow type fixed-width binary ("w:") for non-variable TILEDB_CHAR [#1286](https://github.com/TileDB-Inc/TileDB-Py/pull/1286)
 
 # TileDB-Py 0.17.1 Release Notes

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -888,6 +888,23 @@ class TestMultiRange(DiskTestCase):
             assert "py.getitem_time.pandas_index_update_time :" in internal_stats
         tiledb.stats_disable()
 
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    def test_fixed_width_char(self):
+        uri = self.path("test_fixed_width_char")
+        schema = tiledb.ArraySchema(
+            domain=tiledb.Domain(tiledb.Dim(name="dim", domain=(0, 2), dtype=np.uint8)),
+            attrs=[tiledb.Attr(dtype="|S3")],
+        )
+        tiledb.Array.create(uri, schema)
+
+        data = np.array(["cat", "dog", "hog"], dtype="|S3")
+
+        with tiledb.open(uri, mode="w") as A:
+            A[:] = data
+
+        with tiledb.open(uri, mode="r") as A:
+            assert all(A.query(use_arrow=True).df[:][""] == data)
+
 
 # parametrize dtype and sparse
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Previously, this errored out with `ArrowInvalid: Expected 3 buffers for imported type large_binary, ArrowArray struct has 2`
* Fixed-width `TILEDB_CHAR` was using type large binary ("Z") which requires 3 buffers, including an offset buffer, that is not present or necessary for fixed-width binary strings
* This does not handle fixed-width `TILEDB_UTF8`