### PR TITLE
Fix `.df` and `.multi_index` Returning Attrs Used In Query Condition

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # In Progress
 
 ## Bug Fixes
-* Fix `.df` and `.multi_index` always returning attributes applied in query conditions []()
+* Fix `.df` and `.multi_index` always returning attributes applied in query conditions [#1433](https://github.com/TileDB-Inc/TileDB-Py/pull/1433)
 
 # Release 0.18.2
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# In Progress
+
+## Bug Fixes
+* Fix `.df` and `.multi_index` always returning attributes applied in query conditions []()
+
 # Release 0.18.2
 
 ## TileDB Embedded updates:

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -721,7 +721,7 @@ public:
     py::object init_pyqc = cond.attr("init_query_condition");
 
     try {
-      attrs_ = init_pyqc(pyschema_, attrs_).cast<std::vector<std::string>>();
+      init_pyqc(pyschema_, attrs_);
     } catch (tiledb::TileDBError &e) {
       TPY_ERROR_LOC(e.what());
     } catch (py::error_already_set &e) {

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -141,8 +141,6 @@ class QueryCondition:
                 "be made up of one or more Boolean expressions."
             )
 
-        return query_attrs
-
 
 @dataclass
 class QueryConditionTree(ast.NodeVisitor):
@@ -325,9 +323,6 @@ class QueryConditionTree(ast.NodeVisitor):
 
             if node.func.id == "dim" and not self.schema.domain.has_dim(variable):
                 raise TileDBError(f"{node.func.id} is not a dimension.")
-
-        if self.schema.has_attr(variable) and variable not in self.query_attrs:
-            self.query_attrs.append(variable)
 
         return variable
 

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -704,6 +704,25 @@ class QueryConditionTest(DiskTestCase):
             # ensures that ' a' does not match 'a'
             assert len(result["A"]) == 0
 
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    def test_do_not_return_attrs(self):
+        with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
+            cond = None
+            assert "D" in A.query(cond=cond, attrs=None)[:]
+            assert "D" not in A.query(cond=cond, attrs=[])[:]
+            assert "D" in A.query(cond=cond, attrs=None).df[:]
+            assert "D" not in A.query(cond=cond, attrs=[]).df[:]
+            assert "D" in A.query(cond=cond, attrs=None).multi_index[:]
+            assert "D" not in A.query(cond=cond, attrs=[]).multi_index[:]
+
+            cond = "D > 100"
+            assert "D" in A.query(cond=cond, attrs=None)[:]
+            assert "D" not in A.query(cond=cond, attrs=[])[:]
+            assert "D" in A.query(cond=cond, attrs=None).df[:]
+            assert "D" not in A.query(cond=cond, attrs=[]).df[:]
+            assert "D" in A.query(cond=cond, attrs=None).multi_index[:]
+            assert "D" not in A.query(cond=cond, attrs=[]).multi_index[:]
+
 
 class QueryDeleteTest(DiskTestCase):
     def test_basic_sparse(self):


### PR DESCRIPTION
When using query conditions with `.df` and `.multi_index`, the attribute that was applied in condition would be returned in the result regardless of what was passed to the `attr` argument.

For example,
```
with open.tiledb(uri, "r") as A:
   cond = "att < 10"

   result = A.query(cond=cond, attr=[])[:]
   # with the regular indexer, this correctly did not return any attributes back
   assert "att" not in result 

   result = A.query(cond=cond, attr=[]).df[:]
   # this PR's bug fix: despite asking for no attributes back, the results would still 
   # return an `att` column which would cause this assertion to fail
   assert "att" not in result
```