### PR TITLE
Dimension label API refinement

### DIFF
--- a/examples/quickstart_dimension_labels.py
+++ b/examples/quickstart_dimension_labels.py
@@ -42,29 +42,16 @@ import tiledb
 
 def create_array(uri: str):
     """Create array schema with dimension labels"""
-    d1 = tiledb.Dim("d1", domain=(1, 5))
-    d2 = tiledb.Dim("d2", domain=(1, 5))
-    dom = tiledb.Domain(d1, d2)
+    dim1 = tiledb.Dim("d1", domain=(1, 5))
+    dim2 = tiledb.Dim("d2", domain=(1, 5))
+    dom = tiledb.Domain(dim1, dim2)
     att = tiledb.Attr("a1", dtype=np.int64)
     dim_labels = {
-        "l1": tiledb.DimLabelSchema(
-            0,
-            "decreasing",
-            label_dtype=np.int64,
-            dim_dtype=d2.dtype,
-        ),
-        "l2": tiledb.DimLabelSchema(
-            1,
-            "increasing",
-            label_dtype=np.int64,
-            dim_dtype=d2.dtype,
-        ),
-        "l3": tiledb.DimLabelSchema(
-            1,
-            "increasing",
-            label_dtype=np.float64,
-            dim_dtype=d2.dtype,
-        ),
+        0: {"l1": dim1.create_label_schema("decreasing", np.int64)},
+        1: {
+            "l2": dim2.create_label_schema("increasing", np.int64),
+            "l3": dim2.create_label_schema("increasing", np.float64),
+        },
     }
     schema = tiledb.ArraySchema(domain=dom, attrs=(att,), dim_labels=dim_labels)
     tiledb.Array.create(uri, schema)

--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -32,6 +32,7 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
     :param bool allows_duplicates: True if duplicates are allowed
     :param bool sparse: True if schema is sparse, else False \
         (set by SparseArray and DenseArray derived classes)
+    :param dim_labels: dict(dim_index, dict(dim_name, tiledb.DimSchema))
     :param tiledb.Ctx ctx: A TileDB Context
     :raises: :py:exc:`tiledb.TileDBError`
 
@@ -97,8 +98,9 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
 
         self._allows_dups = allows_duplicates
 
-        for label_name, label_schema in dim_labels.items():
-            self._add_dim_label(self._ctx, label_name, label_schema)
+        for dim_index, labels_on_dim in dim_labels.items():
+            for label_name, label_schema in labels_on_dim.items():
+                self._add_dim_label(self._ctx, label_name, dim_index, label_schema)
 
         self._check()
 

--- a/tiledb/cc/dimension_label.cc
+++ b/tiledb/cc/dimension_label.cc
@@ -83,7 +83,7 @@ void init_dimension_label(py::module &m) {
              return py::capsule(dim_label.ptr().get(), "dim_label", nullptr);
            })
 
