### PR TITLE
Array and Group Metadata Store Bytes as `TILEDB_BLOB`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,10 +2,12 @@
 
 ## API Changes
 * Add support for `XORFilter` [#1294](https://github.com/TileDB-Inc/TileDB-Py/pull/1294)
+* Array and Group metadata now store bytes as `TILEDB_BLOB` [#1384](https://github.com/TileDB-Inc/TileDB-Py/pull/1384)
+* Addition of `{Array,Group}.metadata.dump()` [#1384](https://github.com/TileDB-Inc/TileDB-Py/pull/1384)
 
 ## Bug Fixes
 * Correct writing empty/null strings to array. `tiledb.main.array_to_buffer` needs to resize data buffer at the end of `convert_unicode`; otherwise, last cell will be store with trailing nulls chars [#1339](https://github.com/TileDB-Inc/TileDB-Py/pull/1339)
-* Revert [#1326](https://github.com/TileDB-Inc/TileDB-Py/pull/1326) due to issues with `Context` lifetime with in multiprocess settings []()
+* Revert [#1326](https://github.com/TileDB-Inc/TileDB-Py/pull/1326) due to issues with `Context` lifetime with in multiprocess settings [#1372](https://github.com/TileDB-Inc/TileDB-Py/pull/1372)
 
 ## Improvements
 * Addition of Utility Function `get_last_ctx_err_str()` for C API [#1351](https://github.com/TileDB-Inc/TileDB-Py/pull/1351)

--- a/tiledb/cc/enum.cc
+++ b/tiledb/cc/enum.cc
@@ -20,21 +20,19 @@ void init_enums(py::module &m) {
   m.def("TILEDB_OFFSET_SIZE", []() { return TILEDB_OFFSET_SIZE; });
   m.def("TILEDB_TIMESTAMP_NOW_MS", []() { return TILEDB_TIMESTAMP_NOW_MS; });
 
-  py::enum_<tiledb_datatype_t>(m, "DataType", py::module_local()) DENUM(INT32)
-      DENUM(INT64) DENUM(FLOAT32) DENUM(FLOAT64) DENUM(CHAR) DENUM(INT8)
-          DENUM(UINT8) DENUM(INT16) DENUM(UINT16) DENUM(UINT32) DENUM(UINT64)
-              DENUM(STRING_ASCII) DENUM(STRING_UTF8) DENUM(STRING_UTF16) DENUM(
-                  STRING_UTF32) DENUM(STRING_UCS2) DENUM(STRING_UCS4) DENUM(ANY)
-                  DENUM(DATETIME_YEAR) DENUM(DATETIME_WEEK) DENUM(DATETIME_DAY)
-                      DENUM(DATETIME_HR) DENUM(DATETIME_MIN) DENUM(DATETIME_SEC)
-                          DENUM(DATETIME_MS) DENUM(DATETIME_US)
-                              DENUM(DATETIME_NS) DENUM(DATETIME_PS)
-                                  DENUM(DATETIME_FS) DENUM(DATETIME_AS)
-                                      DENUM(TIME_HR) DENUM(TIME_MIN)
-                                          DENUM(TIME_SEC) DENUM(TIME_MS)
-                                              DENUM(TIME_US) DENUM(TIME_NS)
-                                                  DENUM(TIME_PS) DENUM(TIME_FS)
-                                                      DENUM(TIME_AS);
+  py::enum_<tiledb_datatype_t>(m, "DataType", py::module_local()) DENUM(
+      INT32) DENUM(INT64) DENUM(FLOAT32) DENUM(FLOAT64) DENUM(CHAR) DENUM(BLOB)
+      DENUM(INT8) DENUM(UINT8) DENUM(INT16) DENUM(UINT16) DENUM(UINT32) DENUM(
+          UINT64) DENUM(STRING_ASCII) DENUM(STRING_UTF8) DENUM(STRING_UTF16)
+          DENUM(STRING_UTF32) DENUM(STRING_UCS2) DENUM(STRING_UCS4) DENUM(ANY)
+              DENUM(DATETIME_YEAR) DENUM(DATETIME_WEEK) DENUM(DATETIME_DAY)
+                  DENUM(DATETIME_HR) DENUM(DATETIME_MIN) DENUM(DATETIME_SEC)
+                      DENUM(DATETIME_MS) DENUM(DATETIME_US) DENUM(DATETIME_NS)
+                          DENUM(DATETIME_PS) DENUM(DATETIME_FS)
+                              DENUM(DATETIME_AS) DENUM(TIME_HR) DENUM(TIME_MIN)
+                                  DENUM(TIME_SEC) DENUM(TIME_MS) DENUM(TIME_US)
+                                      DENUM(TIME_NS) DENUM(TIME_PS)
+                                          DENUM(TIME_FS) DENUM(TIME_AS);
 
   py::enum_<tiledb_array_type_t>(m, "ArrayType") DENUM(DENSE) DENUM(SPARSE);
 

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1142,6 +1142,11 @@ cdef extern from "tiledb/tiledb.h":
         char* path_out,
         unsigned* path_length) nogil
 
+    int tiledb_datatype_to_str(
+        tiledb_datatype_t datatype,
+        const char** datatype_str
+    )
+
 cdef extern from "tiledb/tiledb_experimental.h":
     # Filestore
     int tiledb_filestore_schema_create(


### PR DESCRIPTION
* Addition of `.dump()` functions to output information about metadata