### PR TITLE
CtxMixin classmethods

### DIFF
--- a/tiledb/attribute.py
+++ b/tiledb/attribute.py
@@ -27,28 +27,19 @@ class Attr(CtxMixin, lt.Attribute):
         filters: Union[FilterList, Sequence[Filter]] = None,
         ctx: "Ctx" = None,
         _lt_obj: lt.Attribute = None,
-        _capsule: "PyCapsule" = None,
     ):
         """Class representing a TileDB array attribute.
 
-        :param tiledb.Ctx ctx: A TileDB Context
-        :param str name: Attribute name, empty if anonymous
-        :param dtype: Attribute value datatypes
-        :type dtype: numpy.dtype object or type or string
-        :param nullable: Attribute is nullable
-        :type bool:
-        :param fill: Fill value for unset cells.
+        :param name: Attribute name, empty if anonymous
+        :param dtype: Attribute value datatype
+        :param fill: Fill value for unset cells
         :param var: Attribute is variable-length (automatic for byte/string types)
-        :type dtype: bool
+        :param nullable: Attribute is nullable
         :param filters: List of filters to apply
-        :type filters: FilterList
+        :param ctx: A TileDB Context
         :raises TypeError: invalid dtype
-        :raises: :py:exc:`tiledb.TileDBError`
-
+        :raises tiledb.TileDBError:
         """
-        if _capsule is not None:
-            return super().__init__(ctx, _capsule)
-
         if _lt_obj is not None:
             return super().__init__(ctx, _lt_obj=_lt_obj)
 

--- a/tiledb/attribute.py
+++ b/tiledb/attribute.py
@@ -26,7 +26,6 @@ class Attr(CtxMixin, lt.Attribute):
         nullable: bool = False,
         filters: Union[FilterList, Sequence[Filter]] = None,
         ctx: "Ctx" = None,
-        _lt_obj: lt.Attribute = None,
     ):
         """Class representing a TileDB array attribute.
 
@@ -40,9 +39,6 @@ class Attr(CtxMixin, lt.Attribute):
         :raises TypeError: invalid dtype
         :raises tiledb.TileDBError:
         """
-        if _lt_obj is not None:
-            return super().__init__(ctx, _lt_obj=_lt_obj)
-
         _dtype = None
         if isinstance(dtype, str) and dtype == "ascii":
             tiledb_dtype = lt.DataType.STRING_ASCII
@@ -162,7 +158,7 @@ class Attr(CtxMixin, lt.Attribute):
         :raises: :py:exc:`tiledb.TileDBError`
 
         """
-        return FilterList(ctx=self._ctx, _lt_obj=self._filters)
+        return FilterList.from_pybind11(self._ctx, self._filters)
 
     def _get_fill(self, value, dtype) -> Any:
         if dtype in (lt.DataType.CHAR, lt.DataType.BLOB):

--- a/tiledb/ctx.py
+++ b/tiledb/ctx.py
@@ -52,15 +52,10 @@ class Config(lt.Config):
     :param str path: Set parameter values from persisted Config parameter file
     """
 
-    def __init__(self, params: dict = None, path: str = None, _lt_obj=None):
-        if _lt_obj is not None:
-            return super().__init__(_lt_obj)
-
+    def __init__(self, params: dict = None, path: str = None):
         super().__init__()
-
         if path is not None:
             self.load(path)
-
         if params is not None:
             self.update(params)
 
@@ -356,7 +351,10 @@ class Ctx(lt.Context):
 
     def config(self):
         """Returns the Config instance associated with the Ctx."""
-        return Config(_lt_obj=super().config())
+        new = Config.__new__(Config)
+        # bypass calling Config.__init__, call lt.Config.__init__ instead
+        lt.Config.__init__(new, super().config())
+        return new
 
     def set_tag(self, key: str, value: str):
         """Sets a (string, string) "tag" on the Ctx (internal)."""

--- a/tiledb/ctx.py
+++ b/tiledb/ctx.py
@@ -413,6 +413,14 @@ class CtxMixin:
         # we don't want to set self._ctx
         self._ctx = ctx
 
+    @classmethod
+    def from_capsule(cls, ctx, capsule):
+        """Create an instance of this class from a PyCapsule instance"""
+        self = cls.__new__(cls)
+        # bypass cls.__init__ to call the __init__ of the superclass via CtxMixin.__init__
+        CtxMixin.__init__(self, ctx, capsule)
+        return self
+
 
 def check_ipykernel_warn_once():
     """

--- a/tiledb/dimension.py
+++ b/tiledb/dimension.py
@@ -91,28 +91,20 @@ class Dim(CtxMixin, lt.Dimension):
         dtype: np.dtype = np.uint64,
         var: bool = None,
         ctx: "Ctx" = None,
-        _lt_obj: lt.Dimension = None,
     ):
         """Class representing a dimension of a TileDB Array.
 
