### PR TITLE
Add Support For `QueryCondition` on Sparse Dimensions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,12 @@
 ## Improvements
 * Addition of Utility Function `get_last_ctx_err_str()` for C API [#1351](https://github.com/TileDB-Inc/TileDB-Py/pull/1351)
 
+## API Changes
+* Changes to query conditions [#1341](https://github.com/TileDB-Inc/TileDB-Py/pull/1341)
+    * Support query conditions on sparse dimensions
+    * Deprecate `attr_cond` in favor of `cond`
+    * Deprecate passing `tiledb.QueryCondition` to `cond` in favor of passing string directly
+
 # TileDB-Py 0.17.5 Release Notes
 
 ## Improvements

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from pybind11.setup_helpers import Pybind11Extension
 ### DO NOT USE ON CI
 
 # Target branch: Note that this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.11.3"
+TILEDB_VERSION = "2.12.0"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -703,22 +703,19 @@ public:
   }
 #endif
 
-  void set_attr_cond(py::object attr_cond) {
-    if (!attr_cond.is(py::none())) {
-      py::object init_pyqc = attr_cond.attr("init_query_condition");
+  void set_cond(py::object cond) {
+    py::object init_pyqc = cond.attr("init_query_condition");
 
-      try {
-        attrs_ = init_pyqc(pyschema_, attrs_).cast<std::vector<std::string>>();
-      } catch (tiledb::TileDBError &e) {
-        TPY_ERROR_LOC(e.what());
-      } catch (py::error_already_set &e) {
-        TPY_ERROR_LOC(e.what());
-      }
-
-      auto pyqc = (attr_cond.attr("c_obj")).cast<PyQueryCondition>();
-      auto qc = pyqc.ptr().get();
-      query_->set_condition(*qc);
+    try {
+      attrs_ = init_pyqc(pyschema_, attrs_).cast<std::vector<std::string>>();
+    } catch (tiledb::TileDBError &e) {
+      TPY_ERROR_LOC(e.what());
+    } catch (py::error_already_set &e) {
+      TPY_ERROR_LOC(e.what());
     }
+    auto pyqc = (cond.attr("c_obj")).cast<PyQueryCondition>();
+    auto qc = pyqc.ptr().get();
+    query_->set_condition(*qc);
   }
 
   bool is_dimension(std::string name) { return domain_->has_dimension(name); }
@@ -1605,7 +1602,7 @@ void init_core(py::module &m) {
           .def("set_ranges_bulk", &PyQuery::set_ranges_bulk)
 #endif
           .def("set_subarray", &PyQuery::set_subarray)
-          .def("set_attr_cond", &PyQuery::set_attr_cond)
+          .def("set_cond", &PyQuery::set_cond)
 #if defined(TILEDB_SERIALIZATION)
           .def("set_serialized_query", &PyQuery::set_serialized_query)
 #endif

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1257,15 +1257,15 @@ cdef class Array(object):
     cdef _ndarray_is_varlen(self, np.ndarray array)
 
 cdef class SparseArrayImpl(Array):
-    cdef _read_sparse_subarray(self, list subarray, list attr_names, object attr_cond, tiledb_layout_t layout)
+    cdef _read_sparse_subarray(self, list subarray, list attr_names, object cond, tiledb_layout_t layout)
 
 cdef class DenseArrayImpl(Array):
-    cdef _read_dense_subarray(self, list subarray, list attr_names, object attr_cond, tiledb_layout_t layout, bint include_coords)
+    cdef _read_dense_subarray(self, list subarray, list attr_names, object cond, tiledb_layout_t layout, bint include_coords)
 
 cdef class Query(object):
     cdef Array array
     cdef object attrs
-    cdef object attr_cond
+    cdef object cond
     cdef object dims
     cdef object order
     cdef object coords

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -867,7 +867,7 @@ class TestMultiRange(DiskTestCase):
             A[np.arange(10)] = {"a": a, "b": b}
 
         with tiledb.open(uri, mode="r") as A:
-            q = A.query(attr_cond=tiledb.QueryCondition("a >= 5"), attrs=["a"])
+            q = A.query(cond="a >= 5", attrs=["a"])
             assert {"a", "dim"} == q.multi_index[:].keys() == q[:].keys()
             assert_array_equal(q.multi_index[:]["a"], q[:]["a"])
             assert_array_equal(q.multi_index[:]["a"], q.df[:]["a"])


### PR DESCRIPTION
* Deprecate `attr_cond` in favor of `cond`
* Allow `cond` to take in a string directly instead of using `tiledb.QueryCondition`
* Add `dim()` cast that behaves similarly to `attr()` but specifically for dimensions
* Add tests for overlapping ranges