### PR TITLE
Update requirements_dev.txt to improve contributor workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,14 @@ Thanks for your interest in TileDB-Py. The notes below give some pointers for fi
 ### Contribution Workflow
 
 - Quick steps to build locally:
-  - install prerequisites via pip or conda: `pybind11` `cython` `numpy` `pandas` `pyarrow`
+  - install prerequisites via pip:
+    ```
+    pip install -r requirements_dev.txt 
+    ```
+    or conda: 
+    ```
+    conda install --file requirements_dev.txt
+    ```
   - recommended: install TileDB embedded (libtiledb)
     
     NOTE: if libtiledb path is not specified with `--tiledb`, it will be built automatically by `setup.py`. However, this build
@@ -44,5 +51,5 @@ Thanks for your interest in TileDB-Py. The notes below give some pointers for fi
 
 - Make changes locally, then rebuild with `python setup.py develop [--tiledb=<>]`
 - Make sure to run `pytest` to verify changes against tests (add new tests where applicable).
-  - Execute the tests as `pytest tiledb` from the top-level directory or `pytest` in the `tiledb/` directory.
+  - Execute the tests as `python -m pytest tiledb` from the top-level directory or `python -m pytest` in the `tiledb/` directory.
 - Please submit [pull requests](https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request) against the default [`dev` branch of TileDB-Py](https://github.com/TileDB-Inc/TileDB-Py/tree/dev)

--- a/README.md
+++ b/README.md
@@ -38,3 +38,17 @@ Dataframes functionality (`tiledb.from_pandas`, `Array.df[]`) requires [Pandas](
 We welcome contributions, please see [`CONTRIBUTING.md`](CONTRIBUTING.md) for suggestions and
 development-build instructions. For larger features, please open an issue to discuss goals and
 approach in order to ensure a smooth PR integration and review process.
+
+# Development Quick Installation
+```bash
+pip install -r requirements_dev.txt 
+```
+or 
+```bash
+conda install --file requirements_dev.txt
+```
+And then:
+```bash
+python setup.py develop --tiledb=<tile-db path>
+python -m pytest tiledb
+```

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,5 +13,6 @@ pyarrow >= 1.0
 pandas >= 1.0
 hypothesis >= 6.75
 psutil >= 5.9
+pytest >= 7.3
 contextvars ;python_version<"3.7"
 dataclasses ;python_version<"3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,5 +9,9 @@ pybind11 >= 2.6.2
 setuptools>=42,<=58.3.0
 setuptools_scm >= 1.5.4
 wheel >= 0.30
+pyarrow >= 1.0
+pandas >= 1.0
+hypothesis >= 6.75
+psutil >= 5.9
 contextvars ;python_version<"3.7"
 dataclasses ;python_version<"3.7"


### PR DESCRIPTION
This change makes it so that you can get from cloning the repo to running the tests in only 3 commands:
```
pip install -r requirements_dev.txt 
python setup.py develop --tiledb=<tile-db path>
python -m pytest tiledb
```
The version numbers that I put in are just the latest version, as I am not sure what the correct minimum version is.