-      .def_property_readonly("label_attr_name",
+      .def_property_readonly("_label_attr_name",
                              &DimensionLabel::label_attr_name)
 
       .def_property_readonly("_dim_index", &DimensionLabel::dimension_index)

--- a/tiledb/data_order.py
+++ b/tiledb/data_order.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+import tiledb.cc as lt
+
+
+class DataOrder(Enum):
+    increasing = lt.DataOrder.INCREASING_DATA
+    decreasing = lt.DataOrder.DECREASING_DATA
+    unordered = lt.DataOrder.UNORDERED_DATA

--- a/tiledb/dimension.py
+++ b/tiledb/dimension.py
@@ -150,6 +150,38 @@ class Dim(CtxMixin, lt.Dimension):
         lb, ub = self.domain
         return np.arange(int(lb), int(ub) + 1, dtype=dtype if dtype else self.dtype)
 
+    def create_label_schema(
+        self,
+        dim_index: np.uint32,
+        order: str = "increasing",
+        dtype: np.dtype = np.uint64,
+        tile: Any = None,
+        filters: Union[FilterList, Sequence[Filter]] = None,
+    ):
+        """Creates a dimension label schema for a dimension label on this dimension
+
+        :param dim_index: Index of this dimension in the array schema it is on.
+        :param order: Order or sort of the label data ('increasing' or 'decreasing').
+        :param dtype: Datatype of the label data.
+        :param tile: Tile extent for the dimension of the dimension label. If
+            ``None``, it will use the tile extent of this dimension.
+        :param label_filters: Filter list for the attribute storing the label data.
+
+        :rtype: DimLabelSchema
+
+        """
+        from .dimension_label_schema import DimLabelSchema
+
+        return DimLabelSchema(
+            dim_index,
+            order,
+            dtype,
+            self.dtype,
+            self.tile if tile is None else tile,
+            filters,
+            self._ctx,
+        )
+
     @property
     def dtype(self) -> np.dtype:
         """Numpy dtype representation of the dimension type.

--- a/tiledb/dimension.py
+++ b/tiledb/dimension.py
@@ -152,7 +152,6 @@ class Dim(CtxMixin, lt.Dimension):
 
     def create_label_schema(
         self,
-        dim_index: np.uint32,
         order: str = "increasing",
         dtype: np.dtype = np.uint64,
         tile: Any = None,
@@ -160,7 +159,6 @@ class Dim(CtxMixin, lt.Dimension):
     ):
         """Creates a dimension label schema for a dimension label on this dimension
 
-        :param dim_index: Index of this dimension in the array schema it is on.
         :param order: Order or sort of the label data ('increasing' or 'decreasing').
         :param dtype: Datatype of the label data.
         :param tile: Tile extent for the dimension of the dimension label. If
@@ -173,11 +171,10 @@ class Dim(CtxMixin, lt.Dimension):
         from .dimension_label_schema import DimLabelSchema
 
         return DimLabelSchema(
-            dim_index,
             order,
             dtype,
             self.dtype,
-            self.tile if tile is None else tile,
+            self.tile if tile is None and self.tile != 0 else tile,
             filters,
             self._ctx,
         )

--- a/tiledb/dimension_label.py
+++ b/tiledb/dimension_label.py
@@ -5,6 +5,7 @@ import numpy as np
 import tiledb.cc as lt
 
 from .ctx import CtxMixin
+from .data_order import DataOrder
 from .datatypes import DataType
 
 
@@ -17,7 +18,7 @@ class DimLabel(CtxMixin, lt.DimensionLabel):
         dtype = "ascii" if self.isascii else self.dtype
         return (
             f"DimLabel(name={self.name}, dtype='{dtype!s}', "
-            f"var={self.isvar!s}, uri={self.uri})"
+            f"var={self.isvar!s}, order={self.order!s})"
         )
 
     def _repr_html_(self):
@@ -28,7 +29,7 @@ class DimLabel(CtxMixin, lt.DimensionLabel):
         output.write("<th>Name</th>")
         output.write("<th>Data Type</th>")
         output.write("<th>Is Var-Len</th>")
-        output.write("<th>URI</th>")
+        output.write("<th>Data Order</th>")
         output.write("</tr>")
         output.write(f"{self._repr_html_row_only_()}")
         output.write("</table>")
@@ -42,7 +43,7 @@ class DimLabel(CtxMixin, lt.DimensionLabel):
         output.write(f"<td>{self.name}</td>")
         output.write(f"<td>{'ascii' if self.isascii else self.dtype}</td>")
         output.write(f"<td>{self.isvar}</td>")
-        output.write(f"<td>{self.uri}</td>")
+        output.write(f"<td>{self.order}</td>")
         output.write("</tr>")
 
         return output.getvalue()
@@ -57,7 +58,7 @@ class DimLabel(CtxMixin, lt.DimensionLabel):
         return self._dim_index
 
     @property
-    def label_dtype(self) -> np.dtype:
+    def dtype(self) -> np.dtype:
         """Numpy dtype representation of the label type.
 
         :rtype: numpy.dtype
@@ -66,7 +67,7 @@ class DimLabel(CtxMixin, lt.DimensionLabel):
         return DataType.from_tiledb(self._tiledb_label_dtype).np_dtype
 
     @property
-    def label_isvar(self) -> bool:
+    def isvar(self) -> bool:
         """True if the labels are variable length.
 
         :rtype: bool
@@ -75,13 +76,21 @@ class DimLabel(CtxMixin, lt.DimensionLabel):
         return self._label_ncell == lt.TILEDB_VAR_NUM()
 
     @property
-    def label_isascii(self) -> bool:
+    def isascii(self) -> bool:
         """True if the labels are variable length.
 
         :rtype: bool
 
         """
         return self._tiledb_label_dtype == lt.DataType.STRING_ASCII
+
+    @property
+    def label_attr_name(self) -> str:
+        """Name of the attribute storing the label data.
+
+        :rtype: str
+        """
+        return self._label_attr_name
 
     @property
     def name(self) -> str:
@@ -91,6 +100,14 @@ class DimLabel(CtxMixin, lt.DimensionLabel):
 
         """
         return self._name
+
+    @property
+    def order(self) -> str:
+        """The order of the label data in the dimension label.
+
+        :rtype: str
+        """
+        return DataOrder(self._tiledb_label_order).name
 
     @property
     def uri(self) -> str:

--- a/tiledb/dimension_label_schema.py
+++ b/tiledb/dimension_label_schema.py
@@ -13,7 +13,6 @@ from .filter import Filter, FilterList
 class DimLabelSchema(lt.DimensionLabelSchema):
     def __init__(
         self,
-        dim_index: np.uint32,
         order: str = "increasing",
         label_dtype: np.dtype = np.uint64,
         dim_dtype: np.dtype = np.uint64,
@@ -23,7 +22,6 @@ class DimLabelSchema(lt.DimensionLabelSchema):
     ):
         """Class defining a dimension label to create as part of an array.
 
-        :param dim_index: Index of the target dimension the label is added to.
         :param order: Order or sort of the label data ('increasing' or 'decreasing').
         :param label_dtype: Datatype of the label data.
         :param dim_dtype: Datatype of the target dimension.
@@ -52,7 +50,6 @@ class DimLabelSchema(lt.DimensionLabelSchema):
         # Create the PyBind superclass
         if label_filters is None:
             super().__init__(
-                dim_index,
                 _dim_dtype.tiledb_type,
                 _dim_tile,
                 _label_order.value,
@@ -65,7 +62,6 @@ class DimLabelSchema(lt.DimensionLabelSchema):
                 else FilterList(label_filters)
             )
             super().__init__(
-                dim_index,
                 _dim_dtype.tiledb_type,
                 _dim_tile,
                 _label_order.value,

--- a/tiledb/dimension_label_schema.py
+++ b/tiledb/dimension_label_schema.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Any, Optional, Sequence, Union
 
 import numpy as np
@@ -6,14 +5,9 @@ import numpy as np
 import tiledb.cc as lt
 
 from .ctx import Ctx, default_ctx
+from .data_order import DataOrder
 from .datatypes import DataType
 from .filter import Filter, FilterList
-
-
-class DataOrder(Enum):
-    increasing = lt.DataOrder.INCREASING_DATA
-    decreasing = lt.DataOrder.DECREASING_DATA
-    unordered = lt.DataOrder.UNORDERED_DATA
 
 
 class DimLabelSchema(lt.DimensionLabelSchema):

--- a/tiledb/dimension_label_schema.py
+++ b/tiledb/dimension_label_schema.py
@@ -21,6 +21,17 @@ class DimLabelSchema(lt.DimensionLabelSchema):
         label_filters: Union[FilterList, Sequence[Filter]] = None,
         ctx: Ctx = None,
     ):
+        """Class defining a dimension label to create as part of an array.
+
+        :param dim_index: Index of the target dimension the label is added to.
+        :param order: Order or sort of the label data ('increasing' or 'decreasing').
+        :param label_dtype: Datatype of the label data.
+        :param dim_dtype: Datatype of the target dimension.
+        :param dim_tile: Tile extent for the dimension of the dimension label. If
+            ``None``, it will use the same tile extent as the target dimension.
+        :param label_filters: Filter list for the attribute storing the label data.
+        :param ctx: A TileDB Context.
+        """
         self._ctx = ctx or default_ctx()
 
         # Get DataType and DataOrder objects

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -191,7 +191,7 @@ cdef _write_array(tiledb_ctx_t* ctx_ptr,
         buffer_names.append(label_name)
         # Get label data buffer and offsets buffer for the labels
         dim_label = tiledb_array.schema.dim_label(label_name)
-        if dim_label.label_isvar:
+        if dim_label.isvar:
             buffer, offsets = array_to_buffer(label_values, True, False)
             buffer_sizes[ibuffer] = buffer.nbytes
             buffer_offsets_sizes[ibuffer] = offsets.nbytes
@@ -2219,7 +2219,7 @@ cdef class DenseArrayImpl(Array):
                 name:
                 (data
                 if not type(data) is np.ndarray or data.dtype is np.dtype('O')
-                else np.ascontiguousarray(data, dtype=self.schema.dim_label(name).label_dtype))
+                else np.ascontiguousarray(data, dtype=self.schema.dim_label(name).dtype))
                 for name, data in val.items()
                 if self.schema.has_dim_label(name)
             }
