### PR TITLE
Sync `setuptools` Pinning From `pyproject.toml` To `requirements_*.txt`

### DIFF
--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -13,7 +13,7 @@ numpy>=1.23.2 ; python_version >= "3.11"
 cmake >= 3.21, < 3.22
 cython >= 0.27
 pybind11 >= 2.6.2
-setuptools >= 18.0
+setuptools>=42,<=59.5.0
 setuptools_scm >= 1.5.4
 wheel >= 0.30
 contextvars ;python_version<"3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ numpy >= 1.16.5
 cmake >= 3.23
 cython >= 0.27
 pybind11 >= 2.6.2
-setuptools >= 18.0
+setuptools>=42,<=59.5.0
 setuptools_scm >= 1.5.4
 wheel >= 0.30
 contextvars ;python_version<"3.7"


### PR DESCRIPTION
* This was caught when building from source with Python 3.11 on macos was erroring out and the version of `setuptools` was found to be the culprit
* https://github.com/TileDB-Inc/TileDB-Py/issues/1493