### PR TITLE
`tiledb.main.array_to_buffer` Correct Data Buffer With Empty Strings

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # In Progress
 
 ## Bug Fixes
-* Correct writing empty/null strings to array. `tiledb.main.array_to_buffer` needs to resize data buffer at the end of `convert_unicode`; otherwise, last cell will be store with trailing nulls chars []()
+* Correct writing empty/null strings to array. `tiledb.main.array_to_buffer` needs to resize data buffer at the end of `convert_unicode`; otherwise, last cell will be store with trailing nulls chars [#1339](https://github.com/TileDB-Inc/TileDB-Py/pull/1339)
 
 ## API Changes
 * Addition of `Array.upgrade_version` to upgrade array to latest version [#1334](https://github.com/TileDB-Inc/TileDB-Py/pull/1334)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # In Progress
 
+## Bug Fixes
+* Correct writing empty/null strings to array. `tiledb.main.array_to_buffer` needs to resize data buffer at the end of `convert_unicode`; otherwise, last cell will be store with trailing nulls chars []()
+
 ## API Changes
 * Addition of `Array.upgrade_version` to upgrade array to latest version [#1334](https://github.com/TileDB-Inc/TileDB-Py/pull/1334)
 * Attributes in query conditions no longer need to be passed to `Array.query`'s `attr` arg [#1333](https://github.com/TileDB-Inc/TileDB-Py/pull/1333)

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -147,6 +147,8 @@ private:
       output_p += sz;
       idx++;
     }
+
+    data_buf_->resize(data_nbytes_);
   }
 
   void convert_bytes() {

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -1847,6 +1847,21 @@ class DenseArrayTest(DiskTestCase):
 
         T.close()
 
+    def test_data_begins_with_null_chars(self):
+        path = self.path("test_data_begins_with_null_chars")
+        data = np.array(["", "", "", "a", "", "", "", "", "", "b"], dtype=np.unicode_)
+
+        dom = tiledb.Domain(tiledb.Dim(domain=(1, len(data)), tile=len(data)))
+        att = tiledb.Attr(dtype=np.unicode_, var=True)
+        schema = tiledb.ArraySchema(dom, (att,))
+        tiledb.Array.create(path, schema)
+
+        with tiledb.open(path, mode="w") as T:
+            T[:] = data
+
+        with tiledb.open(path, mode="r") as T:
+            assert_array_equal(data, T[:])
+
 
 class TestVarlen(DiskTestCase):
     def test_varlen_write_bytes(self):


### PR DESCRIPTION
Previously, the following NumPy array would yield the data and offset buffers below.

```
>>> tiledb.main.array_to_buffer(np.array(["", "", "", "a", "", "", "", "", "", "b"], dtype=np.unicode_), True, False)
(array([97, 98,  0,  0,  0,  0,  0,  0,  0,  0], dtype=uint8), array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1], dtype=uint64))
```

The data buffer needs to be resized such that it does not containing the trailing NULLs. Otherwise, when we read the data back, we see the last element padded with trailing NULLs.

This PR now correctly yields the following data buffer.
```
>>> tiledb.main.array_to_buffer(np.array(["", "", "", "a", "", "", "", "", "", "b"], dtype=np.unicode_), True, False)
(array([97, 98], dtype=uint8), array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1], dtype=uint64)
```