### PR TITLE
Do Not Dispatch Success Builds For Azure Nightly Builds

### DIFF
--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -207,7 +207,7 @@ stages:
 
       - job: trigger_success_build
         dependsOn: [build2_python]
-        condition: succeeded()
+        condition: and(succeeded(), startsWith(variables['Build.SourceBranchName'], 'azure-wheel-test-'))
         pool: server
         steps:
           - task: InvokeRESTAPI@1


### PR DESCRIPTION
* This was only disabled for failed builds previously as it would unnecessarily open issues for failed releases
* Sending a dispatch for succeeded builds will attempt to delete the nightly build branch. But the nightly build branch does not exist if this is a regular release