### PR TITLE
Replace Deprecated libtiledb Array Open Functions

### DIFF
--- a/tiledb/libmetadata.pyx
+++ b/tiledb/libmetadata.pyx
@@ -426,7 +426,7 @@ cdef class Metadata:
         cdef const char* buri_ptr = <const char*>buri
 
         with nogil:
-            rc = tiledb_array_consolidate_metadata_with_key(
+            rc = tiledb_array_consolidate_with_key(
                     ctx_ptr,
                     buri_ptr,
                     key_type,

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -576,6 +576,11 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_array_t* array,
         uint64_t* timestamp_end)
 
+    int tiledb_array_set_config(
+        tiledb_ctx_t* ctx,
+        tiledb_array_t* array,
+        tiledb_config_t* config)
+
     int tiledb_array_set_open_timestamp_start(
         tiledb_ctx_t* ctx,
         tiledb_array_t* array,

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1660,7 +1660,7 @@ cdef ArrayPtr preload_array(uri, mode, key, timestamp, ctx=None):
     rc = tiledb_array_alloc(ctx_ptr, uri_ptr, &array_ptr)
     if rc != TILEDB_OK:
         _raise_ctx_err(ctx_ptr, rc)
-    
+
     cdef tiledb_config_t* config_ptr = NULL
     cdef tiledb_error_t* err_ptr = NULL
     if key is not None:
@@ -1676,9 +1676,13 @@ cdef ArrayPtr preload_array(uri, mode, key, timestamp, ctx=None):
         if rc != TILEDB_OK:
             _raise_ctx_err(ctx_ptr, rc)
 
-        rc = tiledb_array_set_config(ctx_ptr, array_ptr, config_ptr)
-        if rc != TILEDB_OK:
-            _raise_ctx_err(ctx_ptr, rc)
+        try:
+          # note: tiledb_array_set_config copies the config
+          rc = tiledb_array_set_config(ctx_ptr, array_ptr, config_ptr)
+          if rc != TILEDB_OK:
+              _raise_ctx_err(ctx_ptr, rc)
+        finally:
+          tiledb_config_free(&config_ptr)
 
     try:
         if set_start:


### PR DESCRIPTION
* Set encryption key in config
* Use `tiledb_array_set_open_timestamp_start` to set timestamp
* `tiledb_array_consolidate_metadata_with_key` --> `tiledb_array_consolidate_with_key`
* `tiledb_array_reopen_at` -> `tiledb_array_reopen`