### PR TITLE
Set MACOS_DEPLOYMENT_TARGET in the python release build section too

### DIFF
--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -66,10 +66,12 @@ stages:
               CIBW_BUILD_VERBOSITY: 3
             macOS_py:
               imageName: "macOS-11"
+              MACOSX_DEPLOYMENT_TARGET: 10.15
               CIBW_SKIP: "cp27-* cp35-* cp36-* pp*"
               CIBW_BUILD_VERBOSITY: 3
             macOS_arm64_py:
               imageName: "macOS-11"
+              MACOSX_DEPLOYMENT_TARGET: 11
               CIBW_BUILD_VERBOSITY: 3
               CIBW_ARCHS_MACOS: "arm64"
               # NumPy is only available in CPython 3.8+ on macOS-arm64


### PR DESCRIPTION
Fixes SC-25097:
```
2023-02-05T06:50:13.1807580Z   /Users/runner/work/1/.libtiledb_dist/dev/include/tiledb/object.h:131:30: error: 'value' is unavailable: introduced in macOS 10.13
2023-02-05T06:50:13.1810710Z         ret += " - \"" + name_.value() + "\">";
2023-02-05T06:50:14.9857250Z   In file included from tiledb/core.cc:24:
2023-02-05T06:50:14.9859180Z   In file included from tiledb/py_arrowio:94:
```