### PR TITLE
Fix sc-27374: default order mapping fallback

### DIFF
--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -464,6 +464,6 @@ _string_to_tiledb_order.update(
         "R": lt.LayoutType.COL_MAJOR,
         "H": lt.LayoutType.HILBERT,
         "U": lt.LayoutType.UNORDERED,
-        None: lt.LayoutType.UNORDERED,
+        None: lt.LayoutType.ROW_MAJOR,  # default (fixed in SC-27374)
     }
 )


### PR DESCRIPTION
Restores prior behavior changed in https://github.com/TileDB-Inc/TileDB-Py/pull/1609.