### PR TITLE
Add Support For Retrieving MBRs Of Var-Sized Dims

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # In Progress
 
 ## API Changes
-* Support retrieving MBRs of var-sized dimensions []()
+* Support retrieving MBRs of var-sized dimensions [#1311](https://github.com/TileDB-Inc/TileDB-Py/pull/1311)
 
 ## Misc Updates
 * Wheels will no longer be supported for macOS 10.15 Catalina; the minimum supported macOS version is now 11 Big Sur [#1300](https://github.com/TileDB-Inc/TileDB-Py/pull/1300)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # In Progress
 
+## API Changes
+* Support retrieving MBRs of var-sized dimensions []()
+
 ## Misc Updates
 * Wheels will no longer be supported for macOS 10.15 Catalina; the minimum supported macOS version is now 11 Big Sur [#1300](https://github.com/TileDB-Inc/TileDB-Py/pull/1300)
 * Wheels will no longer supported for Python 3.6 [#1300](https://github.com/TileDB-Inc/TileDB-Py/pull/1300)

--- a/tiledb/fragment.cc
+++ b/tiledb/fragment.cc
@@ -279,6 +279,13 @@ private:
   }
 
   py::tuple fill_mbr(uint32_t fid, uint32_t mid, uint32_t did) const {
+    py::bool_ isvar = get_dim_isvar(schema_.attr("domain"), did);
+
+    if (isvar) {
+      auto limits = fi_->mbr_var(fid, mid, did);
+      return py::make_tuple(limits.first, limits.second);
+    }
+
     py::dtype type = get_dim_type(schema_.attr("domain"), did);
     py::dtype array_type =
         type.kind() == 'M' ? pybind11::dtype::of<uint64_t>() : type;


### PR DESCRIPTION
Before:

```
johnkerl@ip-192-168-1-183[prod][][~]$ pyttt
tiledbsc.__version__       0.1.11.dev4
tiledb.cloud.__version__   0.7.45
tiledb.__version__         0.17.2
core version               2.11.1
>>> tiledb.array_fragments('krasnow/X/data', include_mbrs=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/johnkerl/git/TileDB-Inc/TileDB-Py/tiledb/highlevel.py", line 141, in array_fragments
    return tiledb.FragmentInfoList(uri, include_mbrs, ctx)
  File "/Users/johnkerl/git/TileDB-Inc/TileDB-Py/tiledb/fragment.py", line 103, in __init__
    schema = tiledb.ArraySchema.load(array_uri, ctx=ctx)
  File "tiledb/libtiledb.pyx", line 2882, in tiledb.libtiledb.ArraySchema.load
  File "tiledb/libtiledb.pyx", line 575, in tiledb.libtiledb._raise_ctx_err
  File "tiledb/libtiledb.pyx", line 560, in tiledb.libtiledb._raise_tiledb_error
tiledb.cc.TileDBError: [TileDB::ArrayDirectory] Error: Cannot open array; Array does not exist.
```

After:

```
johnkerl@ip-192-168-1-183[prod][][t]$ pyttt
tiledbsc.__version__       0.1.11.dev4
tiledb.cloud.__version__   0.7.45
tiledb.__version__         0.17.3.dev3
core version               2.11.1
>>> tiledb.array_fragments('krasnow/X/data', include_mbrs=True)
{'array_schema_name': ('__1661438934847_1661438934847_d356a3c06f544cdf9f1f0eaefa3958d7',
                       '__1661438934847_1661438934847_d356a3c06f544cdf9f1f0eaefa3958d7',
                       '__1661438934847_1661438934847_d356a3c06f544cdf9f1f0eaefa3958d7',
                       '__1661438934847_1661438934847_d356a3c06f544cdf9f1f0eaefa3958d7',
                       '__1661438934847_1661438934847_d356a3c06f544cdf9f1f0eaefa3958d7',
                       '__1661438934847_1661438934847_d356a3c06f544cdf9f1f0eaefa3958d7',
                       '__1661438934847_1661438934847_d356a3c06f544cdf9f1f0eaefa3958d7'),
 'array_uri': 'krasnow/X/data',
 'cell_num': (20003185,
              20001608,
              20002006,
              20002381,
              20000543,
              20001338,
              5914122),
 'has_consolidated_metadata': (False, False, False, False, False, False, False),
 'mbrs': (((('P1_1_AAACCTGAGCGATAGC', 'P1_1_AAGCCGCTCATGTAGC'),
            ('ENSG00000000003', 'ENSG00000288722')),
           (('P1_1_AAGCCGCTCATGTAGC', 'P1_1_ACATGGTTCATTCACT'),
            ('ENSG00000000419', 'ENSG00000288722')),
           (('P1_1_ACATGGTTCATTCACT', 'P1_1_ACTGAACGTCTTCAAG'),
            ('ENSG00000000003', 'ENSG00000288722')),
           (('P1_1_ACTGAACGTCTTCAAG', 'P1_1_AGCCTAAGTATAATGG'),
            ('ENSG00000000003', 'ENSG00000288722')),
 ...
 ...
 ...
 'sparse': (True, True, True, True, True, True, True),
 'timestamp_range': ((1661438956374, 1661438956374),
                     (1661438979717, 1661438979717),
                     (1661439003148, 1661439003148),
                     (1661439025987, 1661439025987),
                     (1661439049095, 1661439049095),
                     (1661439070936, 1661439070936),
                     (1661439079595, 1661439079595)),
 'to_vacuum': (),
 'unconsolidated_metadata_num': 7,
 'uri': ('file:///Users/johnkerl/s/t/krasnow/X/data/__fragments/__1661438956374_1661438956374_c44825c94b614732ad8c2cac56cd76e3_15',
         'file:///Users/johnkerl/s/t/krasnow/X/data/__fragments/__1661438979717_1661438979717_c90c9e03f0ce4198868dea0404c8883e_15',
         'file:///Users/johnkerl/s/t/krasnow/X/data/__fragments/__1661439003148_1661439003148_2671c8679e2d4739b94853632b245587_15',
         'file:///Users/johnkerl/s/t/krasnow/X/data/__fragments/__1661439025987_1661439025987_40f314c0367447939b297d8bd704cfbc_15',
         'file:///Users/johnkerl/s/t/krasnow/X/data/__fragments/__1661439049095_1661439049095_89d8646f5ee344d7b6ff7dd5ca1c7efb_15',
         'file:///Users/johnkerl/s/t/krasnow/X/data/__fragments/__1661439070936_1661439070936_9677236053bd4796a51907d114f44a07_15',
         'file:///Users/johnkerl/s/t/krasnow/X/data/__fragments/__1661439079595_1661439079595_08df3cfe4a0c4565b9f4d2875ba302e2_15'),
 'version': (15, 15, 15, 15, 15, 15, 15)}
```
