### PR TITLE
Use subarray API to set ranges

### DIFF
--- a/tiledb/cc/query.cc
+++ b/tiledb/cc/query.cc
@@ -208,8 +208,13 @@ void init_query(py::module &m) {
 
              // Use the C API here because we are doing typecheck
              auto ctx = q.ctx(); // NB this requires libtiledb >=2.6
-             ctx.handle_error(tiledb_query_set_subarray(
-                 ctx.ptr().get(), q.ptr().get(), const_cast<void *>(a.data())));
+             tiledb_subarray_t *subarray;
+             ctx.handle_error(tiledb_query_get_subarray_t(
+                 ctx.ptr().get(), q.ptr().get(), &subarray));
+             ctx.handle_error(tiledb_subarray_set_subarray(
+                 ctx.ptr().get(), subarray, const_cast<void *>(a.data())));
+             ctx.handle_error(tiledb_query_set_subarray_t(
+                 ctx.ptr().get(), q.ptr().get(), subarray));
            })
       //.def("add_range", ([](Query& this, uint32_t dim_idx, py::object,
       // py::object) {

--- a/tiledb/cc/query.cc
+++ b/tiledb/cc/query.cc
@@ -208,7 +208,7 @@ void init_query(py::module &m) {
 
              // Use the C API here because we are doing typecheck
              auto ctx = q.ctx(); // NB this requires libtiledb >=2.6
-             tiledb_subarray_t *subarray;
+             tiledb_subarray_t *subarray = nullptr;
              ctx.handle_error(tiledb_query_get_subarray_t(
                  ctx.ptr().get(), q.ptr().get(), &subarray));
              ctx.handle_error(tiledb_subarray_set_subarray(

--- a/tiledb/indexing.pyx
+++ b/tiledb/indexing.pyx
@@ -321,6 +321,14 @@ cpdef multi_index(Array array, tuple attr_names, tuple ranges,
     # we loop over the range tuple left to right and apply
     # (unspecified dimensions are excluded)
     cdef Py_ssize_t dim_idx, range_idx
+    cdef tiledb_subarray_t* subarray_ptr = NULL
+    cdef bint is_default = True
+
+    rc = tiledb_subarray_alloc(ctx_ptr, array_ptr, &subarray_ptr)
+    if rc != TILEDB_OK:
+        tiledb_subarray_free(&subarray_ptr)
+        tiledb_query_free(&query_ptr)
+        _raise_ctx_err(ctx_ptr, rc)
 
     for dim_idx in range(len(ranges)):
         c_dim_idx = <uint32_t>dim_idx
@@ -330,8 +338,11 @@ cpdef multi_index(Array array, tuple attr_names, tuple ranges,
         if len(dim_ranges) == 0:
             continue
 
+        is_default = False
         for range_idx in range(len(dim_ranges)):
             if len(dim_ranges[range_idx]) != 2:
+                tiledb_subarray_free(&subarray_ptr)
+                tiledb_query_free(&query_ptr)
                 raise lt.TileDBError("internal error: invalid sub-range: ", dim_ranges[range_idx])
 
             start = np.array(dim_ranges[range_idx][0], dtype=dim.dtype)
@@ -340,14 +351,21 @@ cpdef multi_index(Array array, tuple attr_names, tuple ranges,
             start_ptr = np.PyArray_DATA(start)
             end_ptr = np.PyArray_DATA(end)
 
-            rc = tiledb_query_add_range(ctx_ptr, query_ptr,
-                                        dim_idx,
-                                        start_ptr,
-                                        end_ptr,
-                                        NULL)
+            rc = tiledb_subarray_add_range(
+                    ctx_ptr, subarray_ptr, dim_idx, start_ptr, end_ptr, NULL)
 
             if rc != TILEDB_OK:
+                tiledb_subarray_free(&subarray_ptr)
+                tiledb_query_free(&query_ptr)
                 _raise_ctx_err(ctx_ptr, rc)
+
+        if not is_default:
+            rc = tiledb_query_set_subarray_t(ctx_ptr, query_ptr, subarray_ptr)
+            if rc != TILEDB_OK:
+                tiledb_subarray_free(&subarray_ptr)
+                tiledb_query_free(&query_ptr)
+                _raise_ctx_err(ctx_ptr, rc)
+
     try:
         if coords is None:
             coords = True

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -775,21 +775,6 @@ cdef extern from "tiledb/tiledb.h":
         uint64_t* t1,
         uint64_t* t2)
 
-    int tiledb_query_get_range(
-        tiledb_ctx_t* ctx,
-        const tiledb_query_t* query,
-        uint32_t dim_idx,
-        uint64_t range_idx,
-        const void** start,
-        const void** end,
-        const void** stride)
-
-    int tiledb_query_get_range_num(
-        tiledb_ctx_t* ctx,
-        const tiledb_query_t* query,
-        uint32_t dim_idx,
-        uint64_t * range_num)
-
     int tiledb_query_get_est_result_size(
         tiledb_ctx_t* ctx,
         const tiledb_query_t* query,
@@ -832,28 +817,6 @@ cdef extern from "tiledb/tiledb.h":
         uint64_t start_size,
         const void* end,
         uint64_t end_size)
-
-    int tiledb_subarray_get_range_num(
-        tiledb_ctx_t* ctx,
-        const tiledb_subarray_t* subarray,
-        uint32_t dim_idx,
-        uint64_t* range_num)
-
-    int tiledb_subarray_get_range_var_size(
-        tiledb_ctx_t* ctx,
-        const tiledb_subarray_t* subarray,
-        uint32_t dim_idx,
-        uint64_t range_idx,
-        uint64_t* start_size,
-        uint64_t* end_size)
-
-    int tiledb_subarray_get_range_var(
-        tiledb_ctx_t* ctx,
-        const tiledb_subarray_t* subarray,
-        uint32_t dim_idx,
-        uint64_t range_idx,
-        void* start,
-        void* end)
 
     int tiledb_subarray_set_subarray(
         tiledb_ctx_t* ctx,

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -653,11 +653,6 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_query_type_t query_type,
         tiledb_query_t** query)
 
-    int tiledb_query_set_subarray(
-        tiledb_ctx_t* ctx,
-        tiledb_query_t* query,
-        const void* subarray)
-
     int tiledb_query_set_subarray_t(
         tiledb_ctx_t* ctx,
         tiledb_query_t* query,

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -775,23 +775,6 @@ cdef extern from "tiledb/tiledb.h":
         uint64_t* t1,
         uint64_t* t2)
 
-    int tiledb_query_add_range(
-        tiledb_ctx_t* ctx,
-        tiledb_query_t* query,
-        uint32_t dim_idx,
-        const void * start,
-        const void * end,
-        const void * stride)
-
-    int tiledb_query_add_range_var(
-        tiledb_ctx_t* ctx,
-        tiledb_query_t* query,
-        uint32_t dim_idx,
-        const void * start,
-        uint64_t start_size,
-        const void * end,
-        uint64_t end_size)
-
     int tiledb_query_get_range(
         tiledb_ctx_t* ctx,
         const tiledb_query_t* query,

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -141,6 +141,8 @@ cdef extern from "tiledb/tiledb.h":
         pass
     ctypedef struct tiledb_query_t:
         pass
+    ctypedef struct tiledb_subarray_t:
+        pass
     ctypedef struct tiledb_filter_list_t:
         pass
     ctypedef struct tiledb_vfs_t:
@@ -458,7 +460,7 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_ctx_t* ctx,
         tiledb_array_schema_t* array_schema,
         tiledb_filter_list_t* filter_list)
-    
+
     int tiledb_array_schema_set_validity_filter_list(
         tiledb_ctx_t* ctx,
         tiledb_array_schema_t* array_schema,
@@ -505,7 +507,7 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_ctx_t* ctx,
         const tiledb_array_schema_t* array_schema,
         tiledb_filter_list_t** filter_list)
-    
+
     int tiledb_array_schema_get_validity_filter_list(
         tiledb_ctx_t* ctx,
         tiledb_array_schema_t* array_schema,
@@ -557,10 +559,10 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_ctx_t* ctx,
         const tiledb_array_schema_t* array_schema,
         FILE* out)
-    
+
     int tiledb_array_schema_get_version(
         tiledb_ctx_t* ctx,
-        tiledb_array_schema_t* array_schema, 
+        tiledb_array_schema_t* array_schema,
         uint32_t* version)
 
     int tiledb_array_get_open_timestamp_start(
@@ -638,10 +640,10 @@ cdef extern from "tiledb/tiledb.h":
         const void* encryption_key,
         uint32_t key_length,
         tiledb_config_t* config) nogil
-    
+
     int tiledb_array_delete_array(
-        tiledb_ctx_t* ctx, 
-        tiledb_array_t* array, 
+        tiledb_ctx_t* ctx,
+        tiledb_array_t* array,
         const char* uri) nogil
 
     # Query
@@ -655,6 +657,11 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_ctx_t* ctx,
         tiledb_query_t* query,
         const void* subarray)
+
+    int tiledb_query_set_subarray_t(
+        tiledb_ctx_t* ctx,
+        tiledb_query_t* query,
+        const tiledb_subarray_t*)
 
     int tiledb_query_set_buffer(
         tiledb_ctx_t* ctx,
@@ -740,6 +747,11 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_query_t* query,
         tiledb_query_status_t* status)
 
+    int tiledb_query_get_subarray_t(
+        tiledb_ctx_t* ctx,
+        const tiledb_query_t* query,
+        tiledb_subarray_t** subarray)
+
     int tiledb_query_get_type(
         tiledb_ctx_t* ctx,
         tiledb_query_t* query,
@@ -816,7 +828,59 @@ cdef extern from "tiledb/tiledb.h":
     int tiledb_query_get_stats(
         tiledb_ctx_t* ctx,
         tiledb_query_t* query,
-        char** stats_json);
+        char** stats_json)
+
+    # Subarray
+    int tiledb_subarray_alloc(
+        tiledb_ctx_t* ctx,
+        const tiledb_array_t* array,
+        tiledb_subarray_t** subarray)
+
+    void tiledb_subarray_free(tiledb_subarray_t** subarray)
+
+    int tiledb_subarray_add_range(
+        tiledb_ctx_t* ctx,
+        tiledb_subarray_t* subarray,
+        uint32_t dim_idx,
+        const void* start,
+        const void* end,
+        const void* stride)
+
+    int tiledb_subarray_add_range_var(
+        tiledb_ctx_t* ctx,
+        tiledb_subarray_t* subarray,
+        uint32_t dim_idx,
+        const void* start,
+        uint64_t start_size,
+        const void* end,
+        uint64_t end_size)
+
+    int tiledb_subarray_get_range_num(
+        tiledb_ctx_t* ctx,
+        const tiledb_subarray_t* subarray,
+        uint32_t dim_idx,
+        uint64_t* range_num)
+
+    int tiledb_subarray_get_range_var_size(
+        tiledb_ctx_t* ctx,
+        const tiledb_subarray_t* subarray,
+        uint32_t dim_idx,
+        uint64_t range_idx,
+        uint64_t* start_size,
+        uint64_t* end_size)
+
+    int tiledb_subarray_get_range_var(
+        tiledb_ctx_t* ctx,
+        const tiledb_subarray_t* subarray,
+        uint32_t dim_idx,
+        uint64_t range_idx,
+        void* start,
+        void* end)
+
+    int tiledb_subarray_set_subarray(
+        tiledb_ctx_t* ctx,
+        tiledb_subarray_t* subarray,
+        const void* subarray_v)
 
     # Array
     int tiledb_array_alloc(
@@ -1170,12 +1234,12 @@ cdef extern from "tiledb/tiledb_experimental.h":
         tiledb_ctx_t* ctx,
         const char* uri,
         tiledb_array_schema_t** array_schema) nogil
-    
+
     int tiledb_array_upgrade_version(
-        tiledb_ctx_t* ctx, 
-        const char* array_uri, 
+        tiledb_ctx_t* ctx,
+        const char* array_uri,
         tiledb_config_t* config) nogil
-    
+
     int tiledb_array_consolidate_fragments(
         tiledb_ctx_t* ctx,
         const char* array_uri,

--- a/tiledb/tests/test_serialization.cc
+++ b/tiledb/tests/test_serialization.cc
@@ -45,13 +45,17 @@ public:
     if (array == nullptr)
       TPY_ERROR_LOC("Invalid array pointer.");
 
-    tiledb_query_t *query;
-
-    uint32_t subarray[] = {3, 7};
+    uint32_t subarray_v[] = {3, 7};
     int64_t data[5];
     uint64_t data_size = sizeof(data);
+
+    tiledb_subarray_t *subarray;
+    tiledb_subarray_alloc(ctx, array, &subarray);
+    tiledb_subarray_set_subarray(ctx, subarray, &subarray_v);
+
+    tiledb_query_t *query;
     tiledb_query_alloc(ctx, array, TILEDB_READ, &query);
-    tiledb_query_set_subarray(ctx, query, subarray);
+    tiledb_query_set_subarray_t(ctx, query, subarray);
     tiledb_query_set_layout(ctx, query, TILEDB_UNORDERED);
     tiledb_query_set_buffer(ctx, query, "", data, &data_size);
 
@@ -77,6 +81,7 @@ public:
 
     tiledb_buffer_free(&buff);
     tiledb_buffer_list_free(&buff_list);
+    tiledb_subarray_free(&subarray);
     tiledb_query_free(&query);
 
     return output;


### PR DESCRIPTION
Remove deprecated query C-API functions and replace them with the equivalent subarray C-API functions.