### PR TITLE
Do Not Require Attribute in Query Condition To Be Passed to Query

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# In Progress
+
+## API Changes
+* Attributes in query conditions no longer need to be passed to `Array.query`'s `attr` arg [#1333](https://github.com/TileDB-Inc/TileDB-Py/pull/1333)
+
 # TileDB-Py 0.17.4 Release Notes
 
 ## TileDB Embedded updates:

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -711,7 +711,7 @@ public:
       py::object init_pyqc = attr_cond.attr("init_query_condition");
 
       try {
-        init_pyqc(pyschema_, attrs_);
+        attrs_ = init_pyqc(pyschema_, attrs_).cast<std::vector<std::string>>();
       } catch (tiledb::TileDBError &e) {
         TPY_ERROR_LOC(e.what());
       } catch (py::error_already_set &e) {

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -321,10 +321,6 @@ class QueryConditionTree(ast.NodeVisitor):
 
         if att not in self.query_attrs:
             self.query_attrs.append(att)
-        #     raise tiledb.TileDBError(
-        #         f"Attribute `{att}` given to filter in query's `attr_cond` "
-        #         "arg but not found in `attr` arg."
-        #     )
 
         return att
 

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -135,6 +135,8 @@ class QueryCondition:
                 "be made up of one or more Boolean expressions."
             )
 
+        return query_attrs
+
 
 @dataclass
 class QueryConditionTree(ast.NodeVisitor):
@@ -318,10 +320,11 @@ class QueryConditionTree(ast.NodeVisitor):
             raise tiledb.TileDBError(f"Attribute `{att}` not found in schema.")
 
         if att not in self.query_attrs:
-            raise tiledb.TileDBError(
-                f"Attribute `{att}` given to filter in query's `attr_cond` "
-                "arg but not found in `attr` arg."
-            )
+            self.query_attrs.append(att)
+        #     raise tiledb.TileDBError(
+        #         f"Attribute `{att}` given to filter in query's `attr_cond` "
+        #         "arg but not found in `attr` arg."
+        #     )
 
         return att
 

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -1,6 +1,7 @@
 import pytest
 
 import numpy as np
+from numpy.testing import assert_array_equal
 import string
 
 import tiledb
@@ -665,3 +666,17 @@ class QueryConditionTest(DiskTestCase):
             qc = tiledb.QueryCondition("myint > 10")
             result = A.query(attr_cond=qc, attrs=["myint"])[:]
             assert all(result["myint"] > 10)
+
+    def test_do_not_return_queried_attr(self):
+        with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
+            qc = tiledb.QueryCondition("U < 3")
+
+            i_result = A.query(attr_cond=qc, attrs=["I", "U"])[:]
+            assert "I" in i_result.keys()
+            assert "U" in i_result.keys()
+            assert all(i_result["U"] < 5)
+
+            u_result = A.query(attr_cond=qc, attrs=["I"])[:]
+            assert "I" in u_result.keys()
+            assert "U" not in u_result.keys()
+            assert_array_equal(i_result["I"], u_result["I"])

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -307,10 +307,6 @@ class QueryConditionTest(DiskTestCase):
                 qc = tiledb.QueryCondition("U < 'one'")
                 A.query(attr_cond=qc, attrs=["U"])[:]
 
-            with self.assertRaises(tiledb.TileDBError):
-                qc = tiledb.QueryCondition("U < 1")
-                A.query(attr_cond=qc, attrs=["D"])[:]
-
     def test_check_attrs_dense(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=False)) as A:
             mask = A.attr("U").fill
@@ -330,10 +326,6 @@ class QueryConditionTest(DiskTestCase):
             with self.assertRaises(tiledb.TileDBError):
                 qc = tiledb.QueryCondition("U < 'one'")
                 A.query(attr_cond=qc, attrs=["U"])[:]
-
-            with self.assertRaises(tiledb.TileDBError):
-                qc = tiledb.QueryCondition("U < 1")
-                A.query(attr_cond=qc, attrs=["D"])[:]
 
     @pytest.mark.parametrize("sparse", [True, False])
     def test_error_when_using_dim(self, sparse):


### PR DESCRIPTION
For example,

```
qc = tiledb.QueryCondition("U < 3")
u_result = A.query(attr_cond=qc, attrs=["I"])[:]
```

The query condition is applied to `U` but we no longer have to pass `attrs=["U"]`.