### PR TITLE
Addition of `Group(config=...)` and `Group.set_config`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import Extension, find_packages, setup
 ### DO NOT USE ON CI
 
 # Target branch: Note that this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.15.0"
+TILEDB_VERSION = "2.15.1"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION

--- a/tiledb/cc/group.cc
+++ b/tiledb/cc/group.cc
@@ -98,6 +98,9 @@ void init_group(py::module &m) {
       .def(
           py::init<const Context &, const std::string &, tiledb_query_type_t>(),
           py::keep_alive<1, 2>())
+      .def(py::init<const Context &, const std::string &, tiledb_query_type_t,
+                    const Config &>(),
+           py::keep_alive<1, 2>())
 
       .def("_open", &Group::open)
       .def("_set_config", &Group::set_config)

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import tiledb.cc as lt
 
-from .ctx import Ctx, CtxMixin, default_ctx
+from .ctx import Config, Ctx, CtxMixin, default_ctx
 from .datatypes import DataType
 from .object import Object
 
@@ -251,7 +251,7 @@ class Group(CtxMixin, lt.Group):
             for metadata in self._iter(keys_only=False, dump=True):
                 print(metadata)
 
-    def __init__(self, uri: str, mode: str = "r", ctx: Optional[Ctx] = None):
+    def __init__(self, uri: str, mode: str = "r", close=False, ctx: Optional[Ctx] = None):
         if mode not in Group._mode_to_query_type:
             raise ValueError(f"invalid mode {mode}")
         query_type = Group._mode_to_query_type[mode]
@@ -259,6 +259,9 @@ class Group(CtxMixin, lt.Group):
         super().__init__(ctx, uri, query_type)
 
         self._meta = self.GroupMetadata(self)
+        
+        if close:
+            self.close()
 
     @staticmethod
     def create(uri: str, ctx: Optional[Ctx] = None):
@@ -421,3 +424,13 @@ class Group(CtxMixin, lt.Group):
         :rtype: bool
         """
         return self._is_relative(name)
+    
+    def set_config(self, cfg: Config):
+        """
+        :param cfg: Config to set on the Group
+        :type cfg: Config
+        """
+        if self.isopen:
+            raise ValueError("`set_config` can only be used on closed groups. "
+                             "Use `group.cl0se()` or Group(.., closed=True)")
+        self._set_config(cfg)

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -251,7 +251,9 @@ class Group(CtxMixin, lt.Group):
             for metadata in self._iter(keys_only=False, dump=True):
                 print(metadata)
 
-    def __init__(self, uri: str, mode: str = "r", close=False, ctx: Optional[Ctx] = None):
+    def __init__(
+        self, uri: str, mode: str = "r", close=False, ctx: Optional[Ctx] = None
+    ):
         if mode not in Group._mode_to_query_type:
             raise ValueError(f"invalid mode {mode}")
         query_type = Group._mode_to_query_type[mode]
@@ -259,7 +261,7 @@ class Group(CtxMixin, lt.Group):
         super().__init__(ctx, uri, query_type)
 
         self._meta = self.GroupMetadata(self)
-        
+
         if close:
             self.close()
 
@@ -424,13 +426,15 @@ class Group(CtxMixin, lt.Group):
         :rtype: bool
         """
         return self._is_relative(name)
-    
+
     def set_config(self, cfg: Config):
         """
         :param cfg: Config to set on the Group
         :type cfg: Config
         """
         if self.isopen:
-            raise ValueError("`set_config` can only be used on closed groups. "
-                             "Use `group.cl0se()` or Group(.., closed=True)")
+            raise ValueError(
+                "`set_config` can only be used on closed groups. "
+                "Use `group.cl0se()` or Group(.., closed=True)"
+            )
         self._set_config(cfg)

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -257,7 +257,6 @@ class Group(CtxMixin, lt.Group):
         self,
         uri: str,
         mode: str = "r",
-        close=False,
         config: Config = None,
         ctx: Optional[Ctx] = None,
     ):
@@ -265,17 +264,12 @@ class Group(CtxMixin, lt.Group):
             raise ValueError(f"invalid mode {mode}")
         query_type = Group._mode_to_query_type[mode]
 
-        super().__init__(ctx, uri, query_type)
+        if config is None:
+            super().__init__(ctx, uri, query_type)
+        else:
+            super().__init__(ctx, uri, query_type, config)
 
         self._meta = self.GroupMetadata(self)
