### PR TITLE
Fix Bug For Querying With Unselected Boolean Type

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# In Progress
+
+## Bug Fixes
+* Fix issue where querying an array with a Boolean type when `arrow=True`, but is unselected in `.query(attr=...)`, results in an error `pyarrow.lib.ArrowInvalid: Invalid column index to set field.` []()
+
 # TileDB-Py 0.17.1 Release Notes
 
 ## API Changes

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -349,12 +349,16 @@ class DataFrameIndexer(_BaseIndexer):
             # this is a workaround to cast TILEDB_BOOL types from uint8
             # representation in Arrow to Boolean
             schema = table.schema
-            for n in range(self.array.nattr):
-                attr = self.array.attr(n)
+            for attr_or_dim in schema:
+                if not self.array.schema.has_attr(attr_or_dim.name):
+                    continue
+
+                attr = self.array.attr(attr_or_dim.name)
                 if attr.dtype == bool:
                     field_idx = schema.get_field_index(attr.name)
                     field = pyarrow.field(attr.name, pyarrow.bool_())
                     schema = schema.set(field_idx, field)
+
             table = table.cast(schema)
 
             if self.query.return_arrow:


### PR DESCRIPTION
* Fix issue where querying an array with a Boolean type when `arrow=True`, but is unselected in `.query(attr=...)`, results in an error `pyarrow.lib.ArrowInvalid: Invalid column index to set field.`