### PR TITLE
Update DimLabelSchema

### DIFF
--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -98,15 +98,7 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
         self._allows_dups = allows_duplicates
 
         for label_name, label_schema in dim_labels.items():
-            # TODO: Check dimension type is compatible
-            self._add_dim_label(
-                self._ctx,
-                label_schema.dimension_index,
-                label_name,
-                label_schema._label_order,
-                label_schema._label_dtype,
-                label_schema.label_filters,
-            )
+            self._add_dim_label(self._ctx, label_name, label_schema)
 
         self._check()
 

--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -98,12 +98,13 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
         self._allows_dups = allows_duplicates
 
         for label_name, label_schema in dim_labels.items():
+            # TODO: Check dimension type is compatible
             self._add_dim_label(
                 self._ctx,
                 label_schema.dimension_index,
                 label_name,
-                label_schema._label_tiledb_order,
-                label_schema._label_tiledb_dtype,
+                label_schema._label_order,
+                label_schema._label_dtype,
                 label_schema.label_filters,
             )
 

--- a/tiledb/datatypes.py
+++ b/tiledb/datatypes.py
@@ -117,6 +117,15 @@ class DataType:
             raise ValueError("tile extent must be a scalar")
         return tile_size_array
 
+    def uncast_tile_extent(self, tile_extent: Any) -> np.generic:
+        """Given a tile extent value from PyBind, cast it to appropriate output."""
+        if np.issubdtype(self.np_dtype, np.character):
+            return tile_extent
+        if np.issubdtype(self.np_dtype, np.datetime64):
+            unit = np.datetime_data(self.np_dtype)[0]
+            return np.timedelta64(tile_extent, unit)
+        return self.np_dtype.type(tile_extent)
+
 
 # datatype pairs that have a 1-1 mapping between tiledb and numpy
 _COMMON_DATATYPES = [

--- a/tiledb/dimension.py
+++ b/tiledb/dimension.py
@@ -237,13 +237,8 @@ class Dim(CtxMixin, lt.Dimension):
         :rtype: numpy scalar or np.timedelta64
 
         """
-        np_dtype = self.dtype
-        if np.issubdtype(np_dtype, np.character):
-            return self._tile
-        if np.issubdtype(np_dtype, np.datetime64):
-            unit = np.datetime_data(np_dtype)[0]
-            return np.timedelta64(self._tile, unit)
-        return np_dtype.type(self._tile)
+        dim_dtype = DataType.from_tiledb(self._tiledb_dtype)
+        return dim_dtype.uncast_tile_extent(self._tile)
 
     @property
     def domain(self) -> Tuple["np.generic", "np.generic"]:

--- a/tiledb/tests/test_dimension_label.py
+++ b/tiledb/tests/test_dimension_label.py
@@ -57,7 +57,6 @@ class DimensionLabelTestCase(DiskTestCase):
         # Check the dimension label properties
         dim_label = schema.dim_label("l1")
         assert dim_label.label_dtype == np.float64
-        breakpoint()
         assert not dim_label.label_isvar
         assert not dim_label.label_isascii
 
@@ -74,9 +73,7 @@ class DimensionLabelTestCase(DiskTestCase):
         label_dim = label_array_schema.domain.dim(0)
         assert label_dim.tile == 10
         assert label_dim.dtype == np.uint64
-        # TODO: Adjust the attr name to dim_label.label_attr_name after #1640
-        # is merged
-        label_attr = label_array_schema.attr("label")
+        label_attr = label_array_schema.attr(dim_label.label_attr_name)
         assert label_attr.dtype == np.float64
         assert label_attr.filters == filters
 

--- a/tiledb/tests/test_dimension_label.py
+++ b/tiledb/tests/test_dimension_label.py
@@ -6,6 +6,31 @@ from tiledb.tests.common import DiskTestCase
 
 
 class DimensionLabelTestCase(DiskTestCase):
+    def test_dim_label_schema(self):
+        dim_label_schema = tiledb.DimLabelSchema(
+            0, "decreasing", label_dtype=np.float64, dim_dtype=np.int32
+        )
+        assert dim_label_schema.label_order == "decreasing"
+        assert dim_label_schema.label_dtype == np.float64
+        assert dim_label_schema.dim_dtype == np.int32
+        assert dim_label_schema.dim_tile is None
+        assert dim_label_schema.label_filters is None
+
+        filter = tiledb.FilterList()
+        dim_label_schema = tiledb.DimLabelSchema(
+            10,
+            "increasing",
+            label_dtype=np.float32,
+            dim_dtype=np.int64,
+            dim_tile=20,
+            label_filters=filter,
+        )
+        assert dim_label_schema.label_order == "increasing"
+        assert dim_label_schema.label_dtype == np.float32
+        assert dim_label_schema.dim_dtype == np.int64
+        assert dim_label_schema.dim_tile == 20
+        assert dim_label_schema.label_filters == filter
+
     @pytest.mark.skipif(
         tiledb.libtiledb.version()[0] == 2 and tiledb.libtiledb.version()[1] < 15,
         reason="dimension labels requires libtiledb version 2.15 or greater",


### PR DESCRIPTION
* Create and use `lt.DimensionLabelSchema` to store data needed to create a dimension label.
* Adds support for setting the dimension tile extent on dimension labels.
* Adds support for setting the label filters on dimension labels.
* Adds check for correct dimension datatype before creating dimension label.
* Updates tests.