-
-        if config is not None:
-            self.close()
-            self._set_config(config)
-            self.open(mode)
-
-        if close:
-            self.close()
 
     @staticmethod
     def create(uri: str, ctx: Optional[Ctx] = None):

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -254,7 +254,12 @@ class Group(CtxMixin, lt.Group):
                 print(metadata)
 
     def __init__(
-        self, uri: str, mode: str = "r", close=False, config: Config = None, ctx: Optional[Ctx] = None
+        self,
+        uri: str,
+        mode: str = "r",
+        close=False,
+        config: Config = None,
+        ctx: Optional[Ctx] = None,
     ):
         if mode not in Group._mode_to_query_type:
             raise ValueError(f"invalid mode {mode}")
@@ -263,7 +268,7 @@ class Group(CtxMixin, lt.Group):
         super().__init__(ctx, uri, query_type)
 
         self._meta = self.GroupMetadata(self)
-        
+
         if config is not None:
             self.close()
             self._set_config(config)

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -24,6 +24,8 @@ class Group(CtxMixin, lt.Group):
     :type uri: str
     :param mode: Read mode ('r') or write mode ('w')
     :type mode: str
+    :param config: A TileDB config
+    :type config: Config or dict
     :param ctx: A TileDB context
     :type ctx: tiledb.Ctx
 
@@ -252,7 +254,7 @@ class Group(CtxMixin, lt.Group):
                 print(metadata)
 
     def __init__(
-        self, uri: str, mode: str = "r", close=False, ctx: Optional[Ctx] = None
+        self, uri: str, mode: str = "r", close=False, config: Config = None, ctx: Optional[Ctx] = None
     ):
         if mode not in Group._mode_to_query_type:
             raise ValueError(f"invalid mode {mode}")
@@ -261,6 +263,11 @@ class Group(CtxMixin, lt.Group):
         super().__init__(ctx, uri, query_type)
 
         self._meta = self.GroupMetadata(self)
+        
+        if config is not None:
+            self.close()
+            self._set_config(config)
+            self.open(mode)
 
         if close:
             self.close()

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -576,3 +576,9 @@ class GroupMetadataTest(GroupTestCase):
             G.open()
             assert len(G) == sz
             G.close()
+        
+        for sz, m in enumerate(ms):
+            cfg = tiledb.Config({"sm.group.timestamp_end": m})
+
+            with tiledb.Group(group_uri, config=cfg) as G:
+                assert len(G) == sz

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -529,7 +529,7 @@ class GroupMetadataTest(GroupTestCase):
         with tiledb.Group(group1, mode="r") as G:
             assert G.is_relative("group2_1") is False
             assert G.is_relative("group2_2") is True
-            
+
     def test_set_config(self):
         group_uri = self.path("foo")
         array_uri_1 = self.path("foo/a")
@@ -545,7 +545,7 @@ class GroupMetadataTest(GroupTestCase):
         tiledb.Array.create(array_uri_2, sch)
 
         t1 = time.time()
-        
+
         time.sleep(1)
         with tiledb.Group(group_uri, "w") as G:
             G.add(name="a", uri="a", relative=True)
@@ -560,19 +560,19 @@ class GroupMetadataTest(GroupTestCase):
 
         t3 = time.time()
 
-        ms = np.array([t1, t2, t3], dtype=np.int64) * 1000 
+        ms = np.array([t1, t2, t3], dtype=np.int64) * 1000
 
         for sz, m in enumerate(ms):
-            cfg = tiledb.Config({'sm.group.timestamp_end': m})
-            
+            cfg = tiledb.Config({"sm.group.timestamp_end": m})
+
             # Cannot set config on open group
             with self.assertRaises(ValueError):
                 G = tiledb.Group(group_uri)
                 G.set_config(cfg)
-            
+
             G = tiledb.Group(group_uri, close=True)
             G.set_config(cfg)
-            
+
             G.open()
             assert len(G) == sz
             G.close()

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -565,12 +565,13 @@ class GroupMetadataTest(GroupTestCase):
         for sz, m in enumerate(ms):
             cfg = tiledb.Config({"sm.group.timestamp_end": m})
 
+            G = tiledb.Group(group_uri)
+
             # Cannot set config on open group
             with self.assertRaises(ValueError):
-                G = tiledb.Group(group_uri)
                 G.set_config(cfg)
 
-            G = tiledb.Group(group_uri, close=True)
+            G.close()
             G.set_config(cfg)
 
             G.open()

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -576,7 +576,7 @@ class GroupMetadataTest(GroupTestCase):
             G.open()
             assert len(G) == sz
             G.close()
-        
+
         for sz, m in enumerate(ms):
             cfg = tiledb.Config({"sm.group.timestamp_end": m})
 


### PR DESCRIPTION
* Add `config` parameter to `Group` constructor and `set_config` to the high-level `Group` API. This will help relieve the excessive allocation of `Ctx` objects in the TileDB-SOMA-Py codebase as described in https://github.com/single-cell-data/TileDB-SOMA/issues/1169)
* Group unit tests now use timestamps instead of `time.sleep()`