### PR TITLE
Release 0.17.6

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,8 @@
-# In Progress
+# TileDB-Py 0.17.6 Release Notes
 
 ## Bug Fixes
 * Correct writing empty/null strings to array. `tiledb.main.array_to_buffer` needs to resize data buffer at the end of `convert_unicode`; otherwise, last cell will be store with trailing nulls chars [#1339](https://github.com/TileDB-Inc/TileDB-Py/pull/1339)
-* Revert [#1326](https://github.com/TileDB-Inc/TileDB-Py/pull/1326) due to issues with `Context` lifetime with in multiprocess settings []()
+* Revert [#1326](https://github.com/TileDB-Inc/TileDB-Py/pull/1326) due to issues with `Context` lifetime with in multiprocess settings [#1372](https://github.com/TileDB-Inc/TileDB-Py/pull/1372)
 
 # TileDB-Py 0.17.5 Release Notes
 

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,7 +6,7 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.17.5
+        TILEDBPY_VERSION: 0.17.6
         LIBTILEDB_VERSION: 2.11.3
         LIBTILEDB_SHA: a55a910446f947a6c58839ba4061bd3d50a1ec93
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -8,7 +8,7 @@ stages:
       ${{ else }}:
         TILEDBPY_VERSION: 0.17.6
         LIBTILEDB_VERSION: 2.11.3
-        LIBTILEDB_SHA: a55a910446f947a6c58839ba4061bd3d50a1ec93
+        LIBTILEDB_SHA: 502b0dda8e28f736f3ea6abadbf24002e740c738
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from pybind11.setup_helpers import Pybind11Extension
 ### DO NOT USE ON CI
 
 # Target branch: Note that this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.11.3"
+TILEDB_VERSION = "502b0dda8e28f736f3ea6abadbf24002e740c738"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION


### PR DESCRIPTION
* This is a release branch that will not be merged into dev
* This is still linked against 2.11.3
* It includes bug fixes for moving `Attr` out of Cython and issues with writing empty/null strings to arrays