### PR TITLE
Release 0.19.0 Against 2.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.15"

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -16,9 +16,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
+          - python-version: "3.11"
+            numpy-version: "1.23.2"
           - python-version: "3.10"
             numpy-version: "1.21.6"
           - python-version: "3.9"

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Print Python version
         run: |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,10 @@
-# In Progress
+# Release 0.19.0
+
+## Packaging Notes
+* Added support for Python 3.11
+
+## TileDB Embedded updates:
+* TileDB-Py 0.19.0 includes TileDB Embedded [TileDB 2.13.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.13.0)
 
 ## API Changes
 * Support Boolean types for query conditions [#1432](https://github.com/TileDB-Inc/TileDB-Py/pull/1432)
@@ -10,6 +16,7 @@
 ## Bug Fixes
 * Fix issue where queries in delete mode error out on arrays with string dimensions [#1473](https://github.com/TileDB-Inc/TileDB-Py/pull/1473)
 * Fix representation of nullable integers in dataframe when using PyArrow path [#1439](https://github.com/TileDB-Inc/TileDB-Py/pull/1439)
+* Check for uninitialized query state after submit and error out if uninitialized [#1483](https://github.com/TileDB-Inc/TileDB-Py/pull/1483)
 
 # Release 0.18.3
 

--- a/examples/query_condition_dense.py
+++ b/examples/query_condition_dense.py
@@ -32,8 +32,6 @@
 import tiledb
 import numpy as np
 from pprint import pprint
-import tempfile
-import string
 
 uri = "query_condition_dense"
 
@@ -67,14 +65,14 @@ def read_array(path):
         print()
 
     with tiledb.open(uri) as arr:
-        qc = tiledb.QueryCondition("(2 < attr1 < 6) and (attr2 < 0.5 or attr2 > 0.85)")
+        qc = "(2 < attr1 < 6) and (attr2 < 0.5 or attr2 > 0.85)"
         print(f"--- with query condition {qc}:")
 
         print(f"--- the fill value for attr1 is {arr.attr('attr1').fill}")
         print(f"--- the fill value for attr1 is {arr.attr('attr2').fill}")
 
         print()
-        res = arr.query(attr_cond=qc)[:]
+        res = arr.query(cond=qc)[:]
         pprint(res)
 
 

--- a/examples/query_condition_sparse.py
+++ b/examples/query_condition_sparse.py
@@ -32,8 +32,6 @@
 import tiledb
 import numpy as np
 from pprint import pprint
-import tempfile
-import string
 
 uri = "query_condition_sparse"
 
@@ -67,10 +65,10 @@ def read_array(path):
         print()
 
     with tiledb.open(uri) as arr:
-        qc = tiledb.QueryCondition("(2 < attr1 < 6) and (attr2 < 0.5 or attr2 > 0.85)")
+        qc = "(2 < attr1 < 6) and (attr2 < 0.5 or attr2 > 0.85)"
         print(f"--- with query condition {qc}:")
         print()
-        res = arr.query(attr_cond=qc)[:]
+        res = arr.query(cond=qc)[:]
         pprint(res)
 
 

--- a/examples/query_condition_string.py
+++ b/examples/query_condition_string.py
@@ -52,10 +52,8 @@ def create_array(path):
 
 def read_array(path, cond):
     with tiledb.open(path) as arr:
-        qc = tiledb.QueryCondition(cond)
-
-        print("QueryCondition is: ", qc)
-        res = arr.query(attr_cond=qc)[:]
+        print("QueryCondition is: ", cond)
+        res = arr.query(cond=cond)[:]
         return res
 
 

--- a/examples/vfs.py
+++ b/examples/vfs.py
@@ -76,24 +76,19 @@ def write():
     # Create TileDB VFS
     vfs = tiledb.VFS()
 
-    # Create VFS file handle
-    f = vfs.open("tiledb_vfs.bin", "wb")
-
     # Write binary data
-    vfs.write(f, struct.pack("f", 153.0))
-    vfs.write(f, "abcd".encode("utf-8"))
-    vfs.close(f)
+    with vfs.open("tiledb_vfs.bin", "wb") as f:
+        f.write(struct.pack("f", 153.0))
+        f.write("abcd".encode("utf-8"))
 
     # Write binary data again - this will overwrite the previous file
-    f = vfs.open("tiledb_vfs.bin", "wb")
-    vfs.write(f, struct.pack("f", 153.1))
-    vfs.write(f, "abcdef".encode("utf-8"))
-    vfs.close(f)
+    with vfs.open("tiledb_vfs.bin", "wb") as f:
+        f.write(struct.pack("f", 153.1))
+        f.write("abcdef".encode("utf-8"))
 
     # Append binary data to existing file (this will NOT work on S3)
-    f = vfs.open("tiledb_vfs.bin", "ab")
-    vfs.write(f, "ghijkl".encode("utf-8"))
-    vfs.close(f)
+    with vfs.open("tiledb_vfs.bin", "ab") as f:
+        f.write("ghijkl".encode("utf-8"))
 
 
 def read():
@@ -101,12 +96,14 @@ def read():
     vfs = tiledb.VFS()
 
     # Read binary data
-    f = vfs.open("tiledb_vfs.bin", "rb")
-    f1 = struct.unpack("f", vfs.read(f, 0, 4))[0]
-    s1 = bytes.decode(vfs.read(f, 4, 12), "utf-8")
-    print("Binary read:\n{}\n{}".format(f1, s1))
+    with vfs.open("tiledb_vfs.bin", "rb") as f:
+        # Read the first 4 bytes (bytes [0:4])
+        f1 = struct.unpack("f", f.read(4))[0]
 
-    vfs.close(f)
+        # Read the next 8 bytes (bytes [4:12])
+        s1 = bytes.decode(f.read(8), "utf-8")
+
+        print(f"Binary read:\n{f1}\n{s1}")
 
 
 dirs_files()

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -9,14 +9,14 @@ stages:
           matrix:
             mac:
               imageName: "macOS-11"
-              python.version: "3.11"
+              python.version: "3.10"
               MACOSX_DEPLOYMENT_TARGET: 10.15
             windows:
               imageName: "windows-latest"
-              python.version: "3.11"
+              python.version: "3.10"
             linux_py3:
               imageName: "ubuntu-latest"
-              python.version: "3.11"
+              python.version: "3.10"
           maxParallel: 4
         timeoutInMinutes: 120
 

--- a/misc/azure-ci.yml
+++ b/misc/azure-ci.yml
@@ -9,14 +9,14 @@ stages:
           matrix:
             mac:
               imageName: "macOS-11"
-              python.version: "3.10"
+              python.version: "3.11"
               MACOSX_DEPLOYMENT_TARGET: 10.15
             windows:
               imageName: "windows-latest"
-              python.version: "3.10"
+              python.version: "3.11"
             linux_py3:
               imageName: "ubuntu-latest"
-              python.version: "3.10"
+              python.version: "3.11"
           maxParallel: 4
         timeoutInMinutes: 120
 

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -70,7 +70,7 @@ stages:
         steps:
           - task: UsePythonVersion@0
             inputs:
-              versionSpec: "3.11"
+              versionSpec: "3.10"
             condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
           - script: git tag -f $(TILEDBPY_VERSION)

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -49,7 +49,7 @@ stages:
         condition: always()
         variables:
           cibw_test_requires: "pytest"
-          USE_CIBW_VERSION: 2.3.0
+          USE_CIBW_VERSION: 2.11.3
         strategy:
           matrix:
             linux_py:

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,9 +6,9 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.18.3
-        LIBTILEDB_VERSION: 2.12.3
-        LIBTILEDB_SHA: fdfc2ee106caffe7e3a373b8728a04eabc4d89a5
+        TILEDBPY_VERSION: 0.19.0
+        LIBTILEDB_VERSION: 2.13.0
+        LIBTILEDB_SHA: db00e709701fa1787dce68c7563f775d6a0770ad
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"
@@ -70,7 +70,7 @@ stages:
         steps:
           - task: UsePythonVersion@0
             inputs:
-              versionSpec: "3.10"
+              versionSpec: "3.11"
             condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
           - script: git tag -f $(TILEDBPY_VERSION)

--- a/misc/pypi_linux/build.sh
+++ b/misc/pypi_linux/build.sh
@@ -63,8 +63,21 @@ auditwheel repair dist/*.whl
 /opt/python/cp310-cp310/bin/python3.10 -m pip install wheelhouse/*.whl
 cd tiledb/tests
 
+# build python311 wheel
+cd /home/tiledb
+git clone $TILEDB_PY_REPO TileDB-Py311
+git -C TileDB-Py311 checkout $TILEDBPY_VERSION
+
+cd /home/tiledb/TileDB-Py311
+/opt/python/cp311-cp311m/bin/python3.10 -m pip install -r misc/requirements_wheel.txt
+/opt/python/cp311-cp311/bin/python3.10 setup.py build_ext bdist_wheel --tiledb=/usr/local
+auditwheel repair dist/*.whl
+/opt/python/cp311-cp311/bin/python3.10 -m pip install wheelhouse/*.whl
+cd tiledb/tests
+
 # copy build products out
 cp /home/tiledb/TileDB-Py37/wheelhouse/* /wheels
 cp /home/tiledb/TileDB-Py38/wheelhouse/* /wheels
 cp /home/tiledb/TileDB-Py39/wheelhouse/* /wheels
 cp /home/tiledb/TileDB-Py310/wheelhouse/* /wheels
+cp /home/tiledb/TileDB-Py311/wheelhouse/* /wheels

--- a/misc/pypi_linux/build.sh
+++ b/misc/pypi_linux/build.sh
@@ -69,10 +69,10 @@ git clone $TILEDB_PY_REPO TileDB-Py311
 git -C TileDB-Py311 checkout $TILEDBPY_VERSION
 
 cd /home/tiledb/TileDB-Py311
-/opt/python/cp311-cp311m/bin/python3.10 -m pip install -r misc/requirements_wheel.txt
-/opt/python/cp311-cp311/bin/python3.10 setup.py build_ext bdist_wheel --tiledb=/usr/local
+/opt/python/cp311-cp311m/bin/python3.11 -m pip install -r misc/requirements_wheel.txt
+/opt/python/cp311-cp311/bin/python3.11 setup.py build_ext bdist_wheel --tiledb=/usr/local
 auditwheel repair dist/*.whl
-/opt/python/cp311-cp311/bin/python3.10 -m pip install wheelhouse/*.whl
+/opt/python/cp311-cp311/bin/python3.11 -m pip install wheelhouse/*.whl
 cd tiledb/tests
 
 # copy build products out

--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -6,6 +6,7 @@ numpy==1.19.4 ; python_version == "3.9" and platform_machine !='aarch64'
 # NOTE: oldest-supported-numpy (1.19.2) had forward ABI compat problems
 numpy==1.20.* ; python_version < "3.10" and platform_machine=='aarch64'
 numpy==1.21.* ; python_version >= "3.10"
+numpy>=1.23.0 ; python_version >= "3.11"
 
 #-------------------------------
 # Note 11/23/2021: the current version of the AWS sdk does not work with cmake 3.22

--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -5,8 +5,8 @@ numpy==1.19.4 ; python_version == "3.9" and platform_machine !='aarch64'
 
 # NOTE: oldest-supported-numpy (1.19.2) had forward ABI compat problems
 numpy==1.20.* ; python_version < "3.10" and platform_machine=='aarch64'
-numpy==1.21.* ; python_version >= "3.10"
-numpy>=1.23.0 ; python_version >= "3.11"
+numpy==1.21.* ; "3.11" > python_version >= "3.10"
+numpy>=1.23.2 ; python_version >= "3.11"
 
 #-------------------------------
 # Note 11/23/2021: the current version of the AWS sdk does not work with cmake 3.22

--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -5,7 +5,7 @@ numpy==1.19.4 ; python_version == "3.9" and platform_machine !='aarch64'
 
 # NOTE: oldest-supported-numpy (1.19.2) had forward ABI compat problems
 numpy==1.20.* ; python_version < "3.10" and platform_machine=='aarch64'
-numpy==1.21.* ; "3.11" > python_version >= "3.10"
+numpy==1.21.* ; python_version == "3.10"
 numpy>=1.23.2 ; python_version >= "3.11"
 
 #-------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy>=1.16.5 ; python_version < "3.10" and platform_machine != 'aarch64'
 numpy>=1.19.2 ; python_version < "3.10" and platform_machine == 'aarch64'
 numpy>=1.21.0 ; python_version >= "3.10"
+numpy>=1.23.0 ; python_version >= "3.11"
 packaging
 
 contextvars ;python_version<"3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.16.5 ; python_version < "3.10" and platform_machine != 'aarch64'
 numpy>=1.19.2 ; python_version < "3.10" and platform_machine == 'aarch64'
-numpy>=1.21.0 ; python_version >= "3.10"
-numpy>=1.23.0 ; python_version >= "3.11"
+numpy>=1.21.0 ; "3.11" > python_version >= "3.10"
+numpy>=1.23.2 ; python_version >= "3.11"
 packaging
 
 contextvars ;python_version<"3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.16.5 ; python_version < "3.10" and platform_machine != 'aarch64'
 numpy>=1.19.2 ; python_version < "3.10" and platform_machine == 'aarch64'
-numpy>=1.21.0 ; "3.11" > python_version >= "3.10"
+numpy>=1.21.0 ; python_version == "3.10"
 numpy>=1.23.2 ; python_version >= "3.11"
 packaging
 

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2690,29 +2690,11 @@ cdef class Array(object):
         """Deprecated in 0.9.2.
 
         Use `timestamp_range`
-
-        Returns the timestamp the array is opened at
-
-        :rtype: int
-        :returns: tiledb timestamp at which point the array was opened
-
         """
-        warnings.warn(
-            "timestamp is deprecated; please use timestamp_range. "
-            "It is slated for removal in 0.19.0.",
-            DeprecationWarning,
+        raise TileDBError(
+            "timestamp is deprecated; you must use timestamp_range. "
+            "This message will be removed in 0.21.0.",
         )
-        assert tiledbpy_version < (0, 19, 0)
-
-        cdef tiledb_ctx_t* ctx_ptr = safe_ctx_ptr(self.ctx)
-        cdef tiledb_array_t* array_ptr = self.ptr
-        cdef uint64_t timestamp = 0
-        cdef int rc = TILEDB_OK
-        rc = tiledb_array_get_timestamp(ctx_ptr, array_ptr, &timestamp)
-        if rc != TILEDB_OK:
-            _raise_ctx_err(ctx_ptr, rc)
-        return int(timestamp)
-
 
     @property
     def timestamp_range(self):
@@ -2740,25 +2722,14 @@ cdef class Array(object):
 
     @property
     def coords_dtype(self):
-        """Returns the numpy record array dtype of the array coordinates
-
-        :rtype: numpy.dtype
-        :returns: coord array record dtype
-
         """
-        # deprecated in 0.8.10
-        warnings.warn(
-            """`coords_dtype` is deprecated because combined coords have been removed from libtiledb.
-            Currently it returns a record array of each individual dimension dtype, but it will
-            be removed because that is not applicable to split dimensions.
-            It is slated for removal in 0.19.0""",
-            DeprecationWarning,
+        Deprecated in 0.8.10
+        """
+        raise TileDBError(
+            "`coords_dtype` is deprecated because combined coords have been "
+            "removed from libtiledb. This message will be removed in 0.21.0.",
         )
-        assert tiledbpy_version < (0, 19, 0)
-
-        # returns the record array dtype of the coordinate array
-        return np.dtype([(str(dim.name), dim.dtype) for dim in self.schema.domain])
-
+        
     @property
     def uri(self):
         """Returns the URI of the array"""
@@ -3247,15 +3218,10 @@ cdef class Query(object):
 
     @property
     def attr_cond(self):
-        assert tiledbpy_version < (0, 19, 0)
-
-        warnings.warn(
-            "`attr_cond` is now deprecated and is slated for removal in "
-            "version 0.19.0. Use `cond`.",
-            DeprecationWarning,
+        raise TileDBError(
+            "`attr_cond` is no longer supported. You must use `cond`. "
+            "This message will be removed in 0.21.0."
         )
-
-        return self.cond
 
     @property
     def cond(self):
@@ -3484,20 +3450,15 @@ cdef class DenseArrayImpl(Array):
             raise TileDBError("DenseArray must be opened in read mode")
 
         if attr_cond is not None:
-            assert tiledbpy_version < (0, 19, 0)
-
             if cond is not None:
                 raise TileDBError("Both `attr_cond` and `cond` were passed. "
-                    "Only use `cond`. `attr_cond` is now deprecated "
-                    "and is slated for removal in version 0.19.0."
+                    "Only use `cond`."
                 )
 
-            warnings.warn(
-                "`attr_cond` is now deprecated and is slated for removal in "
-                "version 0.19.0. Use `cond`.",
-                DeprecationWarning,
+            raise TileDBError(
+                "`attr_cond` is no longer supported. You must use `cond`. "
+                "This message will be removed in 0.21.0."
             )
-            cond = attr_cond
 
         return Query(self, attrs=attrs, cond=cond, dims=dims,
                       coords=coords, order=order,
@@ -3544,20 +3505,15 @@ cdef class DenseArrayImpl(Array):
             raise TileDBError("DenseArray must be opened in read mode")
 
         if attr_cond is not None:
-            assert tiledbpy_version < (0, 19, 0)
-
             if cond is not None:
                 raise TileDBError("Both `attr_cond` and `cond` were passed. "
-                    "Only use `cond`. `attr_cond` is now deprecated "
-                    "and is slated for removal in version 0.19.0."
+                    "Only use `cond`."
                 )
 
-            warnings.warn(
-                "`attr_cond` is now deprecated and is slated for removal in "
-                "version 0.19.0. Use `cond`.",
-                DeprecationWarning,
+            raise TileDBError(
+                "`attr_cond` is no longer supported. You must use `cond`. "
+                "This message will be removed in 0.21.0."
             )
-            cond = attr_cond
 
         cdef tiledb_layout_t layout = TILEDB_UNORDERED
         if order is None or order == 'C':
@@ -3623,13 +3579,12 @@ cdef class DenseArrayImpl(Array):
             if isinstance(cond, str):
                 q.set_cond(QueryCondition(cond))
             elif isinstance(cond, QueryCondition):
-                assert tiledbpy_version < (0, 19, 0)
-                warnings.warn(
+                raise TileDBError(
                     "Passing `tiledb.QueryCondition` to `cond` is no longer "
-                    "required and is slated for removal in version 0.19.0. "
-                    "Instead of `cond=tiledb.QueryCondition('expression')`, "
-                    "use `cond='expression'`.",
-                    DeprecationWarning,
+                    "supported as of 0.19.0. Instead of "
+                    "`cond=tiledb.QueryCondition('expression')` "
+                    "you must use `cond='expression'`. This message will be "
+                    "removed in 0.21.0.",
                 )
             else:
                 raise TypeError("`cond` expects type str.")
@@ -4282,20 +4237,15 @@ cdef class SparseArrayImpl(Array):
             raise TileDBError("SparseArray must be opened in read or delete mode")
 
         if attr_cond is not None:
-            assert tiledbpy_version < (0, 19, 0)
-
             if cond is not None:
                 raise TileDBError("Both `attr_cond` and `cond` were passed. "
-                    "Only use `cond`. `attr_cond` is now deprecated "
-                    "and is slated for removal in version 0.19.0."
+                    "Only use `cond`."
                 )
 
-            warnings.warn(
-                "`attr_cond` is now deprecated and is slated for removal in "
-                "version 0.19.0. Use `cond`.",
-                DeprecationWarning,
+            raise TileDBError(
+                "`attr_cond` is no longer supported. You must use `cond`. "
+                "This message will be removed in 0.21.0."
             )
-            cond = attr_cond
 
         # backwards compatibility
         _coords = coords
@@ -4355,20 +4305,15 @@ cdef class SparseArrayImpl(Array):
             raise TileDBError("SparseArray is not opened in read or delete mode")
 
         if attr_cond is not None:
-            assert tiledbpy_version < (0, 19, 0)
-
             if cond is not None:
                 raise TileDBError("Both `attr_cond` and `cond` were passed. "
-                    "Only use `cond`. `attr_cond` is now deprecated "
-                    "and is slated for removal in version 0.19.0."
+                    "`attr_cond` is no longer supported. You must use `cond`. "
                 )
 
-            warnings.warn(
-                "`attr_cond` is now deprecated and is slated for removal in "
-                "version 0.19.0. Use `cond`.",
-                DeprecationWarning,
+            raise TileDBError(
+                "`attr_cond` is no longer supported. You must use `cond`. "
+                "This message will be removed in 0.21.0.",
             )
-            cond = attr_cond
 
         cdef tiledb_layout_t layout = TILEDB_UNORDERED
         if order is None or order == 'U':
@@ -4429,13 +4374,12 @@ cdef class SparseArrayImpl(Array):
             if isinstance(cond, str):
                 q.set_cond(QueryCondition(cond))
             elif isinstance(cond, QueryCondition):
-                assert tiledbpy_version < (0, 19, 0)
-                warnings.warn(
+                raise TileDBError(
                     "Passing `tiledb.QueryCondition` to `cond` is no longer "
-                    "required and is slated for removal in version 0.19.0. "
-                    "Instead of `cond=tiledb.QueryCondition('expression')`, "
-                    "use `cond='expression'`.",
-                    DeprecationWarning,
+                    "supported as of 0.19.0. Instead of "
+                    "`cond=tiledb.QueryCondition('expression')` "
+                    "you must use `cond='expression'`. This message will be "
+                    "removed in 0.21.0.",
                 )
             else:
                 raise TypeError("`cond` expects type str.")

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -7,7 +7,6 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from numbers import Real
 from dataclasses import dataclass
-import warnings
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union, cast
 
 
@@ -447,17 +446,12 @@ def _get_pyquery(
         if isinstance(query.cond, str):
             pyquery.set_cond(QueryCondition(query.cond))
         elif isinstance(query.cond, QueryCondition):
-            from tiledb import version as tiledbpy_version
-
-            assert tiledbpy_version() < (0, 19, 0)
-            warnings.warn(
-                "Passing `tiledb.QueryCondition` to `cond` is no longer "
-                "required and is slated for removal in version 0.19.0. "
-                "Instead of `cond=tiledb.QueryCondition('expression')`, "
-                "use `cond='expression'`.",
-                DeprecationWarning,
+            raise TileDBError(
+                "Passing `tiledb.QueryCondition` to `cond` is no longer supported "
+                "as of 0.19.0. Instead of `cond=tiledb.QueryCondition('expression')` "
+                "you must use `cond='expression'`. This message will be "
+                "removed in 0.21.0.",
             )
-            pyquery.set_cond(query.cond)
         else:
             raise TypeError("`cond` expects type str.")
 

--- a/tiledb/tests/test_attribute.py
+++ b/tiledb/tests/test_attribute.py
@@ -3,6 +3,7 @@ import xml.etree.ElementTree
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
+import sys
 
 import tiledb
 from tiledb.tests.common import assert_captured, DiskTestCase, has_pandas
@@ -184,4 +185,8 @@ class AttributeTest(DiskTestCase):
             assert A.schema.attr(0).name == ""
             with pytest.raises(AttributeError) as exc:
                 A.schema.attr(0).name = "can't change"
-            assert "can't set attribute" in str(exc.value)
+
+            if sys.version_info < (3, 11):
+                assert "can't set attribute" in str(exc.value)
+            else:
+                assert "object has no setter" in str(exc.value)

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -53,6 +53,12 @@ class TestDaskSupport(DiskTestCase):
         # future releases.
         "ignore:make_current is deprecated"
     )
+    @pytest.mark.skipif(
+        condition=(
+            sys.version_info >= (3, 11) and (datetime.now() < datetime(2023, 1, 6))
+        ),
+        reason="https://github.com/dask/distributed/issues/6785",
+    )
     def test_dask_multiattr_2d(self):
         uri = self.path("multiattr")
 

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -107,25 +107,29 @@ class QueryConditionTest(DiskTestCase):
 
     def test_unsigned_sparse(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
-            with pytest.raises(DeprecationWarning) as exc_info:
-                result = A.query(cond=tiledb.QueryCondition("U < 5"), attrs=["U"])[:]
-                assert all(result["U"] < 5)
+            with pytest.raises(tiledb.TileDBError) as exc_info:
+                A.query(cond=tiledb.QueryCondition("U < 5"), attrs=["U"])[:]
             assert (
-                "Passing `tiledb.QueryCondition` to `cond` is no longer required"
+                "Passing `tiledb.QueryCondition` to `cond` is no longer supported"
                 in str(exc_info.value)
             )
+
+            result = A.query(cond="U < 5", attrs=["U"])[:]
+            assert all(result["U"] < 5)
 
     def test_unsigned_dense(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=False)) as A:
             mask = A.attr("U").fill
 
-            with pytest.raises(DeprecationWarning) as exc_info:
-                result = A.query(cond=tiledb.QueryCondition("U < 5"), attrs=["U"])[:]
-                assert all(self.filter_dense(result["U"], mask) < 5)
+            with pytest.raises(tiledb.TileDBError) as exc_info:
+                A.query(cond=tiledb.QueryCondition("U < 5"), attrs=["U"])[:]
             assert (
-                "Passing `tiledb.QueryCondition` to `cond` is no longer required"
+                "Passing `tiledb.QueryCondition` to `cond` is no longer supported"
                 in str(exc_info.value)
             )
+
+            result = A.query(cond="U < 5", attrs=["U"])[:]
+            assert all(self.filter_dense(result["U"], mask) < 5)
 
     def test_signed_sparse(self):
         uri = self.create_input_array_UIDSA(sparse=True)
@@ -622,21 +626,21 @@ class QueryConditionTest(DiskTestCase):
                 A.query(cond=qc, attr_cond=qc)
             assert "Both `attr_cond` and `cond` were passed." in str(exc_info.value)
 
-            with pytest.raises(DeprecationWarning) as exc_info:
+            with pytest.raises(tiledb.TileDBError) as exc_info:
                 A.query(attr_cond=qc)
-            assert "`attr_cond` is now deprecated" in str(exc_info.value)
+            assert "`attr_cond` is no longer supported" in str(exc_info.value)
 
-            with pytest.raises(DeprecationWarning) as exc_info:
+            with pytest.raises(tiledb.TileDBError) as exc_info:
                 A.query(cond=qc).attr_cond
-            assert "`attr_cond` is now deprecated" in str(exc_info.value)
+            assert "`attr_cond` is no longer supported" in str(exc_info.value)
 
             with pytest.raises(tiledb.TileDBError) as exc_info:
                 A.subarray(1, cond=qc, attr_cond=qc)
             assert "Both `attr_cond` and `cond` were passed." in str(exc_info.value)
 
-            with pytest.raises(DeprecationWarning) as exc_info:
+            with pytest.raises(tiledb.TileDBError) as exc_info:
                 A.subarray(1, attr_cond=qc)
-            assert "`attr_cond` is now deprecated" in str(exc_info.value)
+            assert "`attr_cond` is no longer supported" in str(exc_info.value)
 
     def test_on_dense_dimensions(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=False)) as A:

--- a/tiledb/tests/test_vfs.py
+++ b/tiledb/tests/test_vfs.py
@@ -141,21 +141,6 @@ class TestVFS(DiskTestCase):
         self.assertEqual(fio.read(3), buffer)
         fio.close()
 
-        buffer = b"abc"
-        fio = vfs.open(self.path("abc"), "wb")
-        with pytest.warns(DeprecationWarning, match="Use `FileIO.write`"):
-            vfs.write(fio, buffer)
-        with pytest.warns(DeprecationWarning, match="Use `FileIO.close`"):
-            vfs.close(fio)
-        self.assertEqual(vfs.file_size(self.path("abc")), 3)
-
-        fio = vfs.open(self.path("abc"), "rb")
-        with pytest.warns(
-            DeprecationWarning, match="Use `FileIO.seek` and `FileIO.read`"
-        ):
-            self.assertEqual(vfs.read(fio, 0, 3), buffer)
-        fio.close()
-
         # write / read empty input
         fio = vfs.open(self.path("baz"), "wb")
         fio.write(b"")

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -1,12 +1,9 @@
-from copy import copy
 import io
 from typing import List, Optional, Type, TYPE_CHECKING, Union
 from types import TracebackType
-import warnings
 
 import tiledb.cc as lt
 from .ctx import default_ctx
-from .version import version_tuple as tiledbpy_version
 
 if TYPE_CHECKING:
     from .libtiledb import Ctx, Config
@@ -82,12 +79,10 @@ class VFS(lt.VFS):
 
         """
         if isinstance(file, FileIO):
-            warnings.warn(
-                f"`tiledb.VFS().open` now returns a a FileIO object. Use "
-                "`FileIO.close`. It is slated for removal in 0.19.0.",
-                DeprecationWarning,
+            raise lt.TileDBError(
+                "`tiledb.VFS().open` now returns a a FileIO object. Use "
+                "`FileIO.close`. This message will be removed in 0.21.0.",
             )
-            assert tiledbpy_version < (0, 19, 0)
         file.close()
         return file
 
@@ -101,12 +96,10 @@ class VFS(lt.VFS):
 
         """
         if isinstance(file, FileIO):
-            warnings.warn(
-                f"`tiledb.VFS().open` now returns a a FileIO object. Use "
-                "`FileIO.write`. It is slated for removal in 0.19.0.",
-                DeprecationWarning,
+            raise lt.TileDBError(
+                "`tiledb.VFS().open` now returns a a FileIO object. Use "
+                "`FileIO.write`. This message will be removed in 0.21.0.",
             )
-            assert tiledbpy_version < (0, 19, 0)
         if isinstance(buff, str):
             buff = buff.encode()
         file.write(buff)
@@ -123,14 +116,11 @@ class VFS(lt.VFS):
 
         """
         if isinstance(file, FileIO):
-            warnings.warn(
-                f"`tiledb.VFS().open` now returns a a FileIO object. Use "
-                "`FileIO.seek` and `FileIO.read`. It is slated for removal "
-                "in 0.19.0.",
-                DeprecationWarning,
+            raise lt.TileDBError(
+                "`tiledb.VFS().open` now returns a a FileIO object. Use "
+                "`FileIO.seek` and `FileIO.read`. This message will be removed "
+                "in 0.21.0."
             )
-            assert tiledbpy_version < (0, 19, 0)
-            return file.read(nbytes)
 
         if nbytes == 0:
             return b""


### PR DESCRIPTION
* Support wheels for Python 3.11
* `DeprecationWarning`s for 0.19.0 now error out. These have been changed to `TileDBError`s. Error messages will be removed in two release cycles