### PR TITLE
Fix webp filter options

### DIFF
--- a/tiledb/filter.py
+++ b/tiledb/filter.py
@@ -679,7 +679,7 @@ class WebpFilter(Filter):
 
     def __init__(
         self,
-        input_format: int = None,
+        input_format: lt.WebpInputFormat = None,
         quality: float = None,
         lossless: bool = None,
         ctx: "Ctx" = None,
@@ -693,21 +693,21 @@ class WebpFilter(Filter):
 
         if input_format is not None:
             self._set_option(
-                lt.Context(self._ctx.__capsule__(), False),
+                self._ctx,
                 lt.FilterOption.WEBP_INPUT_FORMAT,
-                input_format,
+                lt.WebpInputFormat(input_format),
             )
 
         if quality is not None:
             self._set_option(
-                lt.Context(self._ctx.__capsule__(), False),
+                self._ctx,
                 lt.FilterOption.WEBP_QUALITY,
                 float(quality),
             )
 
         if lossless is not None:
             self._set_option(
-                lt.Context(self._ctx.__capsule__(), False),
+                self._ctx,
                 lt.FilterOption.WEBP_LOSSLESS,
                 lossless,
             )
@@ -721,22 +721,22 @@ class WebpFilter(Filter):
 
     @property
     def input_format(self):
-        return self._get_option(
-            lt.Context(self._ctx.__capsule__(), False),
+        return lt.WebpInputFormat(self._get_option(
+            self._ctx,
             lt.FilterOption.WEBP_INPUT_FORMAT,
-        )
+        ))
 
     @property
     def quality(self):
         return self._get_option(
-            lt.Context(self._ctx.__capsule__(), False),
+            self._ctx,
             lt.FilterOption.WEBP_QUALITY,
         )
 
     @property
     def lossless(self):
         return self._get_option(
-            lt.Context(self._ctx.__capsule__(), False),
+            self._ctx,
             lt.FilterOption.WEBP_LOSSLESS,
         )
 

--- a/tiledb/filter.py
+++ b/tiledb/filter.py
@@ -721,10 +721,12 @@ class WebpFilter(Filter):
 
     @property
     def input_format(self):
-        return lt.WebpInputFormat(self._get_option(
-            self._ctx,
-            lt.FilterOption.WEBP_INPUT_FORMAT,
-        ))
+        return lt.WebpInputFormat(
+            self._get_option(
+                self._ctx,
+                lt.FilterOption.WEBP_INPUT_FORMAT,
+            )
+        )
 
     @property
     def quality(self):

--- a/tiledb/tests/test_webp.py
+++ b/tiledb/tests/test_webp.py
@@ -12,6 +12,26 @@ import tiledb
     reason="Can't create WebP filter; built with TILEDB_WEBP=OFF",
 )
 @pytest.mark.parametrize(
+    "format, quality, lossless",
+    [
+        (tiledb.filter.lt.WebpInputFormat.WEBP_RGB, 100.0, False),  # Test setting format with enum values
+        (tiledb.filter.lt.WebpInputFormat.WEBP_BGR, 50.0, True),
+        (tiledb.filter.lt.WebpInputFormat.WEBP_RGBA, 25.5, False),
+        (4, 0.0, True),                                             # Test setting format with integral type
+    ],
+)
+def test_webp_ctor(format, quality, lossless):
+    webp_filter = tiledb.WebpFilter(input_format=format, quality=quality, lossless=lossless)
+    np.testing.assert_equal(webp_filter.input_format, tiledb.filter.lt.WebpInputFormat(format))
+    np.testing.assert_equal(webp_filter.quality, quality)
+    np.testing.assert_equal(webp_filter.lossless, lossless)
+
+
+@pytest.mark.skipif(
+    not main.test_webp_filter.webp_filter_exists(),
+    reason="Can't create WebP filter; built with TILEDB_WEBP=OFF",
+)
+@pytest.mark.parametrize(
     "attr_dtype, dim_dtype, var, sparse",
     [
         (np.int64, np.int64, None, True),  # Sparse arrays are not supported

--- a/tiledb/tests/test_webp.py
+++ b/tiledb/tests/test_webp.py
@@ -14,15 +14,23 @@ import tiledb
 @pytest.mark.parametrize(
     "format, quality, lossless",
     [
-        (tiledb.filter.lt.WebpInputFormat.WEBP_RGB, 100.0, False),  # Test setting format with enum values
+        (
+            tiledb.filter.lt.WebpInputFormat.WEBP_RGB,
+            100.0,
+            False,
+        ),  # Test setting format with enum values
         (tiledb.filter.lt.WebpInputFormat.WEBP_BGR, 50.0, True),
         (tiledb.filter.lt.WebpInputFormat.WEBP_RGBA, 25.5, False),
-        (4, 0.0, True),                                             # Test setting format with integral type
+        (4, 0.0, True),  # Test setting format with integral type
     ],
 )
 def test_webp_ctor(format, quality, lossless):
-    webp_filter = tiledb.WebpFilter(input_format=format, quality=quality, lossless=lossless)
-    np.testing.assert_equal(webp_filter.input_format, tiledb.filter.lt.WebpInputFormat(format))
+    webp_filter = tiledb.WebpFilter(
+        input_format=format, quality=quality, lossless=lossless
+    )
+    np.testing.assert_equal(
+        webp_filter.input_format, tiledb.filter.lt.WebpInputFormat(format)
+    )
     np.testing.assert_equal(webp_filter.quality, quality)
     np.testing.assert_equal(webp_filter.lossless, lossless)
 


### PR DESCRIPTION
Fixed by updating `filter.py` to remove use of `__capsule__` and `lt.Context`. Added some new unit tests to protect against this in the future. 

Also updated type of `input_format` to use the `WebpInputFormat` enum, but we still support setting input format using integral values and a test for this was also added in this PR.