### PR TITLE
[WIP] Use certifi certs if available

### DIFF
--- a/tiledb/ctx.py
+++ b/tiledb/ctx.py
@@ -517,6 +517,14 @@ def default_ctx(config: Union["Config", dict] = None) -> "Ctx":
             "dictionary with config parameters."
         )
 
+    if config is not None and config.get("vfs.s3.ca_file") == "":
+        try:
+            import certifi
+
+            config["vfs.s3.ca_file"] = certifi.where()
+        except:
+            pass
+
     try:
         ctx = _ctx_var.get()
         if config is not None:

--- a/tiledb/ctx.py
+++ b/tiledb/ctx.py
@@ -517,13 +517,16 @@ def default_ctx(config: Union["Config", dict] = None) -> "Ctx":
             "dictionary with config parameters."
         )
 
-    if config is not None and config.get("vfs.s3.ca_file") == "":
-        try:
+    try:
+        if config is None:
+            config = dict()
+        if config.get("vfs.s3.ca_file", "") == "":
+            # Use certifi certificates if available, to avoid stale certificates.
             import certifi
 
             config["vfs.s3.ca_file"] = certifi.where()
-        except:
-            pass
+    except:
+        pass
 
     try:
         ctx = _ctx_var.get()


### PR DESCRIPTION
This avoids use of old certificates, matching behavior of many other packages. Fixes runtime certificate error in macOS-arm64 wheels for S3 backend.