### PR TITLE
Fix Nullable Integers in `df` when using PyArrow Path

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 * Fix `.df` and `.multi_index` always returning attributes applied in query conditions [#1433](https://github.com/TileDB-Inc/TileDB-Py/pull/1433)
+* Fix representation of nullable integers in dataframe when using PyArrow path []()
 
 # Release 0.18.2
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 * Fix `.df` and `.multi_index` always returning attributes applied in query conditions [#1433](https://github.com/TileDB-Inc/TileDB-Py/pull/1433)
-* Fix representation of nullable integers in dataframe when using PyArrow path []()
+* Fix representation of nullable integers in dataframe when using PyArrow path [#1439](https://github.com/TileDB-Inc/TileDB-Py/pull/1439)
 
 # Release 0.18.2
 

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -337,7 +337,7 @@ class DataFrameIndexer(_BaseIndexer):
 
                 tdb_attr = self.array.attr(pa_attr.name)
 
-                if tdb_attr.dtype == bool:
+                if np.issubdtype(tdb_attr.dtype, bool):
                     # this is a workaround to cast TILEDB_BOOL types from uint8
                     # representation in Arrow to Boolean
                     dtype = "uint8"

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -329,52 +329,68 @@ class DataFrameIndexer(_BaseIndexer):
             with timing("buffer_conversion_time"):
                 table = self.pyquery._buffers_to_pa_table()
 
-            # this is a workaround to cast TILEDB_BOOL types from uint8
-            # representation in Arrow to Boolean
-            schema = table.schema
-            for attr_or_dim in schema:
-                if not self.array.schema.has_attr(attr_or_dim.name):
+            columns = []
+            pa_schema = table.schema
+            for pa_attr in pa_schema:
+                if not self.array.schema.has_attr(pa_attr.name):
                     continue
 
-                attr = self.array.attr(attr_or_dim.name)
-                if attr.dtype == bool:
-                    field_idx = schema.get_field_index(attr.name)
-                    field = pyarrow.field(attr.name, pyarrow.bool_())
-                    schema = schema.set(field_idx, field)
+                tdb_attr = self.array.attr(pa_attr.name)
 
-            table = table.cast(schema)
+                if tdb_attr.dtype == bool:
+                    # this is a workaround to cast TILEDB_BOOL types from uint8
+                    # representation in Arrow to Boolean
+                    dtype = "uint8"
+                elif tdb_attr.isnullable and np.issubdtype(tdb_attr.dtype, np.integer):
+                    # this is a workaround for PyArrow's to_pandas function
+                    # converting all integers with NULLs to float64:
+                    # https://arrow.apache.org/docs/python/pandas.html#arrow-pandas-conversion
+                    extended_dtype_mapping = {
+                        pyarrow.int8(): pd.Int8Dtype(),
+                        pyarrow.int16(): pd.Int16Dtype(),
+                        pyarrow.int32(): pd.Int32Dtype(),
+                        pyarrow.int64(): pd.Int64Dtype(),
+                        pyarrow.uint8(): pd.UInt8Dtype(),
+                        pyarrow.uint16(): pd.UInt16Dtype(),
+                        pyarrow.uint32(): pd.UInt32Dtype(),
+                        pyarrow.uint64(): pd.UInt64Dtype(),
+                    }
+                    dtype = extended_dtype_mapping[pa_attr.type]
+                else:
+                    continue
+
+                columns.append(
+                    {
+                        "field_name": tdb_attr.name,
+                        "name": tdb_attr.name,
+                        "numpy_type": f"{dtype}",
+                        "pandas_type": f"{dtype}",
+                    }
+                )
+
+            metadata = {
+                b"pandas": json.dumps(
+                    {
+                        "columns": columns,
+                        "index_columns": [
+                            {
+                                "kind": "range",
+                                "name": None,
+                                "start": 0,
+                                "step": 1,
+                                "stop": len(table),
+                            }
+                        ],
+                    }
+                ).encode()
+            }
+
+            table = table.cast(pyarrow.schema(pa_schema, metadata=metadata))
 
             if self.query.return_arrow:
                 return table
 
-            # setting integer_object_nulls=True prevents loss of precision when
-            # casting NULL integer to float64 back to integer
-            df = table.to_pandas(integer_object_nulls=True)
-
-            # this is a workaround for PyArrow's to_pandas function converting
-            # all integers with NULLs to float64:
-            # https://arrow.apache.org/docs/python/pandas.html#arrow-pandas-conversion
-            null_integer_type_mapper = {
-                pyarrow.uint8(): pd.UInt8Dtype(),
-                pyarrow.int8(): pd.Int8Dtype(),
-                pyarrow.uint16(): pd.UInt16Dtype(),
-                pyarrow.int16(): pd.Int16Dtype(),
-                pyarrow.uint32(): pd.UInt32Dtype(),
-                pyarrow.int32(): pd.Int32Dtype(),
-                pyarrow.uint64(): pd.UInt64Dtype(),
-                pyarrow.int64(): pd.Int64Dtype(),
-            }
-
-            # NULL integers in the dataframe are `object` dtype as set by
-            # integer_object_nulls=True above; check if the column in the
-            # Arrow table schema was originally an integer and cast to the
-            # associated Pandas extended dtype if so
-            for col in df.select_dtypes("object"):
-                field_idx = schema.get_field_index(col)
-                pa_type = schema[field_idx].type
-                if pa_type in null_integer_type_mapper:
-                    df[col] = df[col].astype(null_integer_type_mapper[pa_type])
-
+            df = table.to_pandas()
         else:
             df = DataFrame(_get_pyquery_results(self.pyquery, self.array.schema))
 


### PR DESCRIPTION
* Workaround PyArrow's `Table.to_pandas` converting all nullable integers to float64 type