### PR TITLE
Use architecture-specific libtiledb install path to get correct libti…

### DIFF
--- a/misc/azure-libtiledb-darwin.yml
+++ b/misc/azure-libtiledb-darwin.yml
@@ -2,7 +2,7 @@ steps:
   - task: Cache@2
     inputs:
       key: 'libtiledb v0 | "$(Agent.OS)" | "$(imageName)" | "$(LIBTILEDB_SHA)" | "$(CMAKE_OSX_ARCHITECTURES)" | setup.py | **/azure-*.yml, !tiledb_src/**, !tiledb_build/**'
-      path: $(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)
+      path: '$(TILEDB_INSTALL)'
       cacheHitVar: LIBTILEDB_CACHE_RESTORED
 
   - bash: |

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -12,7 +12,7 @@ stages:
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"
-      TILEDB_INSTALL: "$(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)"
+      TILEDB_INSTALL: "$(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)" # UPDATE IN macOS sections below too!
       TILEDB_GCS: ON # set here, override for macOS-arm64
     condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranchName'], 'release-'), startsWith(variables['Build.SourceBranchName'], 'azure-wheel-test-'))
 
@@ -25,12 +25,14 @@ stages:
               imageName: "macOS-11"
               CMAKE_OSX_ARCHITECTURES: "x86_64"
               MACOSX_DEPLOYMENT_TARGET: 10.15
+              TILEDB_INSTALL: "$(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)-macos-x86_64"
             macOS_libtiledb_arm64:
               imageName: "macOS-11"
               CMAKE_OSX_ARCHITECTURES: "arm64"
               MACOSX_DEPLOYMENT_TARGET: 11
               TILEDB_GCS: OFF
               BUILD_MAGIC_MACOS_UNIVERSAL: "ON"
+              TILEDB_INSTALL: "$(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)-macos-arm64"
             windows_libtiledb:
               imageName: "windows-latest"
         pool:

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -12,8 +12,11 @@ stages:
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"
-      TILEDB_INSTALL: "$(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)" # UPDATE IN macOS sections below too!
       TILEDB_GCS: ON # set here, override for macOS-arm64
+      # UPDATE TILEDB_INSTALL:
+      # - IN macOS sections below too!
+      # - IN azure-libtiledb-darwin.yml 'path' input, if applicable
+      TILEDB_INSTALL: "$(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)"
     condition: or(startsWith(variables['Build.SourceBranch'], 'refs/tags'), startsWith(variables['Build.SourceBranchName'], 'release-'), startsWith(variables['Build.SourceBranchName'], 'azure-wheel-test-'))
 
     jobs:


### PR DESCRIPTION
…ledb on macOS-arm64

Fixes (correctly) the warning [here](https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=30693&view=logs&j=3094b6d3-484e-574d-e9ba-d762c1161906), which leads to an unusable wheel:
```
2023-03-07T17:50:21.2339550Z   ld: warning: ignoring file /Users/runner/work/1/.libtiledb_dist/1fb59c4410823c5f615661997021437d7223041a/lib/libtiledb.dylib, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
```
when the x86_64 artifact gets pulled into the arm64 build variant due to identical cache key.