### PR TITLE
Addition of Utility Function `get_last_ctx_err_str()` for C API

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,9 @@
 ## Bug Fixes
 * Correct writing empty/null strings to array. `tiledb.main.array_to_buffer` needs to resize data buffer at the end of `convert_unicode`; otherwise, last cell will be store with trailing nulls chars [#1339](https://github.com/TileDB-Inc/TileDB-Py/pull/1339)
 
+## Improvements
+* Addition of Utility Function `get_last_ctx_err_str()` for C API [#1351](https://github.com/TileDB-Inc/TileDB-Py/pull/1351)
+
 # TileDB-Py 0.17.5 Release Notes
 
 ## Improvements

--- a/setup.py
+++ b/setup.py
@@ -652,6 +652,7 @@ TILEDB_MAIN_SOURCES = [
     "tiledb/npbuffer.cc",
     "tiledb/fragment.cc",
     "tiledb/schema_evolution.cc",
+    "tiledb/util.cc",
     "tiledb/tests/test_metadata.cc",
     # TODO currently included in core.cc due to dependency.
     #      need to un-comment after refactor.

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -15,9 +15,6 @@
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
 
-#define TILEDB_DEPRECATED
-#define TILEDB_DEPRECATED_EXPORT
-
 #include <tiledb/tiledb.h>              // C
 #include <tiledb/tiledb>                // C++
 #include <tiledb/tiledb_experimental.h> // C

--- a/tiledb/fragment.cc
+++ b/tiledb/fragment.cc
@@ -6,9 +6,6 @@
 
 #include <exception>
 
-#define TILEDB_DEPRECATED
-#define TILEDB_DEPRECATED_EXPORT
-
 #include "util.h"
 #include <tiledb/tiledb> // C++
 

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -15,9 +15,6 @@
 //#include "debug.cc"
 #endif
 
-#define TILEDB_DEPRECATED
-#define TILEDB_DEPRECATED_EXPORT
-
 #include <tiledb/tiledb> // C++
 
 // anonymous namespace for helper functions

--- a/tiledb/query_condition.cc
+++ b/tiledb/query_condition.cc
@@ -3,9 +3,6 @@
 
 #include <exception>
 
-#define TILEDB_DEPRECATED
-#define TILEDB_DEPRECATED_EXPORT
-
 #include "util.h"
 #include <tiledb/tiledb> // C++
 

--- a/tiledb/schema_evolution.cc
+++ b/tiledb/schema_evolution.cc
@@ -16,37 +16,6 @@ typedef struct {
 
 using ArraySchemaEvolution = PyArraySchemaEvolution;
 
-void _throw_tiledb_error(tiledb_error_t *err_ptr) {
-  const char *err_msg_ptr = NULL;
-  int ret = tiledb_error_message(err_ptr, &err_msg_ptr);
-  if (ret != TILEDB_OK) {
-    tiledb_error_free(&err_ptr);
-    if (ret == TILEDB_OOM) {
-      throw std::bad_alloc();
-    }
-    TPY_ERROR_LOC("error retrieving error message");
-  }
-
-  TPY_ERROR_LOC(std::string(err_msg_ptr));
-}
-
-void _throw_ctx_err(tiledb_ctx_t *ctx_ptr, int rc) {
-  if (rc == TILEDB_OK)
-    return;
-  if (rc == TILEDB_OOM)
-    throw std::bad_alloc();
-
-  tiledb_error_t *err_ptr = NULL;
-  int ret = tiledb_ctx_get_last_error(ctx_ptr, &err_ptr);
-  if (ret != TILEDB_OK) {
-    tiledb_error_free(&err_ptr);
-    if (ret == TILEDB_OOM)
-      throw std::bad_alloc();
-    TPY_ERROR_LOC("error retrieving error object from ctx");
-  }
-  _throw_tiledb_error(err_ptr);
-}
-
 void init_schema_evolution(py::module &m) {
   py::class_<ArraySchemaEvolution>(m, "ArraySchemaEvolution")
       .def(py::init([](py::object ctx_py) {
@@ -57,7 +26,7 @@ void init_schema_evolution(py::module &m) {
         tiledb_array_schema_evolution_t *evol_p;
         int rc = tiledb_array_schema_evolution_alloc(ctx_c, &evol_p);
         if (rc != TILEDB_OK) {
-          _throw_ctx_err(ctx_c, rc);
+          TPY_ERROR_LOC(get_last_ctx_err_str(ctx_c, rc));
         }
 
         return new PyArraySchemaEvolution({ctx_c, evol_p});
@@ -72,7 +41,7 @@ void init_schema_evolution(py::module &m) {
              int rc = tiledb_array_schema_evolution_add_attribute(
                  inst.ctx_, inst.evol_, attr_c);
              if (rc != TILEDB_OK) {
-               _throw_ctx_err(inst.ctx_, rc);
+               TPY_ERROR_LOC(get_last_ctx_err_str(inst.ctx_, rc));
              }
            })
       .def("drop_attribute",
@@ -80,13 +49,13 @@ void init_schema_evolution(py::module &m) {
              int rc = tiledb_array_schema_evolution_drop_attribute(
                  inst.ctx_, inst.evol_, attr_name.c_str());
              if (rc != TILEDB_OK) {
-               _throw_ctx_err(inst.ctx_, rc);
+               TPY_ERROR_LOC(get_last_ctx_err_str(inst.ctx_, rc));
              }
            })
       .def("array_evolve", [](ArraySchemaEvolution &inst, std::string uri) {
         int rc = tiledb_array_evolve(inst.ctx_, uri.c_str(), inst.evol_);
         if (rc != TILEDB_OK) {
-          _throw_ctx_err(inst.ctx_, rc);
+          TPY_ERROR_LOC(get_last_ctx_err_str(inst.ctx_, rc));
         }
       });
 }

--- a/tiledb/serialization.cc
+++ b/tiledb/serialization.cc
@@ -6,9 +6,6 @@
 
 #include <exception>
 
-#define TILEDB_DEPRECATED
-#define TILEDB_DEPRECATED_EXPORT
-
 #include "util.h"
 #include <tiledb/tiledb>                 // C++
 #include <tiledb/tiledb_serialization.h> // C

--- a/tiledb/tests/test_schema_evolution.py
+++ b/tiledb/tests/test_schema_evolution.py
@@ -40,6 +40,7 @@ def test_schema_evolution(tmp_path):
     with pytest.raises(tiledb.TileDBError) as excinfo:
         se.add_attribute(newattr)
     assert "Input attribute name is already there" in str(excinfo.value)
+    assert "tiledb/schema_evolution.cc" in str(excinfo.value)
 
     se.array_evolve(uri)
 

--- a/tiledb/util.cc
+++ b/tiledb/util.cc
@@ -1,0 +1,34 @@
+#include "util.h"
+
+#include <tiledb/tiledb>
+
+std::string _get_tiledb_err_str(tiledb_error_t *err_ptr) {
+  const char *err_msg_ptr = NULL;
+  int ret = tiledb_error_message(err_ptr, &err_msg_ptr);
+
+  if (ret != TILEDB_OK) {
+    tiledb_error_free(&err_ptr);
+    if (ret == TILEDB_OOM) {
+      throw std::bad_alloc();
+    }
+    return "error retrieving error message";
+  }
+  return std::string(err_msg_ptr);
+}
+
+std::string get_last_ctx_err_str(tiledb_ctx_t *ctx_ptr, int rc) {
+  if (rc == TILEDB_OOM)
+    throw std::bad_alloc();
+
+  tiledb_error_t *err_ptr = NULL;
+  int ret = tiledb_ctx_get_last_error(ctx_ptr, &err_ptr);
+
+  if (ret != TILEDB_OK) {
+    tiledb_error_free(&err_ptr);
+    if (ret == TILEDB_OOM) {
+      throw std::bad_alloc();
+    }
+    return "error retrieving error object from ctx";
+  }
+  return _get_tiledb_err_str(err_ptr);
+}

--- a/tiledb/util.h
+++ b/tiledb/util.h
@@ -1,10 +1,13 @@
 #include <cmath>
+#include <tiledb/tiledb>
 
 #ifndef TILEDB_PY_UTIL_H
 #define TILEDB_PY_UTIL_H
 
 const uint64_t DEFAULT_INIT_BUFFER_BYTES = 1310720 * 8;
 const uint64_t DEFAULT_ALLOC_MAX_BYTES = uint64_t(5 * pow(2, 30));
+
+std::string get_last_ctx_err_str(tiledb_ctx_t *, int);
 
 #define TPY_ERROR_STR(m)                                                       \
   [](auto m) -> std::string {                                     \


### PR DESCRIPTION
* Replaces `throw_tiledb_error()` and `_throw_ctx_err()` that was previously in `schema_evolution.cc`