### PR TITLE
Use Safe `repr` If Parent Pybind11 Constructor Fails

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# In Progress
+
+## Bug Fixes
+* Introduce safe repr for classes for `Filter`, `FilterList`, `Dim`, `Domain`, and `Attr`
+
 # Release 0.19.1
 
 ## TileDB Embedded updates:

--- a/tiledb/attribute.py
+++ b/tiledb/attribute.py
@@ -96,7 +96,14 @@ class Attr(lt.Attribute):
 
         var = var or False
 
-        super().__init__(self._ctx, name, tiledb_dtype)
+        try:
+            super().__init__(self._ctx, name, tiledb_dtype)
+        except lt.TileDBError as e:
+            # we set this here because if the super().__init__() constructor above
+            # fails, we want to check if self._ctx is None in __repr__ so we can
+            # perform a safe repr
+            self._ctx = None
+            raise lt.TileDBError(e) from None
 
         if _ncell:
             self._ncell = _ncell
@@ -235,6 +242,10 @@ class Attr(lt.Attribute):
         return self._tiledb_dtype == lt.DataType.STRING_ASCII
 
     def __repr__(self):
+        # use safe repr if pybind11 constructor failed
+        if self._ctx is None:
+            return object.__repr__(self)
+
         filters_str = ""
         if self.filters:
             filters_str = ", filters=FilterList(["

--- a/tiledb/tests/test_dimension.py
+++ b/tiledb/tests/test_dimension.py
@@ -110,3 +110,7 @@ class DimensionTest(unittest.TestCase):
             "shape only valid for integer and datetime dimension domains",
         ):
             dim.shape
+
+    @pytest.mark.xfail
+    def test_fail_on_0_extent(self):
+        tiledb.Dim(domain=(0, 10), tile=0)


### PR DESCRIPTION
* This fixes a larger scale issue that was originally caught in the SOMA unit tests https://github.com/single-cell-data/TileDB-SOMA/pull/653
* When the parent Pybind11 constructor fails, Pytest prints a backtrace of all the arguments in `super().__init__()` which includes the `self` object. Since the object does not exist, using the Pybind11 wrapped properties, namely `_filters`, results in a segfault
* We use `self._ctx`, which is a property that only exists on the pure Python object, to check if the object has been properly instantiated