### PR TITLE
Permit true-ASCII attributes in non-from-pandas dataframes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # In Progress
 
 ## API Changes
+* Permit true-ASCII attributes in non-from-pandas dataframes [#1337](https://github.com/TileDB-Inc/TileDB-Py/pull/1337)
 * Addition of `Array.upgrade_version` to upgrade array to latest version [#1334](https://github.com/TileDB-Inc/TileDB-Py/pull/1334)
 * Attributes in query conditions no longer need to be passed to `Array.query`'s `attr` arg [#1333](https://github.com/TileDB-Inc/TileDB-Py/pull/1333)
 

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1534,7 +1534,8 @@ cdef class Attr(object):
         if isinstance(dtype, str) and dtype == "ascii":
             tiledb_dtype = TILEDB_STRING_ASCII
             ncells = TILEDB_VAR_NUM
-            var = True
+            if var is None:
+                var = True
         else:
             _dtype = np.dtype(dtype)
             tiledb_dtype, ncells = array_type_ncells(_dtype)

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1534,6 +1534,7 @@ cdef class Attr(object):
         if isinstance(dtype, str) and dtype == "ascii":
             tiledb_dtype = TILEDB_STRING_ASCII
             ncells = TILEDB_VAR_NUM
+            var = True
         else:
             _dtype = np.dtype(dtype)
             tiledb_dtype, ncells = array_type_ncells(_dtype)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -526,7 +526,15 @@ class AttributeTest(DiskTestCase):
         dom = tiledb.Domain(
             tiledb.Dim(name="d", domain=(1, 4), tile=1, dtype=np.uint32)
         )
-        attrs = [tiledb.Attr(name="A", dtype="ascii", var=True)]
+
+        with pytest.raises(TypeError) as exc_info:
+            tiledb.Attr(name="A", dtype="ascii", var=False)
+        assert (
+            str(exc_info.value) == "dtype is not compatible with var-length attribute"
+        )
+
+        attrs = [tiledb.Attr(name="A", dtype="ascii")]
+
         schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=sparse)
         tiledb.Array.create(path, schema)
 
@@ -547,6 +555,7 @@ class AttributeTest(DiskTestCase):
             assert A.schema.nattr == 1
             A.schema.dump()
             assert_captured(capfd, "Type: STRING_ASCII")
+            assert A.schema.attr("A").isvar
             assert A.schema.attr("A").dtype == np.bytes_
             assert A.schema.attr("A").isascii
             assert_array_equal(A[:]["A"], np.asarray(ascii_data, dtype=np.bytes_))


### PR DESCRIPTION
Context:

* Forward-porting https://github.com/single-cell-data/TileDB-SOMA/pull/273 from the `main-old` branch of `tiledbsoma-py` to the `main` branch.
* On `main-old` all the dataframes are written using `from_pandas`: e.g. https://github.com/single-cell-data/TileDB-SOMA/blob/0.1.12/apis/python/src/tiledbsoma/annotation_dataframe.py#L411-L425
* On `main` dataframes can be created that way, or from Arrow as at https://github.com/single-cell-data/TileDB-SOMA/blob/53af1a7a26dd241013102e9ac5b7db9e6a128393/apis/python/src/tiledbsoma/soma_dataframe.py#L92-L108
* When I use `dtype="ascii"` as on https://github.com/single-cell-data/TileDB-SOMA/pull/273, but in this non-from-pandas context (see https://github.com/single-cell-data/TileDB-SOMA/pull/359), I get
```
#!/usr/bin/env python

import tiledbsoma as t
import pyarrow as pa
import os, shutil

uri = 'foo'
if os.path.exists(uri):
    shutil.rmtree(uri)

sdf = t.SOMADataFrame(uri)
sdf.create(pa.schema([("A", pa.int32()), ("B", pa.string())]))
```

giving me

```
Traceback (most recent call last):
  File "/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/./foo.py", line 12, in <module>
    sdf.create(pa.schema([("A", pa.int32()), ("B", pa.string())]))
  File "/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/soma_dataframe.py", line 53, in create
    self._create_empty(schema)
  File "/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/soma_dataframe.py", line 86, in _create_empty
    attrs = [
  File "/Users/johnkerl/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/soma_dataframe.py", line 87, in <listcomp>
    tiledb.Attr(
  File "tiledb/libtiledb.pyx", line 1574, in tiledb.libtiledb.Attr.__init__
TypeError: dtype is not compatible with var-length attribute
```

However, with this mod in place, the array-create succeeds as intended.