### PR TITLE
Allow discovery of non-ASCII dataframe attributes

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -244,7 +244,7 @@ cdef _write_array(tiledb_ctx_t* ctx_ptr,
             try:
                 values[i] = np.asarray(values[i], dtype=np.bytes_)
             except Exception as exc:
-                raise TileDBError(f'dtype of attr {tiledb_array.schema.attr[i].name} is "ascii" but attr_val contains invalid ASCII characters')
+                raise TileDBError(f'dtype of attr {tiledb_array.schema.attr(i).name} is "ascii" but attr_val contains invalid ASCII characters')
 
         attr = tiledb_array.schema.attr(i)
 

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -244,7 +244,7 @@ cdef _write_array(tiledb_ctx_t* ctx_ptr,
             try:
                 values[i] = np.asarray(values[i], dtype=np.bytes_)
             except Exception as exc:
-                raise TileDBError(f'Attr\'s dtype is "ascii" but attr_val contains invalid ASCII characters')
+                raise TileDBError(f'dtype of attr {tiledb_array.schema.attr[i].name} is "ascii" but attr_val contains invalid ASCII characters')
 
         attr = tiledb_array.schema.attr(i)
 
@@ -4098,7 +4098,7 @@ def _setitem_impl_sparse(self: Array, selection, val, dict nullmaps):
             try:
                 np.asarray(attr_val, dtype=np.bytes_)
             except Exception as exc:
-                raise TileDBError(f'Attr\'s dtype is "ascii" but attr_val contains invalid ASCII characters')
+                raise TileDBError(f'dtype of attr {attr.name} is "ascii" but attr_val contains invalid ASCII characters')
 
         ncells = sparse_coords[0].shape[0]
         if attr_val.size != ncells:


### PR DESCRIPTION
During ingest of a mutli-GB dataset I found this error:

```
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/annotation_dataframe.py", line 463, in from_dataframe
    raise e
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/annotation_dataframe.py", line 444, in from_dataframe
    tiledb.from_pandas(
  File "/home/ubuntu/git/TileDB-Inc/TileDB-Py/tiledb/dataframe_.py", line 451, in from_pandas
    _from_pandas(uri, dataframe, tiledb_args)
  File "/home/ubuntu/git/TileDB-Inc/TileDB-Py/tiledb/dataframe_.py", line 523, in _from_pandas
    _write_array(
  File "/home/ubuntu/git/TileDB-Inc/TileDB-Py/tiledb/dataframe_.py", line 607, in _write_array
    libtiledb._setitem_impl_sparse(A, tuple(coords), write_dict, nullmaps)
  File "tiledb/libtiledb.pyx", line 4068, in tiledb.libtiledb._setitem_impl_sparse
tiledb.cc.TileDBError: Attr's dtype is "ascii" but attr_val contains invalid ASCII characters
```

The input data (a `pandas.DataFrame` from a single-cell H5AD file) has 29 attributes and this error message makes it difficult to tell which one of them is at fault.

With this PR we now get this:

```
  File "<stdin>", line 1, in <module>
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/annotation_dataframe.py", line 463, in from_dataframe
    raise e
  File "/home/ubuntu/git/single-cell-data/TileDB-SOMA/apis/python/src/tiledbsoma/annotation_dataframe.py", line 444, in from_dataframe
    tiledb.from_pandas(
  File "/home/ubuntu/git/TileDB-Inc/TileDB-Py/tiledb/dataframe_.py", line 451, in from_pandas
    _from_pandas(uri, dataframe, tiledb_args)
  File "/home/ubuntu/git/TileDB-Inc/TileDB-Py/tiledb/dataframe_.py", line 523, in _from_pandas
    _write_array(
  File "/home/ubuntu/git/TileDB-Inc/TileDB-Py/tiledb/dataframe_.py", line 607, in _write_array
    libtiledb._setitem_impl_sparse(A, tuple(coords), write_dict, nullmaps)
  File "tiledb/libtiledb.pyx", line 4068, in tiledb.libtiledb._setitem_impl_sparse
tiledb.cc.TileDBError: dtype of attr Comorbidities is "ascii" but attr_val contains invalid ASCII characters
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

which is more actionable.
