### PR TITLE
Support Query Deletes on Sparse Arrays

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 * Array and Group metadata now store bytes as `TILEDB_BLOB` [#1384](https://github.com/TileDB-Inc/TileDB-Py/pull/1384)
 * Addition of `{Array,Group}.metadata.dump()` [#1384](https://github.com/TileDB-Inc/TileDB-Py/pull/1384)
 * Addition of `Group.is_relative` to check if the URI component of a group member is relative [#1386](https://github.com/TileDB-Inc/TileDB-Py/pull/1386)
+* Addition of query deletes to delete data that satisifies a given query condition [#1309](https://github.com/TileDB-Inc/TileDB-Py/pull/1309)
 
 ## Bug Fixes
 * Correct writing empty/null strings to array. `tiledb.main.array_to_buffer` needs to resize data buffer at the end of `convert_unicode`; otherwise, last cell will be store with trailing nulls chars [#1339](https://github.com/TileDB-Inc/TileDB-Py/pull/1339)
@@ -37,6 +38,7 @@
 
 ## API Changes
 * Addition of `FloatScaleFilter` [#1195](https://github.com/TileDB-Inc/TileDB-Py/pull/1195)
+* Addition of `d` mode for arrays to delete data that satisfies a given query condition [#1309](https://github.com/TileDB-Inc/TileDB-Py/pull/1309)
 
 ## Misc Updates
 * Wheels are minimally supported for macOS 10.15 Catalina [#1275](https://github.com/TileDB-Inc/TileDB-Py/pull/1275)

--- a/tiledb/cc/enum.cc
+++ b/tiledb/cc/enum.cc
@@ -63,7 +63,11 @@ void init_enums(py::module &m) {
       .value("UNINITIALIZED", Query::Status::UNINITIALIZED)
       .export_values();
 
-  py::enum_<tiledb_query_type_t>(m, "QueryType") DENUM(READ) DENUM(WRITE);
+  py::enum_<tiledb_query_type_t>(m, "QueryType")
+      .value("READ", TILEDB_READ)
+      .value("WRITE", TILEDB_WRITE)
+      .value("DELETE", TILEDB_DELETE)
+      .value("MODIFY_EXCLUSIVE", TILEDB_MODIFY_EXCLUSIVE);
 
   py::enum_<tiledb_query_condition_op_t>(m, "QueryConditionOp",
                                          py::module_local()) DENUM(LT) DENUM(LE)

--- a/tiledb/highlevel.py
+++ b/tiledb/highlevel.py
@@ -15,7 +15,7 @@ def open(uri, mode="r", key=None, attr=None, config=None, timestamp=None, ctx=No
         See the TileDB `time traveling <https://docs.tiledb.com/main/how-to/arrays/reading-arrays/time-traveling>`_
         documentation for detailed functionality description.
     :param key: encryption key, str or None
-    :param str mode: (default 'r') Open the array object in read 'r', write 'w', or  modify exclusive 'm' mode
+    :param str mode: (default 'r') Open the array object in read 'r', write 'w',  modify exclusive 'm' mode, or  delete 'd' mode
     :param attr: attribute name to select from a multi-attribute array, str or None
     :param config: TileDB config dictionary, dict or None
     :return: open TileDB {Sparse,Dense}Array object

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -43,6 +43,7 @@ cdef extern from "tiledb/tiledb.h":
 
     ctypedef enum tiledb_query_type_t:
         TILEDB_MODIFY_EXCLUSIVE
+        TILEDB_DELETE
         TILEDB_READ
         TILEDB_WRITE
 

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3883,6 +3883,10 @@ cdef class Query(object):
             print(output)
         else:
             return output
+    
+    def submit(self):
+        """An alias for calling the regular indexer [:]"""
+        return self[:]
 
 
 cdef class DenseArrayImpl(Array):
@@ -4068,11 +4072,11 @@ cdef class DenseArrayImpl(Array):
                 DeprecationWarning,
             )
             cond = attr_cond
-
+        
         return Query(self, attrs=attrs, cond=cond, dims=dims,
-                     coords=coords, order=order, use_arrow=use_arrow,
-                     return_arrow=return_arrow,
-                     return_incomplete=return_incomplete)
+                      coords=coords, order=order, 
+                      use_arrow=use_arrow, return_arrow=return_arrow,
+                      return_incomplete=return_incomplete)
 
     def subarray(self, selection, attrs=None, cond=None, attr_cond=None,
                  coords=False, order=None):
@@ -4886,10 +4890,9 @@ cdef class SparseArrayImpl(Array):
             _coords = True
 
         return Query(self, attrs=attrs, cond=cond, dims=dims,
-                     coords=_coords, index_col=index_col, order=order, 
-                     use_arrow=use_arrow, return_arrow=return_arrow,
-                     return_incomplete=return_incomplete)
-
+                      coords=_coords, index_col=index_col, order=order, 
+                      use_arrow=use_arrow, return_arrow=return_arrow,
+                      return_incomplete=return_incomplete)
 
     def subarray(self, selection, coords=True, attrs=None, cond=None,
                  attr_cond=None, order=None):

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2858,15 +2858,18 @@ cdef ArrayPtr preload_array(uri, mode, key, timestamp, ctx=None):
     cdef tiledb_encryption_type_t key_type = TILEDB_NO_ENCRYPTION
     cdef void* key_ptr = NULL
     cdef unsigned int key_len = 0
+
     # convert python mode string to a query type
-    if mode == 'r':
-        query_type = TILEDB_READ
-    elif mode == 'w':
-        query_type = TILEDB_WRITE
-    elif mode == 'm':
-        query_type = TILEDB_MODIFY_EXCLUSIVE
-    else:
-        raise ValueError("TileDB array mode must be 'r', 'w', or 'm")
+    mode_to_query_type = {
+        "r": TILEDB_READ,
+        "w": TILEDB_WRITE,
+        "m": TILEDB_MODIFY_EXCLUSIVE,
+        "d": TILEDB_DELETE
+    }
+    if mode not in mode_to_query_type:
+        raise ValueError("TileDB array mode must be 'r', 'w', 'm', or 'd'")
+    query_type = mode_to_query_type[mode]
+
     # check the key, and convert the key to bytes
     if key is not None:
         if isinstance(key, str):
@@ -2938,7 +2941,7 @@ cdef class Array(object):
     an Array instance is initialized, the array is opened with the specified mode.
 
     :param str uri: URI of array to open
-    :param str mode: (default 'r') Open the array object in read 'r' or write 'w' mode
+    :param str mode: (default 'r') Open the array object in read 'r', write 'w', or delete 'd' mode
     :param str key: (default None) If not None, encryption key to decrypt the array
     :param tuple timestamp: (default None) If int, open the array at a given TileDB
         timestamp. If tuple, open at the given start and end TileDB timestamps.
@@ -3719,11 +3722,10 @@ cdef class Query(object):
     """
 
     def __init__(self, array, attrs=None, cond=None, dims=None,
-                 coords=False, index_col=True,
-                 order=None, use_arrow=None, return_arrow=False,
-                 return_incomplete=False):
-        if array.mode != 'r':
-            raise ValueError("array mode must be read-only")
+                 coords=False, index_col=True, order=None, 
+                 use_arrow=None, return_arrow=False, return_incomplete=False):
+        if array.mode not in  ('r', 'd'):
+            raise ValueError("array mode must be read or delete mode")
 
         if dims is not None and coords == True:
             raise ValueError("Cannot pass both dims and coords=True to Query")
@@ -4015,6 +4017,7 @@ cdef class DenseArrayImpl(Array):
             then no dimensions are returned, unless coords=True.
         :param coords: if True, return array of coodinate value (default False).
         :param order: 'C', 'F', 'U', or 'G' (row-major, col-major, unordered, TileDB global order)
+        :param mode: "r" to read (default), "d" to delete
         :param use_arrow: if True, return dataframes via PyArrow if applicable.
         :param return_arrow: if True, return results as a PyArrow Table if applicable.
         :param return_incomplete: if True, initialize and return an iterable Query object over the indexed range.
@@ -4048,7 +4051,7 @@ cdef class DenseArrayImpl(Array):
 
         """
         if not self.isopen or self.mode != 'r':
-            raise TileDBError("DenseArray is not opened for reading")
+            raise TileDBError("DenseArray must be opened in read mode")
 
         if attr_cond is not None:
             assert tiledbpy_version < (0, 19, 0)
@@ -4108,7 +4111,7 @@ cdef class DenseArrayImpl(Array):
 
         """
         if not self.isopen or self.mode != 'r':
-            raise TileDBError("DenseArray is not opened for reading")
+            raise TileDBError("DenseArray must be opened in read mode")
 
         if attr_cond is not None:
             assert tiledbpy_version < (0, 19, 0)
@@ -4198,7 +4201,6 @@ cdef class DenseArrayImpl(Array):
                     "use `cond='expression'`.",
                     DeprecationWarning,
                 )
-                q.set_cond(cond)
             else:
                 raise TypeError("`cond` expects type str.")
 
@@ -4828,6 +4830,7 @@ cdef class SparseArrayImpl(Array):
             and only set specified index(es) in the final dataframe, or None.
         :param coords: (deprecated) if True, return array of coordinate value (default False).
         :param order: 'C', 'F', or 'G' (row-major, col-major, tiledb global order)
+        :param mode: "r" to read
         :param use_arrow: if True, return dataframes via PyArrow if applicable.
         :param return_arrow: if True, return results as a PyArrow Table if applicable.
         :return: A proxy Query object that can be used for indexing into the SparseArray
@@ -4856,9 +4859,9 @@ cdef class SparseArrayImpl(Array):
         OrderedDict([('a1', array([1, 2]))])
 
         """
-        if not self.isopen:
-            raise TileDBError("SparseArray is not opened")
-
+        if not self.isopen or self.mode not in  ('r', 'd'):
+            raise TileDBError("SparseArray must be opened in read or delete mode")
+        
         if attr_cond is not None:
             assert tiledbpy_version < (0, 19, 0)
 
@@ -4883,9 +4886,10 @@ cdef class SparseArrayImpl(Array):
             _coords = True
 
         return Query(self, attrs=attrs, cond=cond, dims=dims,
-                     coords=_coords, index_col=index_col, order=order,
+                     coords=_coords, index_col=index_col, order=order, 
                      use_arrow=use_arrow, return_arrow=return_arrow,
                      return_incomplete=return_incomplete)
+
 
     def subarray(self, selection, coords=True, attrs=None, cond=None,
                  attr_cond=None, order=None):
@@ -4929,10 +4933,9 @@ cdef class SparseArrayImpl(Array):
         OrderedDict([('a1', array([1, 2]))])
 
         """
-
-        if not self.isopen or self.mode != 'r':
-            raise TileDBError("SparseArray is not opened for reading")
-
+        if not self.isopen or self.mode not in ('r', 'd'):
+            raise TileDBError("SparseArray is not opened in read or delete mode")
+        
         if attr_cond is not None:
             assert tiledbpy_version < (0, 19, 0)
 
@@ -5016,11 +5019,16 @@ cdef class SparseArrayImpl(Array):
                     "use `cond='expression'`.",
                     DeprecationWarning,
                 )
-                q.set_cond(cond)
             else:
                 raise TypeError("`cond` expects type str.")
-        q.set_ranges([list([x]) for x in subarray])
+        
+        if self.mode == "r":
+            q.set_ranges([list([x]) for x in subarray])
+        
         q.submit()
+
+        if self.mode == 'd':
+            return
 
         cdef object results = OrderedDict()
         results = q.results()

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -170,7 +170,7 @@ class GroupTest(GroupTestCase):
         time.sleep(0.001)
         grp.close()
 
-    def test_group_members(self, capfd):
+    def test_group_members(self):
         grp_path = self.path("test_group_members")
         tiledb.Group.create(grp_path)
 

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 import string
+from numpy.testing import assert_array_equal
 
 import tiledb
 from tiledb.tests.common import DiskTestCase, has_pandas
@@ -674,3 +675,139 @@ class QueryConditionTest(DiskTestCase):
 
             result = A.query(cond="2 <= data < 6 or 5 <= data < 9")[:]
             assert_array_equal(result["data"], A[2:9]["data"])
+
+
+class QueryDeleteTest(DiskTestCase):
+    def test_basic_sparse(self):
+        path = self.path("test_basic_sparse")
+        dom = tiledb.Domain(tiledb.Dim(domain=(1, 10), tile=1, dtype=np.uint32))
+        attrs = [tiledb.Attr("ints", dtype=np.uint32)]
+        schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=True)
+        tiledb.Array.create(path, schema)
+
+        data = np.random.randint(1, 10, 10)
+
+        qc = "ints < 5"
+
+        with tiledb.open(path, "w") as A:
+            A[np.arange(1, 11)] = data
+
+            with pytest.raises(
+                tiledb.TileDBError,
+                match="SparseArray must be opened in read or delete mode",
+            ):
+                A.query(cond=qc)
+
+        with tiledb.open(path, "r") as A:
+            assert_array_equal(data, A[:]["ints"])
+
+        with tiledb.open(path, "d") as A:
+            with pytest.raises(
+                tiledb.TileDBError,
+                match="Cannot initialize deletes; One condition is needed",
+            ):
+                A.query()
+
+            A.query(cond=qc)
+
+        with tiledb.open(path, "r") as A:
+            assert all(A[:]["ints"] >= 5)
+
+    def test_basic_dense(self):
+        path = self.path("test_basic_dense")
+
+        dom = tiledb.Domain(tiledb.Dim(domain=(1, 10), tile=1))
+        attrs = [tiledb.Attr("ints", dtype=np.uint8)]
+        schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=False)
+        tiledb.Array.create(path, schema)
+
+        with tiledb.open(path, "d") as A:
+            with pytest.raises(
+                tiledb.TileDBError,
+                match="DenseArray must be opened in read mode",
+            ):
+                A.query()
+
+    def test_with_fragments(self):
+        path = self.path("test_with_fragments")
+
+        dom = tiledb.Domain(tiledb.Dim(domain=(1, 3), tile=1))
+        attrs = [tiledb.Attr("ints", dtype=np.uint8)]
+        schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=True)
+        tiledb.Array.create(path, schema)
+
+        with tiledb.open(path, "w", timestamp=1) as A:
+            A[1] = 1
+
+        with tiledb.open(path, "w", timestamp=2) as A:
+            A[2] = 2
+
+        with tiledb.open(path, "w", timestamp=3) as A:
+            A[3] = 3
+
+        with tiledb.open(path, "r") as A:
+            assert_array_equal([1, 2, 3], A[:]["ints"])
+
+        with tiledb.open(path, "d", timestamp=3) as A:
+            A.query(cond="ints == 1")
+
+        with tiledb.open(path, "r", timestamp=1) as A:
+            assert_array_equal([1], A[:]["ints"])
+
+        with tiledb.open(path, "r", timestamp=2) as A:
+            assert_array_equal([1, 2], A[:]["ints"])
+
+        with tiledb.open(path, "r", timestamp=3) as A:
+            assert_array_equal([2, 3], A[:]["ints"])
+
+        assert len(tiledb.array_fragments(path)) == 3
+
+        tiledb.consolidate(path)
+        tiledb.vacuum(path)
+
+        assert len(tiledb.array_fragments(path)) == 1
+
+        with tiledb.open(path, "r") as A:
+            assert A.nonempty_domain() == ((1, 3),)
+            assert_array_equal([2, 3], A[:]["ints"])
+
+    def test_purge_deleted_cells(self):
+        path = self.path("test_with_fragments")
+
+        dom = tiledb.Domain(tiledb.Dim(domain=(1, 3), tile=1))
+        attrs = [tiledb.Attr("ints", dtype=np.uint8)]
+        schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=True)
+        tiledb.Array.create(path, schema)
+
+        with tiledb.open(path, "w", timestamp=1) as A:
+            A[1] = 1
+
+        with tiledb.open(path, "w", timestamp=2) as A:
+            A[2] = 2
+
+        with tiledb.open(path, "w", timestamp=3) as A:
+            A[3] = 3
+
+        with tiledb.open(path, "r") as A:
+            assert_array_equal([1, 2, 3], A[:]["ints"])
+
+        with tiledb.open(path, "d", timestamp=3) as A:
+            A.query(cond="ints == 1")
+
+        with tiledb.open(path, "r", timestamp=1) as A:
+            assert_array_equal([1], A[:]["ints"])
+
+        with tiledb.open(path, "r", timestamp=2) as A:
+            assert_array_equal([1, 2], A[:]["ints"])
+
+        with tiledb.open(path, "r", timestamp=3) as A:
+            assert_array_equal([2, 3], A[:]["ints"])
+
+        cfg = tiledb.Config({"sm.consolidation.purge_deleted_cells": "true"})
+        with tiledb.scope_ctx(cfg):
+            tiledb.consolidate(path)
+        tiledb.vacuum(path)
+
+        with tiledb.open(path, "r") as A:
+            assert A.nonempty_domain() == ((2, 3),)
+            assert_array_equal([2, 3], A[:]["ints"])

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -696,7 +696,7 @@ class QueryDeleteTest(DiskTestCase):
                 tiledb.TileDBError,
                 match="SparseArray must be opened in read or delete mode",
             ):
-                A.query(cond=qc)
+                A.query(cond=qc).submit()
 
         with tiledb.open(path, "r") as A:
             assert_array_equal(data, A[:]["ints"])
@@ -706,9 +706,9 @@ class QueryDeleteTest(DiskTestCase):
                 tiledb.TileDBError,
                 match="Cannot initialize deletes; One condition is needed",
             ):
-                A.query()
+                A.query().submit()
 
-            A.query(cond=qc)
+            A.query(cond=qc).submit()
 
         with tiledb.open(path, "r") as A:
             assert all(A[:]["ints"] >= 5)
@@ -749,7 +749,7 @@ class QueryDeleteTest(DiskTestCase):
             assert_array_equal([1, 2, 3], A[:]["ints"])
 
         with tiledb.open(path, "d", timestamp=3) as A:
-            A.query(cond="ints == 1")
+            A.query(cond="ints == 1").submit()
 
         with tiledb.open(path, "r", timestamp=1) as A:
             assert_array_equal([1], A[:]["ints"])
@@ -792,7 +792,7 @@ class QueryDeleteTest(DiskTestCase):
             assert_array_equal([1, 2, 3], A[:]["ints"])
 
         with tiledb.open(path, "d", timestamp=3) as A:
-            A.query(cond="ints == 1")
+            A.query(cond="ints == 1").submit()
 
         with tiledb.open(path, "r", timestamp=1) as A:
             assert_array_equal([1], A[:]["ints"])


### PR DESCRIPTION
Example usage:
```
with tiledb.open(path, "d") as A:
    A.query(cond="attr < 4").submit()
```

* Delete data that satisfies a query condition
* Chery-picked relevant commit from https://github.com/TileDB-Inc/TileDB-Py/pull/1309