### PR TITLE
Explicitly Use Python 3.10 For Nightly Builds

### DIFF
--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -1,5 +1,7 @@
 name: Daily Test Build TileDB-Py Against Core
 
+#on: [push]
+
 on:
   workflow_dispatch:
   schedule:
@@ -43,6 +45,8 @@ jobs:
     steps:
       - name: Set up Python
         uses: actions/setup-python@v2
+        with:
+            python-version: "3.10"
 
       - name: Print Python version
         run: |


### PR DESCRIPTION
* Fix for #1418
* Explicitly use Python 3.10. Otherwise, default is now to use Python 3.11 which we (and PyArrow) do not yet fully support.