### PR TITLE
Add release builder support for macOS-arm64 wheels

### DIFF
--- a/misc/azure-libtiledb-darwin.yml
+++ b/misc/azure-libtiledb-darwin.yml
@@ -20,7 +20,8 @@ steps:
       mkdir -p $TILEDB_BUILD
       cd $TILEDB_BUILD
 
-      $TILEDB_SRC/bootstrap --force-build-all-deps --disable-werror --enable=s3,gcs,azure,serialization --enable-static-tiledb --disable-avx2 --disable-tests --prefix=$TILEDB_INSTALL
+      # note: CMAKE_OSX_ARCHITECTURES is ignored on non-macOS platforms
+      cmake -B $TILEDB_BUILD -S $TILEDB_SRC/ -DTILEDB_FORCE_ALL_DEPS=ON -DTILEDB_WERROR=OFF -DTILEDB_GCS=${TILEDB_GCS} -DTILEDB_S3=ON -DTILEDB_AZURE=ON -DCOMPILER_SUPPORTS_AVX2=FALSE -DTILEDB_TESTS=OFF -DTILEDB_STATIC=ON -DCMAKE_INSTALL_PREFIX=$TILEDB_INSTALL -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
 
       cmake --build $TILEDB_BUILD --config Release -j3
       cmake --build $TILEDB_BUILD --target install-tiledb --config Release

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -13,7 +13,7 @@ stages:
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"
       TILEDB_INSTALL: "$(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)"
-      MACOSX_DEPLOYMENT_TARGET: 10.15
+      TILEDB_GCS: ON # set here, override for macOS-arm64
     condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranchName'], 'release-'), startsWith(variables['Build.SourceBranchName'], 'azure-wheel-test-'))
 
     jobs:
@@ -23,6 +23,14 @@ stages:
           matrix:
             macOS_libtiledb:
               imageName: "macOS-11"
+              CMAKE_OSX_ARCHITECTURES: "x86_64"
+              MACOSX_DEPLOYMENT_TARGET: 10.15
+            macOS_libtiledb_arm64:
+              imageName: "macOS-11"
+              CMAKE_OSX_ARCHITECTURES: "arm64"
+              MACOSX_DEPLOYMENT_TARGET: 11
+              TILEDB_GCS: OFF
+              BUILD_MAGIC_MACOS_UNIVERSAL: "ON"
             windows_libtiledb:
               imageName: "windows-latest"
         pool:
@@ -60,6 +68,11 @@ stages:
               imageName: "macOS-11"
               CIBW_SKIP: "cp27-* cp35-* cp36-* pp*"
               CIBW_BUILD_VERBOSITY: 3
+            macOS_arm64_py:
+              imageName: "macOS-11"
+              CIBW_BUILD_VERBOSITY: 3
+              CIBW_ARCHS_MACOS: "arm64"
+              CIBW_SKIP: "cp27-* cp35-* cp36-* cp37-* cp38-* cp39-* pp*"
             windows_py:
               imageName: "windows-latest"
               CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp*"
@@ -134,7 +147,9 @@ stages:
 
               export TILEDB_WHEEL_BUILD=1
               # use the requirements_wheel.txt with numpy pins to ensure ABI compatibility
-              export CIBW_TEST_COMMAND="python -c 'import tiledb'"
+              if [[ "$CIBW_ARCHS" != "arm64" ]]; then
+                export CIBW_TEST_COMMAND="python -c 'import tiledb'"
+              fi
               echo "${TILEDB_INSTALL}"
 
               python -c "import os; print(os.environ.get('CIBW_ENVIRONMENT', None))"

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -72,7 +72,8 @@ stages:
               imageName: "macOS-11"
               CIBW_BUILD_VERBOSITY: 3
               CIBW_ARCHS_MACOS: "arm64"
-              CIBW_SKIP: "cp27-* cp35-* cp36-* cp37-* cp38-* cp39-* pp*"
+              # NumPy is only available in CPython 3.8+ on macOS-arm64
+              CIBW_SKIP: "cp27-* cp35-* cp36-* cp37-* pp*"
             windows_py:
               imageName: "windows-latest"
               CIBW_SKIP: "cp27-* cp35-* cp36-* *-win32 pp*"


### PR DESCRIPTION
Adds support for building macOS arm64 wheels for CPython 3.8-3.11.