### PR TITLE
Install Using `python setup.py develop` In Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           else 
             # Build from source as fallback
             python setup.py build_ext --inplace
-            python setup.py install
+            python setup.py develop
           fi
         if: matrix.os == 'macos-11'
 
@@ -90,7 +90,7 @@ jobs:
           else 
             # Build from source as fallback
             python setup.py build_ext --inplace
-            python setup.py install
+            python setup.py develop
           fi
         if: matrix.os == 'ubuntu-latest'
 

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Build TileDB-Py
         run: |
           python setup.py build_ext --inplace --werror
-          python setup.py install
+          python setup.py develop
         env:
           TILEDB_FORCE_ALL_DEPS: True
 

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Build TileDB-Py
         run: |
           python setup.py build_ext --inplace --werror
-          python setup.py install
+          python setup.py develop
         env:
           TILEDB_FORCE_ALL_DEPS: True
 

--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -13,7 +13,7 @@ numpy>=1.23.2 ; python_version >= "3.11"
 cmake >= 3.21, < 3.22
 cython >= 0.27
 pybind11 >= 2.6.2
-setuptools>=42,<=59.4.0
+setuptools>=42,<=58.4.0
 setuptools_scm >= 1.5.4
 wheel >= 0.30
 contextvars ;python_version<"3.7"

--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -13,7 +13,7 @@ numpy>=1.23.2 ; python_version >= "3.11"
 cmake >= 3.21, < 3.22
 cython >= 0.27
 pybind11 >= 2.6.2
-setuptools>=42,<=59.5.0
+setuptools>=42,<=59.4.0
 setuptools_scm >= 1.5.4
 wheel >= 0.30
 contextvars ;python_version<"3.7"

--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -13,7 +13,7 @@ numpy>=1.23.2 ; python_version >= "3.11"
 cmake >= 3.21, < 3.22
 cython >= 0.27
 pybind11 >= 2.6.2
-setuptools>=42,<=58.4.0
+setuptools>=42,<=58.3.0
 setuptools_scm >= 1.5.4
 wheel >= 0.30
 contextvars ;python_version<"3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 
 # https://askubuntu.com/a/1407138
-# we encounter the above error in versions of setuptools<=59.4.0
-requires = ["setuptools>=42,<=59.4.0", "wheel", "pybind11>=2.6.2"]
+# we encounter the above error in versions of setuptools<=58.4.0
+requires = ["setuptools>=42,<=58.4.0", "wheel", "pybind11>=2.6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 
 # https://askubuntu.com/a/1407138
-# we encounter the above error in versions of setuptools<=58.4.0
-requires = ["setuptools>=42,<=58.4.0", "wheel", "pybind11>=2.6.2"]
+# we encounter the above error in versions of setuptools<=58.3.0
+requires = ["setuptools>=42,<=58.3.0", "wheel", "pybind11>=2.6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=42,<=59.5.0", "wheel", "pybind11>=2.6.2"]
+
+# https://askubuntu.com/a/1407138
+# we encounter the above error in versions of setuptools<=59.4.0
+requires = ["setuptools>=42,<=59.4.0", "wheel", "pybind11>=2.6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ numpy >= 1.16.5
 cmake >= 3.23
 cython >= 0.27
 pybind11 >= 2.6.2
-setuptools>=42,<=59.4.0
+setuptools>=42,<=58.4.0
 setuptools_scm >= 1.5.4
 wheel >= 0.30
 contextvars ;python_version<"3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ numpy >= 1.16.5
 cmake >= 3.23
 cython >= 0.27
 pybind11 >= 2.6.2
-setuptools>=42,<=59.5.0
+setuptools>=42,<=59.4.0
 setuptools_scm >= 1.5.4
 wheel >= 0.30
 contextvars ;python_version<"3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ numpy >= 1.16.5
 cmake >= 3.23
 cython >= 0.27
 pybind11 >= 2.6.2
-setuptools>=42,<=58.4.0
+setuptools>=42,<=58.3.0
 setuptools_scm >= 1.5.4
 wheel >= 0.30
 contextvars ;python_version<"3.7"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from pybind11.setup_helpers import Pybind11Extension
 ### DO NOT USE ON CI
 
 # Target branch: Note that this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.13.0"
+TILEDB_VERSION = "dev"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from pybind11.setup_helpers import Pybind11Extension
 ### DO NOT USE ON CI
 
 # Target branch: Note that this should be set to the current core release, not `dev`
-TILEDB_VERSION = "dev"
+TILEDB_VERSION = "2.13.0"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION


### PR DESCRIPTION
* On macOS with Python 3.11, using `python setup.py install` to build from source errors out. Replace with using `develop` instead