@@ -2578,7 +2578,7 @@ def _setitem_impl_sparse(self: Array, selection, val, dict nullmaps):
         name:
         (data
         if not type(data) is np.ndarray or data.dtype is np.dtype('O')
-        else np.ascontiguousarray(data, dtype=self.schema.dim_label(name).label_dtype))
+        else np.ascontiguousarray(data, dtype=self.schema.dim_label(name).dtype))
         for name, data in val.items()
         if self.schema.has_dim_label(name)
     }

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -486,7 +486,7 @@ class LabelIndexer(MultiRangeIndexer):
         self._labels: Dict[int, str] = {}
         for label_name in labels:
             dim_label = array.schema.dim_label(label_name)
-            if dim_label.label_isvar:
+            if dim_label.isvar:
                 raise NotImplementedError(
                     "querying by variable length labels is not yet implemented"
                 )
@@ -632,7 +632,7 @@ def _get_pyquery_results(
             arr.dtype = (
                 schema.attr_or_dim_dtype(name)
                 if not schema.has_dim_label(name)
-                else schema.dim_label(name).label_dtype
+                else schema.dim_label(name).dtype
             )
         result_dict[name if name != "__attr" else ""] = arr
     return result_dict

--- a/tiledb/tests/test_dimension_label.py
+++ b/tiledb/tests/test_dimension_label.py
@@ -31,6 +31,25 @@ class DimensionLabelTestCase(DiskTestCase):
         assert dim_label_schema.dim_tile == 20
         assert dim_label_schema.label_filters == filter
 
+    def test_dim_label_schema_from_dim(self):
+        dim = tiledb.Dim("dim", domain=(1, 10), dtype=np.int32, tile=10)
+        dim_label_schema = dim.create_label_schema(0, "decreasing", np.float64)
+        assert dim_label_schema.label_order == "decreasing"
+        assert dim_label_schema.label_dtype == np.float64
+        assert dim_label_schema.dim_dtype == np.int32
+        assert dim_label_schema.dim_tile == 10
+        assert dim_label_schema.label_filters is None
+
+        filter = tiledb.FilterList()
+        dim_label_schema = dim.create_label_schema(
+            0, order="increasing", dtype=np.float32, tile=5, filters=filter
+        )
+        assert dim_label_schema.label_order == "increasing"
+        assert dim_label_schema.label_dtype == np.float32
+        assert dim_label_schema.dim_dtype == np.int32
+        assert dim_label_schema.dim_tile == 5
+        assert dim_label_schema.label_filters == filter
+
     @pytest.mark.skipif(
         tiledb.libtiledb.version()[0] == 2 and tiledb.libtiledb.version()[1] < 15,
         reason="dimension labels requires libtiledb version 2.15 or greater",

--- a/tiledb/tests/test_dimension_label.py
+++ b/tiledb/tests/test_dimension_label.py
@@ -56,9 +56,9 @@ class DimensionLabelTestCase(DiskTestCase):
 
         # Check the dimension label properties
         dim_label = schema.dim_label("l1")
-        assert dim_label.label_dtype == np.float64
-        assert not dim_label.label_isvar
-        assert not dim_label.label_isascii
+        assert dim_label.dtype == np.float64
+        assert not dim_label.isvar
+        assert not dim_label.isascii
 
         # Create array check values in dimension label schema
         uri = self.path("array_with_label")

--- a/tiledb/tests/test_dimension_label.py
+++ b/tiledb/tests/test_dimension_label.py
@@ -8,7 +8,7 @@ from tiledb.tests.common import DiskTestCase
 class DimensionLabelTestCase(DiskTestCase):
     def test_dim_label_schema(self):
         dim_label_schema = tiledb.DimLabelSchema(
-            0, "decreasing", label_dtype=np.float64, dim_dtype=np.int32
+            "decreasing", label_dtype=np.float64, dim_dtype=np.int32
         )
         assert dim_label_schema.label_order == "decreasing"
         assert dim_label_schema.label_dtype == np.float64
@@ -18,7 +18,6 @@ class DimensionLabelTestCase(DiskTestCase):
 
         filter = tiledb.FilterList()
         dim_label_schema = tiledb.DimLabelSchema(
-            10,
             "increasing",
             label_dtype=np.float32,
             dim_dtype=np.int64,
@@ -33,7 +32,7 @@ class DimensionLabelTestCase(DiskTestCase):
 
     def test_dim_label_schema_from_dim(self):
         dim = tiledb.Dim("dim", domain=(1, 10), dtype=np.int32, tile=10)
-        dim_label_schema = dim.create_label_schema(0, "decreasing", np.float64)
+        dim_label_schema = dim.create_label_schema("decreasing", np.float64)
         assert dim_label_schema.label_order == "decreasing"
         assert dim_label_schema.label_dtype == np.float64
         assert dim_label_schema.dim_dtype == np.int32
@@ -42,7 +41,7 @@ class DimensionLabelTestCase(DiskTestCase):
 
         filter = tiledb.FilterList()
         dim_label_schema = dim.create_label_schema(
-            0, order="increasing", dtype=np.float32, tile=5, filters=filter
+            order="increasing", dtype=np.float32, tile=5, filters=filter
         )
         assert dim_label_schema.label_order == "increasing"
         assert dim_label_schema.label_dtype == np.float32
@@ -60,14 +59,15 @@ class DimensionLabelTestCase(DiskTestCase):
         att = tiledb.Attr("val", dtype=np.uint64)
         filters = tiledb.FilterList([tiledb.ZstdFilter(10)])
         dim_labels = {
-            "l1": tiledb.DimLabelSchema(
-                0,
-                "increasing",
-                label_dtype=np.float64,
-                dim_dtype=dim.dtype,
-                dim_tile=10,
-                label_filters=filters,
-            )
+            0: {
+                "l1": tiledb.DimLabelSchema(
+                    "increasing",
+                    label_dtype=np.float64,
+                    dim_dtype=dim.dtype,
+                    dim_tile=10,
+                    label_filters=filters,
+                )
+            }
         }
         schema = tiledb.ArraySchema(domain=dom, attrs=(att,), dim_labels=dim_labels)
         assert schema.has_dim_label("l1")
@@ -105,12 +105,11 @@ class DimensionLabelTestCase(DiskTestCase):
         dom = tiledb.Domain(dim)
         att = tiledb.Attr("val", dtype=np.uint64)
         dim_labels = {
-            "l1": tiledb.DimLabelSchema(
-                2,
-                "increasing",
-                label_dtype=dim.dtype,
-                dim_dtype=dim.dtype,
-            )
+            2: {
+                "l1": tiledb.DimLabelSchema(
+                    "increasing", label_dtype=dim.dtype, dim_dtype=dim.dtype
+                )
+            }
         }
 
         with pytest.raises(tiledb.TileDBError):
@@ -125,12 +124,11 @@ class DimensionLabelTestCase(DiskTestCase):
         dom = tiledb.Domain(dim)
         att = tiledb.Attr("val", dtype=np.uint64)
         dim_labels = {
-            "label": tiledb.DimLabelSchema(
-                2,
-                "increasing",
-                label_dtype=dim.dtype,
-                dim_dtype=np.int32,
-            )
+            2: {
+                "label": tiledb.DimLabelSchema(
+                    "increasing", label_dtype=dim.dtype, dim_dtype=np.int32
+                )
+            }
         }
 
         with pytest.raises(tiledb.TileDBError):
@@ -145,14 +143,7 @@ class DimensionLabelTestCase(DiskTestCase):
         dim = tiledb.Dim("d1", domain=(1, 10))
         dom = tiledb.Domain(dim)
         att = tiledb.Attr("a1", dtype=np.int64)
-        dim_labels = {
-            "l1": tiledb.DimLabelSchema(
-                0,
-                "increasing",
-                label_dtype=np.int64,
-                dim_dtype=dim.dtype,
-            )
-        }
+        dim_labels = {0: {"l1": dim.create_label_schema("increasing", np.int64)}}
         schema = tiledb.ArraySchema(domain=dom, attrs=(att,), dim_labels=dim_labels)
 
         # Create array
@@ -202,24 +193,13 @@ class DimensionLabelTestCase(DiskTestCase):
         dom = tiledb.Domain(dim1, dim2)
         att = tiledb.Attr("value", dtype=np.int64)
         dim_labels = {
-            "x1": tiledb.DimLabelSchema(
-                0,
-                "increasing",
-                label_dtype=np.float64,
-                dim_dtype=dim1.dtype,
-            ),
-            "x2": tiledb.DimLabelSchema(
-                0,
-                "decreasing",
-                label_dtype=np.int64,
-                dim_dtype=dim1.dtype,
-            ),
-            "y1": tiledb.DimLabelSchema(
-                1,
-                "increasing",
-                label_dtype=np.int64,
-                dim_dtype=dim2.dtype,
-            ),
+            0: {
+                "x1": dim1.create_label_schema("increasing", np.float64),
+                "x2": dim1.create_label_schema("decreasing", np.int64),
+            },
+            1: {
+                "y1": dim2.create_label_schema("increasing", np.int64),
+            },
         }
         schema = tiledb.ArraySchema(domain=dom, attrs=(att,), dim_labels=dim_labels)
 
@@ -276,14 +256,7 @@ class DimensionLabelTestCase(DiskTestCase):
         dim = tiledb.Dim("index", domain=(1, 10))
         dom = tiledb.Domain(dim)
         att = tiledb.Attr("value", dtype=np.int64)
-        dim_labels = {
-            "l1": tiledb.DimLabelSchema(
-                0,
-                "increasing",
-                label_dtype=np.int64,
-                dim_dtype=dim.dtype,
-            )
-        }
+        dim_labels = {0: {"l1": dim.create_label_schema("increasing", np.int64)}}
         schema = tiledb.ArraySchema(
             domain=dom, attrs=(att,), dim_labels=dim_labels, sparse=True
         )

--- a/tiledb/tests/test_query.py
+++ b/tiledb/tests/test_query.py
@@ -15,14 +15,7 @@ class QueryTest(DiskTestCase):
         dim = tiledb.Dim("d1", domain=(1, 10))
         dom = tiledb.Domain(dim)
         att = tiledb.Attr("a1", dtype=np.int64)
-        dim_labels = {
-            "l1": tiledb.DimLabelSchema(
-                0,
-                "increasing",
-                label_dtype=np.int64,
-                dim_dtype=dim.dtype,
-            )
-        }
+        dim_labels = {0: {"l1": dim.create_label_schema("increasing", np.int64)}}
         schema = tiledb.ArraySchema(domain=dom, attrs=(att,), dim_labels=dim_labels)
 
         # Create array

--- a/tiledb/tests/test_subarray.py
+++ b/tiledb/tests/test_subarray.py
@@ -76,14 +76,7 @@ class SubarrayTest(DiskTestCase):
         dim = tiledb.Dim("d1", domain=(1, 10), dtype=np.uint32)
         dom = tiledb.Domain(dim)
         att = tiledb.Attr("a1", dtype=np.int64)
-        dim_labels = {
-            "l1": tiledb.DimLabelSchema(
-                0,
-                "increasing",
-                label_dtype=np.int64,
-                dim_dtype=dim.dtype,
-            )
-        }
+        dim_labels = {0: {"l1": dim.create_label_schema("increasing", np.int64)}}
         schema = tiledb.ArraySchema(domain=dom, attrs=(att,), dim_labels=dim_labels)
 
         # Create array


### PR DESCRIPTION
Improve `DimLabel` class API:
  * Add `order` property to `DimLabel` and use in repr functions
  * Remove `label_` prefix from dtype, isvar, and isascii
  * Remove URI form repr functions

Improve `DimLabelSchema` class:
  * Remove `dim_index` from `DimLabelSchema`
  * Add factory method to create `DimLabelSchema` from a `Dim`

Changes to `ArraySchema` class:
  * Change `dim_labels` input to be a dict of dict over dimension index and dim label name