-        :param str name: the dimension name, empty if anonymous
-        :param domain:
-        :type domain: tuple(int, int) or tuple(float, float)
+        :param name: Dimension name, empty if anonymous
+        :param domain: TileDB domain
         :param tile: Tile extent
-        :type tile: int or float
         :param filters: List of filters to apply
-        :type filters: FilterList
-        :dtype: the Dim numpy dtype object, type object, or string \
-            that can be corerced into a numpy dtype object
+        :param dtype: Dimension value datatype
+        :param var: Dimension is variable-length (automatic for byte/string types)
+        :param ctx: A TileDB Context
         :raises ValueError: invalid domain or tile extent
         :raises TypeError: invalid domain, tile extent, or dtype type
-        :raises: :py:exc:`TileDBError`
-        :param tiledb.Ctx ctx: A TileDB Context
-
+        :raises tiledb.TileDBError:
         """
-        if _lt_obj is not None:
-            return super().__init__(ctx, _lt_obj=_lt_obj)
-
         if var is not None:
             if var and np.dtype(dtype) not in (np.str_, np.bytes_):
                 raise TypeError("'var=True' specified for non-str/bytes dtype")
@@ -288,7 +280,7 @@ class Dim(CtxMixin, lt.Dimension):
         :raises: :py:exc:`tiledb.TileDBError`
 
         """
-        return FilterList(ctx=self._ctx, _lt_obj=self._filters)
+        return FilterList.from_pybind11(self._ctx, self._filters)
 
     @property
     def shape(self) -> Tuple["np.generic", "np.generic"]:

--- a/tiledb/domain.py
+++ b/tiledb/domain.py
@@ -17,12 +17,7 @@ class Domain(CtxMixin, lt.Domain):
     Represents a TileDB domain.
     """
 
-    def __init__(
-        self,
-        *dims: Dim,
-        ctx: "Ctx" = None,
-        _lt_obj: lt.Domain = None,
-    ):
+    def __init__(self, *dims: Dim, ctx: "Ctx" = None):
         """Class representing the domain of a TileDB Array.
 
         :param *dims*: one or more tiledb.Dim objects up to the Domain's ndim
@@ -30,9 +25,6 @@ class Domain(CtxMixin, lt.Domain):
         :raises TypeError: All dimensions must have the same dtype
         :raises tiledb.TileDBError:
         """
-        if _lt_obj is not None:
-            return super().__init__(ctx, _lt_obj=_lt_obj)
-
         super().__init__(ctx)
 
         # support passing a list of dims without splatting
@@ -100,7 +92,7 @@ class Domain(CtxMixin, lt.Domain):
 
     def __iter__(self):
         """Returns a generator object that iterates over the domain's dimension objects"""
-        return (Dim(_lt_obj=self._dim(i)) for i in range(self.ndim))
+        return (Dim.from_pybind11(self._ctx, self._dim(i)) for i in range(self.ndim))
 
     def __eq__(self, other):
         """Returns true if Domain is equal to self.
@@ -193,8 +185,7 @@ class Domain(CtxMixin, lt.Domain):
             raise ValueError(
                 f"Unsupported dim identifier: '{dim_id!r}' (expected int or str)"
             )
-
-        return Dim(_lt_obj=self._dim(dim_id))
+        return Dim.from_pybind11(self._ctx, self._dim(dim_id))
 
     def has_dim(self, name):
         """

--- a/tiledb/domain.py
+++ b/tiledb/domain.py
@@ -22,19 +22,14 @@ class Domain(CtxMixin, lt.Domain):
         *dims: Dim,
         ctx: "Ctx" = None,
         _lt_obj: lt.Domain = None,
-        _capsule: "PyCapsule" = None,
     ):
         """Class representing the domain of a TileDB Array.
 
         :param *dims*: one or more tiledb.Dim objects up to the Domain's ndim
+        :param ctx: A TileDB Context
         :raises TypeError: All dimensions must have the same dtype
-        :raises: :py:exc:`TileDBError`
-        :param tiledb.Ctx ctx: A TileDB Context
-
+        :raises tiledb.TileDBError:
         """
-        if _capsule is not None:
-            return super().__init__(ctx, _capsule)
-
         if _lt_obj is not None:
             return super().__init__(ctx, _lt_obj=_lt_obj)
 

--- a/tiledb/filter.py
+++ b/tiledb/filter.py
@@ -737,21 +737,18 @@ class FilterList(CtxMixin, lt.FilterList):
         chunksize: int = None,
         ctx: "Ctx" = None,
         _lt_obj: lt.FilterList = None,
-        _capsule: "PyCapsule" = None,
     ):
