### PR TITLE
Use subarray to set ranges in PyQuery

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -554,12 +554,12 @@ def stats_dump(version=True, print_out=True, include_python=True, json=False, ve
             )
             stats_str += f"- Number of attributes read: {attr_num}\n"
 
-            read_compute_est_result_size = stats_json_core["timers"][
-                "Context.StorageManager.Query.Subarray.read_compute_est_result_size.sum"
-            ]
-            stats_str += (
-                f"- Time to compute estimated result size: {read_compute_est_result_size}\n"
-            )
+            read_compute_est_result_size = stats_json_core["timers"].get(
+                "Context.StorageManager.Query.Subarray.read_compute_est_result_size.sum")
+            if read_compute_est_result_size is not None:
+                stats_str += (
+                    f"- Time to compute estimated result size: {read_compute_est_result_size}\n"
+                )
 
             read_tiles = stats_json_core["timers"][
                 "Context.StorageManager.Query.Reader.read_tiles.sum"

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -45,7 +45,7 @@ class FixesTest(DiskTestCase):
             with tiledb.open(uri) as b:
                 q = tiledb.main.PyQuery(ctx3, b, ("",), (), 0, False)
                 q._return_incomplete = True
-                q.set_ranges([[(0, max_val)]])
+                q.set_ranges([[(0, max_val - 1)]])
                 q._allocate_buffers()
                 buffers = list(*q._get_buffers().values())
                 assert buffers[0].nbytes == max_val


### PR DESCRIPTION
Use a subarray to add ranges in PyQuery instead of deprecated `Query::add_range` calls.