### PR TITLE
[2.12] Add Support For `Array.delete_fragments`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## API Changes
 * Add support for `XORFilter` [#1294](https://github.com/TileDB-Inc/TileDB-Py/pull/1294)
+* Addition of `Array.delete_fragments`; deprecate `tiledb.delete_fragments` [#1329](https://github.com/TileDB-Inc/TileDB-Py/pull/1329)
 
 ## Bug Fixes
 * Correct writing empty/null strings to array. `tiledb.main.array_to_buffer` needs to resize data buffer at the end of `convert_unicode`; otherwise, last cell will be store with trailing nulls chars [#1339](https://github.com/TileDB-Inc/TileDB-Py/pull/1339)

--- a/tiledb/fragment.py
+++ b/tiledb/fragment.py
@@ -135,8 +135,10 @@ class FragmentInfoList:
         warnings.warn(
             "FragmentInfoList.non_empty_domain is deprecated; "
             "please use FragmentInfoList.nonempty_domain",
+            "It is slated for removal in 0.19.0.",
             DeprecationWarning,
         )
+        assert tiledb.version() < (0, 19, 0)
         return self.nonempty_domain
 
     @property
@@ -144,8 +146,10 @@ class FragmentInfoList:
         warnings.warn(
             "FragmentInfoList.to_vacuum_num is deprecated; "
             "please use len(FragmentInfoList.to_vacuum)",
+            "It is slated for removal in 0.19.0.",
             DeprecationWarning,
         )
+        assert tiledb.version() < (0, 19, 0)
         return len(self.to_vacuum)
 
     @property
@@ -153,8 +157,10 @@ class FragmentInfoList:
         warnings.warn(
             "FragmentInfoList.to_vacuum_uri is deprecated; "
             "please use FragmentInfoList.to_vacuum",
+            "It is slated for removal in 0.19.0.",
             DeprecationWarning,
         )
+        assert tiledb.version() < (0, 19, 0)
         return self.to_vacuum
 
     @property
@@ -162,8 +168,10 @@ class FragmentInfoList:
         warnings.warn(
             "FragmentInfoList.dense is deprecated; "
             "please use FragmentInfoList.sparse",
+            "It is slated for removal in 0.19.0.",
             DeprecationWarning,
         )
+        assert tiledb.version() < (0, 19, 0)
         return list(~np.array(self.sparse))
 
     def __getattr__(self, name):
@@ -305,35 +313,43 @@ class FragmentInfo:
     def non_empty_domain(self):
         warnings.warn(
             "FragmentInfo.non_empty_domain is deprecated; "
-            "please use FragmentInfo.nonempty_domain",
+            "please use FragmentInfo.nonempty_domain. ",
+            "It is slated for removal in 0.19.0.",
             DeprecationWarning,
         )
+        assert tiledb.version() < (0, 19, 0)
         return self.nonempty_domain
 
     @property
     def to_vacuum_num(self):
         warnings.warn(
             "FragmentInfo.to_vacuum_num is deprecated; "
-            "please use len(FragmentInfoList.to_vacuum)",
+            "please use len(FragmentInfoList.to_vacuum).",
+            "It is slated for removal in 0.19.0.",
             DeprecationWarning,
         )
+        assert tiledb.version() < (0, 19, 0)
         return len(self._frags.to_vacuum)
 
     @property
     def to_vacuum_uri(self):
         warnings.warn(
             "FragmentInfo.to_vacuum_uri is deprecated; "
-            "please use FragmentInfoList.to_vacuum",
+            "please use FragmentInfoList.to_vacuum.",
+            "It is slated for removal in 0.19.0.",
             DeprecationWarning,
         )
+        assert tiledb.version() < (0, 19, 0)
         return self._frags.to_vacuum
 
     @property
     def to_vacuum_uri(self):
         warnings.warn(
             "FragmentInfo.dense is deprecated; please use FragmentInfo.sparse",
+            "It is slated for removal in 0.19.0.",
             DeprecationWarning,
         )
+        assert tiledb.version() < (0, 19, 0)
         return not self._frags.sparse
 
 
@@ -345,8 +361,11 @@ def FragmentsInfo(array_uri, ctx=None):
     """
 
     warnings.warn(
-        "FragmentsInfo is deprecated; please use FragmentInfoList", DeprecationWarning
+        "FragmentsInfo is deprecated; please use FragmentInfoList. "
+        "It is slated for removal in 0.19.0.",
+        DeprecationWarning,
     )
+    assert tiledb.version() < (0, 19, 0)
 
     if ctx is None:
         ctx = tiledb.default_ctx()
@@ -370,6 +389,13 @@ def delete_fragments(
     :param dry_run: (optional) Preview fragments to be deleted without
         running (default: False)
     """
+    warnings.warn(
+        "tiledb.delete_fragments is deprecated in lieu of Array.delete_fragments. "
+        "It is slated for removal in 0.19.0.",
+        DeprecationWarning,
+    )
+    assert tiledb.version() < (0, 19, 0)
+
     if not isinstance(timestamp_range, tuple) and len(timestamp_range) != 2:
         raise TypeError(
             "'timestamp_range' argument expects tuple(start: int, end: int)"

--- a/tiledb/highlevel.py
+++ b/tiledb/highlevel.py
@@ -15,7 +15,7 @@ def open(uri, mode="r", key=None, attr=None, config=None, timestamp=None, ctx=No
         See the TileDB `time traveling <https://docs.tiledb.com/main/how-to/arrays/reading-arrays/time-traveling>`_
         documentation for detailed functionality description.
     :param key: encryption key, str or None
-    :param str mode: (default 'r') Open the array object in read 'r' or write 'w' mode
+    :param str mode: (default 'r') Open the array object in read 'r', write 'w', or  modify exclusive 'm' mode
     :param attr: attribute name to select from a multi-attribute array, str or None
     :param config: TileDB config dictionary, dict or None
     :return: open TileDB {Sparse,Dense}Array object

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -42,6 +42,7 @@ cdef extern from "tiledb/tiledb.h":
         TILEDB_ARRAY
 
     ctypedef enum tiledb_query_type_t:
+        TILEDB_MODIFY_EXCLUSIVE
         TILEDB_READ
         TILEDB_WRITE
 
@@ -882,6 +883,13 @@ cdef extern from "tiledb/tiledb.h":
         const void* key_ptr,
         unsigned int key_len,
         tiledb_config_t* config) nogil
+
+    int tiledb_array_delete_fragments(
+        tiledb_ctx_t* ctx,
+        tiledb_array_t* array,
+        const char* uri,
+        uint64_t timestamp_start,
+        uint64_t timestamp_end)
 
     int tiledb_array_get_schema(
         tiledb_ctx_t* ctx,

--- a/tiledb/tests/test_fragments.py
+++ b/tiledb/tests/test_fragments.py
@@ -654,7 +654,10 @@ class DeleteFragmentsTest(DiskTestCase):
         assert len(frags) == 10
         assert frags.timestamp_range == ts
 
-        tiledb.delete_fragments(path, (3, 6))
+        with pytest.warns(
+            DeprecationWarning, match="tiledb.delete_fragments is deprecated"
+        ):
+            tiledb.delete_fragments(path, (3, 6))
         frags = tiledb.array_fragments(path)
         assert len(frags) == 6
         assert frags.timestamp_range == ts[:2] + ts[6:]
@@ -690,7 +693,10 @@ class DeleteFragmentsTest(DiskTestCase):
             assert_array_equal(A[:]["a1"], ts2_data)
             assert_array_equal(A[:]["a2"], ts2_data)
 
-        tiledb.delete_fragments(path, (2, 2))
+        with pytest.warns(
+            DeprecationWarning, match="tiledb.delete_fragments is deprecated"
+        ):
+            tiledb.delete_fragments(path, (2, 2))
 
         frags = tiledb.array_fragments(path)
         assert len(frags) == 1

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -5,6 +5,7 @@ import warnings
 
 import tiledb.cc as lt
 from .ctx import default_ctx
+from .version import version_tuple as tiledbpy_version
 
 if TYPE_CHECKING:
     from .libtiledb import Ctx, Config
@@ -83,9 +84,10 @@ class VFS(lt.VFS):
         if isinstance(file, FileIO):
             warnings.warn(
                 f"`tiledb.VFS().open` now returns a a FileIO object. Use "
-                "`FileIO.close`.",
+                "`FileIO.close`. It is slated for removal in 0.19.0.",
                 DeprecationWarning,
             )
+            assert tiledbpy_version < (0, 19, 0)
         file.close()
         return file
 
@@ -101,9 +103,10 @@ class VFS(lt.VFS):
         if isinstance(file, FileIO):
             warnings.warn(
                 f"`tiledb.VFS().open` now returns a a FileIO object. Use "
-                "`FileIO.write`.",
+                "`FileIO.write`. It is slated for removal in 0.19.0.",
                 DeprecationWarning,
             )
+            assert tiledbpy_version < (0, 19, 0)
         if isinstance(buff, str):
             buff = buff.encode()
         file.write(buff)
@@ -122,9 +125,11 @@ class VFS(lt.VFS):
         if isinstance(file, FileIO):
             warnings.warn(
                 f"`tiledb.VFS().open` now returns a a FileIO object. Use "
-                "`FileIO.seek` and `FileIO.read`.",
+                "`FileIO.seek` and `FileIO.read`. It is slated for removal "
+                "in 0.19.0.",
                 DeprecationWarning,
             )
+            assert tiledbpy_version < (0, 19, 0)
             return file.read(nbytes)
 
         if nbytes == 0:


### PR DESCRIPTION
Example usage:
```
with tiledb.open(path, "m") as A:
    A.delete_fragments(3, 6)
```