### PR TITLE
Restore `__version__` variable.

### DIFF
--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -111,6 +111,7 @@ from .subarray import Subarray
 from .version_helper import version
 from .vfs import VFS, FileIO
 
+__version__ = version.version
 group_create = Group.create
 
 # Note: we use a modified namespace packaging to allow continuity of existing TileDB-Py imports.


### PR DESCRIPTION
Someone *cough* accidentally deleted the `__version__` string variable when they refactored the way setuptools-scm handled versions. This brings it back while also subjecting the reader to the word “version” enough to reach semantic satiation.