-        if _capsule is not None:
-            super().__init__(ctx, _capsule)
-        elif _lt_obj is not None:
-            super().__init__(ctx, _lt_obj=_lt_obj)
-        else:
-            super().__init__(ctx)
-            if filters is not None:
-                for f in filters:
-                    if not isinstance(f, Filter):
-                        raise ValueError(
-                            "filters argument must be an iterable of TileDB filter objects"
-                        )
-                    self._add_filter(f)
+        if _lt_obj is not None:
+            return super().__init__(ctx, _lt_obj=_lt_obj)
+
+        super().__init__(ctx)
+        if filters is not None:
+            for f in filters:
+                if not isinstance(f, Filter):
+                    raise ValueError(
+                        "filters argument must be an iterable of TileDB filter objects"
+                    )
+                self._add_filter(f)
         if chunksize is not None:
             self._chunksize = chunksize
 

--- a/tiledb/filter.py
+++ b/tiledb/filter.py
@@ -732,15 +732,8 @@ class FilterList(CtxMixin, lt.FilterList):
     }
 
     def __init__(
-        self,
-        filters: Sequence[Filter] = None,
-        chunksize: int = None,
-        ctx: "Ctx" = None,
-        _lt_obj: lt.FilterList = None,
+        self, filters: Sequence[Filter] = None, chunksize: int = None, ctx: "Ctx" = None
     ):
-        if _lt_obj is not None:
-            return super().__init__(ctx, _lt_obj=_lt_obj)
-
         super().__init__(ctx)
         if filters is not None:
             for f in filters:

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1316,8 +1316,7 @@ cdef class ArraySchema(object):
         check_error(self.ctx,
             tiledb_array_schema_get_offsets_filter_list(
                 ctx_ptr, self.ptr, &filter_list_ptr))
-        return FilterList(self.ctx,
-            _capsule=PyCapsule_New(filter_list_ptr, "fl", NULL))
+        return FilterList.from_capsule(self.ctx, PyCapsule_New(filter_list_ptr, "fl", NULL))
 
     @property
     def coords_filters(self):
@@ -1331,8 +1330,7 @@ cdef class ArraySchema(object):
         check_error(self.ctx,
             tiledb_array_schema_get_coords_filter_list(
                 ctx_ptr, self.ptr, &filter_list_ptr))
-        return FilterList(self.ctx,
-            _capsule=PyCapsule_New(filter_list_ptr, "fl", NULL))
+        return FilterList.from_capsule(self.ctx, PyCapsule_New(filter_list_ptr, "fl", NULL))
 
     @coords_filters.setter
     def coords_filters(self, value):
@@ -1354,8 +1352,7 @@ cdef class ArraySchema(object):
         check_error(self.ctx,
             tiledb_array_schema_get_validity_filter_list(
                 ctx_ptr, self.ptr, &validity_list_ptr))
-        return FilterList(self.ctx,
-            _capsule=PyCapsule_New(validity_list_ptr, "fl", NULL))
+        return FilterList.from_capsule(self.ctx, PyCapsule_New(validity_list_ptr, "fl", NULL))
 
     @property
     def domain(self):
@@ -1369,7 +1366,7 @@ cdef class ArraySchema(object):
         cdef tiledb_ctx_t* ctx_ptr = safe_ctx_ptr(self.ctx)
         check_error(self.ctx,
                     tiledb_array_schema_get_domain(ctx_ptr, self.ptr, &dom))
-        return Domain(self.ctx, _capsule=PyCapsule_New(dom, "dom", NULL))
+        return Domain.from_capsule(self.ctx, PyCapsule_New(dom, "dom", NULL))
 
     @property
     def nattr(self):
@@ -1444,7 +1441,7 @@ cdef class ArraySchema(object):
         check_error(self.ctx,
                     tiledb_array_schema_get_attribute_from_name(
                         ctx_ptr, self.ptr, bname, &attr_ptr))
-        return Attr(self.ctx, _capsule=PyCapsule_New(attr_ptr, "attr", NULL))
+        return Attr.from_capsule(self.ctx, PyCapsule_New(attr_ptr, "attr", NULL))
 
     cdef _attr_idx(self, int idx):
         cdef tiledb_attribute_t* attr_ptr = NULL
@@ -1452,7 +1449,7 @@ cdef class ArraySchema(object):
         check_error(self.ctx,
                     tiledb_array_schema_get_attribute_from_index(
                         ctx_ptr, self.ptr, idx, &attr_ptr))
-        return Attr(self.ctx, _capsule=PyCapsule_New(attr_ptr, "attr", NULL))
+        return Attr.from_capsule(self.ctx, PyCapsule_New(attr_ptr, "attr", NULL))
 
     def attr(self, object key not None):
         """Returns an Attr instance given an int index or string label


### PR DESCRIPTION
Replace "private" constructor parameters (`_capsule`, `_lt_obv`) with `CtxMixin` classmethods (`from_capsule`, `from_pybind11`).Follow-up to https://github.com/TileDB-Inc/TileDB-Py/pull/1548.
