### PR TITLE
Fix `Attr.fill` for UTF-8; add tests for UTF-8 Query Condition on dense arrays

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # In Progress 
 
 ## API Changes
-* Add support for UTF-8 Datatypes in query conditions []()
+* Add support for UTF-8 Datatypes in query conditions [#1594](https://github.com/TileDB-Inc/TileDB-Py/pull/1594)
 
 # Release 0.20.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,7 @@
 # In Progress 
 
-## API Changes
-* Add support for UTF-8 Datatypes in query conditions [#1594](https://github.com/TileDB-Inc/TileDB-Py/pull/1594)
+## Bug Fixes
+* Correct `Attr.fill` for UTF-8 [#1594](https://github.com/TileDB-Inc/TileDB-Py/pull/1594)
 
 # Release 0.20.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
+# In Progress 
+
+## API Changes
+* Add support for UTF-8 Datatypes in query conditions []()
+
 # Release 0.20.0
 
+## TileDB Embedded updates
 * TileDB-Py 0.20.0 includes TileDB Embedded [TileDB 2.14.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.14.0)
 
 ## Bug Fixes

--- a/tiledb/attribute.py
+++ b/tiledb/attribute.py
@@ -98,7 +98,10 @@ class Attr(CtxMixin, lt.Attribute):
                 self._filters = FilterList(filters)
 
         if fill is not None:
-            self._fill = np.array([fill], dtype=self.dtype)
+            if self._tiledb_dtype == lt.DataType.STRING_UTF8:
+                self._fill = np.array([fill.encode("utf-8")], dtype="S")
+            else:
+                self._fill = np.array([fill], dtype=self.dtype)
 
         if nullable is not None:
             self._nullable = nullable
@@ -163,6 +166,9 @@ class Attr(CtxMixin, lt.Attribute):
     def _get_fill(self, value, dtype) -> Any:
         if dtype in (lt.DataType.CHAR, lt.DataType.BLOB):
             return value.tobytes()
+
+        if dtype == lt.DataType.STRING_UTF8:
+            return b"".join(value).decode("utf-8")
 
         if tiledb_type_is_datetime(dtype):
             return value[0].astype(np.timedelta64)

--- a/tiledb/cc/common.cc
+++ b/tiledb/cc/common.cc
@@ -200,7 +200,7 @@ py::size_t get_ncells(py::dtype type) {
   if (type == py::dtype("S"))
     return type.itemsize() == 0 ? TILEDB_VAR_NUM : type.itemsize();
 
-  if (type == py::dtype("U")) {
+  if (type.is(py::dtype("U"))) {
     auto np_unicode_size = py::dtype("U").itemsize();
     return type.itemsize() == 0 ? TILEDB_VAR_NUM
                                 : type.itemsize() / np_unicode_size;

--- a/tiledb/tests/test_attribute.py
+++ b/tiledb/tests/test_attribute.py
@@ -36,7 +36,7 @@ class AttributeTest(DiskTestCase):
         "dtype, fill",
         [
             (np.dtype(bytes), b"abc"),
-            # (str, "defg"),
+            (str, "defg"),
             (np.float32, np.float32(0.4023573667780681)),
             (np.float64, np.float64(0.0560602549760851)),
             (np.dtype("M8[ns]"), np.timedelta64(11, "ns")),

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -6,7 +6,7 @@ import string
 from numpy.testing import assert_array_equal
 
 import tiledb
-from tiledb.tests.common import DiskTestCase, has_pandas
+from tiledb.tests.common import DiskTestCase, has_pandas, rand_utf8
 
 
 class QueryConditionTest(DiskTestCase):
@@ -19,6 +19,9 @@ class QueryConditionTest(DiskTestCase):
 
         if isinstance(mask, np.timedelta64):
             return data[np.invert(np.isnat(data))]
+
+        if isinstance(mask, (str, bytes)):
+            return data[np.invert(data == mask)]
 
         return data[data != mask]
 
@@ -34,6 +37,7 @@ class QueryConditionTest(DiskTestCase):
             tiledb.Attr(name="D", dtype=np.float64),
             tiledb.Attr(name="S", dtype=np.dtype("|S1"), var=False),
             tiledb.Attr(name="A", dtype="ascii", var=True),
+            tiledb.Attr(name="UTF", dtype=np.dtype("U"), var=True),
         ]
 
         schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=sparse)
@@ -45,7 +49,14 @@ class QueryConditionTest(DiskTestCase):
                 "I": np.random.randint(-5, 5, 10),
                 "D": np.random.rand(10),
                 "S": np.array(list(string.ascii_lowercase[:10]), dtype="|S1"),
-                "A": np.array(list(string.ascii_lowercase[:10]), dtype="|S1"),
+                "A": np.array(
+                    list(string.ascii_lowercase[i] * (i + 1) for i in range(10)),
+                    dtype="|S",
+                ),
+                "UTF": np.array(
+                    ["$", "£$", "€ह£$", "한ह£", "£$𐍈"]
+                    + [rand_utf8(np.random.randint(1, 100)) for _ in range(5)]
+                ),
             }
 
             if sparse:
@@ -204,13 +215,23 @@ class QueryConditionTest(DiskTestCase):
             assert len(result["A"]) == 1
             assert result["A"][0] == b"a"
 
+            for t in A.query(attrs=["UTF"])[:]["UTF"]:
+                cond = f"UTF == '{t}'"
+                result = A.query(cond=cond, attrs=["UTF"])[:]
+                assert result["UTF"] == t
+
     def test_string_dense(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=False)) as A:
-            result = A.query(cond="S == 'c'", attrs=["S"])[:]
+            result = A.query(cond="S == 'ccc'", attrs=["S"])[:]
             assert all(self.filter_dense(result["S"], A.attr("S").fill) == b"c")
 
-            result = A.query(cond="A == 'a'", attrs=["A"])[:]
-            assert all(self.filter_dense(result["A"], A.attr("A").fill) == b"a")
+            result = A.query(cond="A == 'ccc'", attrs=["A"])[:]
+            assert all(self.filter_dense(result["A"], A.attr("A").fill) == b"ccc")
+
+            for t in A.query(attrs=["UTF"])[:]["UTF"]:
+                cond = f"UTF == '{t}'"
+                result = A.query(cond=cond, attrs=["UTF"])[:]
+                assert all(self.filter_dense(result["UTF"], A.attr("UTF").fill) == t)
 
     def test_combined_types_sparse(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
@@ -692,7 +713,7 @@ class QueryConditionTest(DiskTestCase):
             assert_array_equal(result["d"], A[:6]["d"])
 
             qc = """
-                U < 5   
+                U < 5
             or
                                                 I >= 5
             """
@@ -700,9 +721,9 @@ class QueryConditionTest(DiskTestCase):
             assert all((result["U"] < 5) | (result["U"] > 5))
 
             qc = """
-                
+
                                                 A == ' a'
-        
+
             """
             result = A.query(cond=qc)[:]
             # ensures that ' a' does not match 'a'

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -713,7 +713,7 @@ class QueryConditionTest(DiskTestCase):
             assert_array_equal(result["d"], A[:6]["d"])
 
             qc = """
-                U < 5
+                U < 5   
             or
                                                 I >= 5
             """
@@ -721,9 +721,9 @@ class QueryConditionTest(DiskTestCase):
             assert all((result["U"] < 5) | (result["U"] > 5))
 
             qc = """
-
+                
                                                 A == ' a'
-
+        
             """
             result = A.query(cond=qc)[:]
             # ensures that ' a' does not match 'a'


### PR DESCRIPTION
- Correct `Attr.fill` for UTF-8
- Add unit tests for UTF-8 query conditions on dense arrays