### PR TITLE
Fix Whitespace Handling in Query Conditions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # In Progress
 
 ## Bug Fixes
-* Properly handle whitespaces in a query condition as if it were a Python expression []()
+* Properly handle whitespaces in a query condition []()
 
 # Release 0.18.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# In Progress
+
+## Bug Fixes
+* Properly handle whitespaces in a query condition as if it were a Python expression []()
+
 # Release 0.18.0
 
 ## TileDB Embedded updates:

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -118,7 +118,7 @@ class QueryCondition:
 
     def __post_init__(self):
         try:
-            self.tree = ast.parse(self.expression, mode="eval")
+            self.tree = ast.parse(f"({self.expression})", mode="eval")
         except:
             raise TileDBError(
                 "Could not parse the given QueryCondition statement: "

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -684,6 +684,9 @@ class QueryConditionTest(DiskTestCase):
             result = A.query(cond="   (     d < 6)  ")[:]
             assert_array_equal(result["d"], A[:6]["d"])
 
+            result = A.query(cond="   (  \n   d \n\t< 6)  ")[:]
+            assert_array_equal(result["d"], A[:6]["d"])
+
             qc = """
                 U < 5   
             or

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -676,6 +676,31 @@ class QueryConditionTest(DiskTestCase):
             result = A.query(cond="2 <= data < 6 or 5 <= data < 9")[:]
             assert_array_equal(result["data"], A[2:9]["data"])
 
+    def test_with_whitespace(self):
+        with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
+            result = A.query(cond="        d < 6")[:]
+            assert_array_equal(result["d"], A[:6]["d"])
+
+            result = A.query(cond="   (     d < 6)  ")[:]
+            assert_array_equal(result["d"], A[:6]["d"])
+
+            qc = """
+                U < 5   
+            or
+                                                I >= 5
+            """
+            result = A.query(cond=qc)[:]
+            assert all((result["U"] < 5) | (result["U"] > 5))
+
+            qc = """
+                
+                                                A == ' a'
+        
+            """
+            result = A.query(cond=qc)[:]
+            # ensures that ' a' does not match 'a'
+            assert len(result["A"]) == 0
+
 
 class QueryDeleteTest(DiskTestCase):
     def test_basic_sparse(self):


### PR DESCRIPTION
- Wrap the query condition in parenthesis prior to parsing with AST to support multi-line continuation and whitespace padding that would be valid in Python if-cond statements