### PR TITLE
Update test_bytes_{numpy,df} to address test failures

### DIFF
--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -1,11 +1,12 @@
 import tiledb
 import importlib
+import time
 import numpy as np
 import pytest
 
 import hypothesis
 import hypothesis.strategies as st
-from hypothesis import given
+from hypothesis import given, reproduce_failure
 from numpy.testing import assert_array_equal
 
 from tiledb.tests.common import DiskTestCase, has_pandas
@@ -21,19 +22,18 @@ class AttrDataTest(DiskTestCase):
 
         uri = self.path()
 
-        if data == b"" or data.count(b"\x00") == len(data):
-            # single-cell empty writes are not supported; TileDB PR 1646
-            array = np.array([data, b"1"], dtype="S0")
-        else:
-            array = np.array([data], dtype="S0")
+        array = np.array([data], dtype="S0")
+
+        start_fnp = time.time()
+        with tiledb.from_numpy(uri, array) as A:
+            pass
+        fnp_time = time.time() - start_fnp
+        hypothesis.note("from_numpy time: {fnp_time}")
 
         # DEBUG
         tiledb.stats_enable()
         tiledb.stats_reset()
         # END DEBUG
-
-        with tiledb.from_numpy(uri, array) as A:
-            pass
 
         with tiledb.open(uri) as A:
             assert_array_equal(A.multi_index[:][""], array)
@@ -56,21 +56,20 @@ class AttrDataTest(DiskTestCase):
 
         uri_df = self.path()
 
-        if data == b"" or data.count(b"\x00") == len(data):
-            # single-cell empty writes are not supported; TileDB PR 1646
-            array = np.array([data, b"1"], dtype="S0")
-        else:
-            array = np.array([data], dtype="S0")
+        array = np.array([data], dtype="S0")
 
         series = pd.Series(array)
         df = pd.DataFrame({"": series})
+
+        start_fpd = time.time()
+        tiledb.from_pandas(uri_df, df, sparse=False)
+        fpd_time = time.time() - start_fpd
+        hypothesis.note("from_pandas time: {fpd_time}")
 
         # DEBUG
         tiledb.stats_enable()
         tiledb.stats_reset()
         # END DEBUG
-
-        tiledb.from_pandas(uri_df, df, sparse=False)
 
         with tiledb.open(uri_df) as A:
             tm.assert_frame_equal(A.df[:], df)

--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -27,7 +27,7 @@ def pytest_configure(config):
 
 
 class AttrDataTest(DiskTestCase):
-    @hypothesis.settings(deadline=1000)
+    @hypothesis.settings(deadline=2000)
     @given(st.binary())
     def test_bytes_numpy(self, data):
         start = time.time()
@@ -60,7 +60,7 @@ class AttrDataTest(DiskTestCase):
         hypothesis.note(f"test_bytes_numpy time: {start - time.time()}")
 
     @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
-    @hypothesis.settings(deadline=1000)
+    @hypothesis.settings(deadline=2000)
     @given(st.binary())
     def test_bytes_df(self, data):
         start = time.time()

--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -1,8 +1,11 @@
+from math import hypot
 import tiledb
-import importlib
 import time
 import numpy as np
 import pytest
+
+pd = pytest.importorskip("pandas")
+tm = pd._testing
 
 import hypothesis
 import hypothesis.strategies as st
@@ -16,6 +19,7 @@ class AttrDataTest(DiskTestCase):
     @hypothesis.settings(deadline=1000)
     @given(st.binary())
     def test_bytes_numpy(self, data):
+        start = time.time()
         # TODO this test is slow. might be nice to run with in-memory
         #      VFS (if faster) but need to figure out correct setup
         # uri = "mem://" + str(uri_int)
@@ -28,7 +32,7 @@ class AttrDataTest(DiskTestCase):
         with tiledb.from_numpy(uri, array) as A:
             pass
         fnp_time = time.time() - start_fnp
-        hypothesis.note("from_numpy time: {fnp_time}")
+        hypothesis.note(f"from_numpy time: {fnp_time}")
 
         # DEBUG
         tiledb.stats_enable()
@@ -42,13 +46,13 @@ class AttrDataTest(DiskTestCase):
 
         # DEBUG
         tiledb.stats_disable()
+        hypothesis.note(f"test_bytes_numpy time: {start - time.time()}")
 
     @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     @hypothesis.settings(deadline=1000)
     @given(st.binary())
     def test_bytes_df(self, data):
-        import pandas as pd
-        from pandas import _testing as tm
+        start = time.time()
 
         # TODO this test is slow. might be nice to run with in-memory
         #      VFS (if faster) but need to figure out correct setup
@@ -64,7 +68,7 @@ class AttrDataTest(DiskTestCase):
         start_fpd = time.time()
         tiledb.from_pandas(uri_df, df, sparse=False)
         fpd_time = time.time() - start_fpd
-        hypothesis.note("from_pandas time: {fpd_time}")
+        hypothesis.note(f"from_pandas time: {fpd_time}")
 
         # DEBUG
         tiledb.stats_enable()
@@ -78,3 +82,4 @@ class AttrDataTest(DiskTestCase):
 
         # DEBUG
         tiledb.stats_disable()
+        hypothesis.note(f"test_bytes_df time: {start - time.time()}")

--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -35,7 +35,7 @@ class AttrDataTest(DiskTestCase):
         #      VFS (if faster) but need to figure out correct setup
         # uri = "mem://" + str(uri_int)
 
-        uri = self.path()
+        uri = "mem://" + self.path()
 
         array = np.array([data], dtype="S0")
 

--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -15,6 +15,17 @@ from numpy.testing import assert_array_equal
 from tiledb.tests.common import DiskTestCase, has_pandas
 
 
+def pytest_configure(config):
+    # Try to work around `https://github.com/HypothesisWorks/hypothesis/issues/2108` and the like
+    # Setting up to generate the strategy can be slow.
+    @given(st.binary())
+    def foo(x):
+        pass
+
+    foo()
+    return
+
+
 class AttrDataTest(DiskTestCase):
     @hypothesis.settings(deadline=1000)
     @given(st.binary())


### PR DESCRIPTION
- Remove work-arounds for previously unsupported codepath
- Add separate timing and `hypothesis.note` for `from_{numpy,pandas}` step so that we can try to determine if that step is the cause of #1194.