### PR TITLE
Also set ReadTheDocs build.tools

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,12 +8,13 @@ version: 2
 # Set build OS to avoid build failures with old compiler
 build:
   os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
 
 sphinx:
   configuration: doc/source/conf.py
 
 python:
-  version: 3.7
   install:
     # this order is important: we need to get cmake
     - requirements: doc/requirements_doc.txt


### PR DESCRIPTION
RTD `build.os` config option requires setting `build.tools` simultaneously.