### PR TITLE
Modify `WebP` Test Inputs To Match Dims With `ArraySchema`

### DIFF
--- a/tiledb/fragment.cc
+++ b/tiledb/fragment.cc
@@ -122,15 +122,6 @@ private:
     }
   }
 
-  void load(tiledb_encryption_type_t encryption_type,
-            const string &encryption_key) const {
-    try {
-      fi_->load(encryption_type, encryption_key);
-    } catch (TileDBError &e) {
-      TPY_ERROR_LOC(e.what());
-    }
-  }
-
   void close() { fi_.reset(); }
 
   py::tuple fill_uri() const {

--- a/tiledb/tests/test_webp.py
+++ b/tiledb/tests/test_webp.py
@@ -127,7 +127,7 @@ def test_webp_filter(width, height, colorspace, lossless):
         3 if int(colorspace) < int(tiledb.filter.lt.WebpInputFormat.WEBP_RGBA) else 4
     )
     data = make_image_data(width, height, pixel_depth)
-    data = np.array(data, dtype=np.uint8)
+    data = np.array(data, dtype=np.uint8).reshape(height, width * pixel_depth)
 
     y_tile = round(height / 2)
     x_tile = round(width / 2) * pixel_depth


### PR DESCRIPTION
* We now check to ensure NumPy array inputs match the dimensions in the
  `ArraySchema` for dense writes as of https://github.com/TileDB-Inc/TileDB-Py/pull/1514