### PR TITLE
Fix "unexpected object type in string conversion" error when using booleans

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -154,6 +154,7 @@ cdef _write_array(
             try:
                 buffer, offsets = array_to_buffer(values[i], True, False)
             except Exception as exc:
+                print(exc)
                 raise type(exc)(f"Failed to convert buffer for attribute: '{attr.name}'") from exc
             buffer_offsets_sizes[i] = offsets.nbytes
         else:
@@ -2800,7 +2801,6 @@ def _setitem_impl_sparse(self: Array, selection, val, dict nullmaps):
                              "coordinate length ({})".format(attr_val.size, ncells))
         sparse_attributes.append(attr._internal_name)
         sparse_values.append(attr_val)
-
     if (len(sparse_attributes) + len(labels) != len(val.keys())) \
         or (len(sparse_values) + len(labels) != len(val.values())):
         raise TileDBError("Sparse write input data count does not match number of attributes")

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -154,7 +154,6 @@ cdef _write_array(
             try:
                 buffer, offsets = array_to_buffer(values[i], True, False)
             except Exception as exc:
-                print(exc)
                 raise type(exc)(f"Failed to convert buffer for attribute: '{attr.name}'") from exc
             buffer_offsets_sizes[i] = offsets.nbytes
         else:
@@ -2801,6 +2800,7 @@ def _setitem_impl_sparse(self: Array, selection, val, dict nullmaps):
                              "coordinate length ({})".format(attr_val.size, ncells))
         sparse_attributes.append(attr._internal_name)
         sparse_values.append(attr_val)
+
     if (len(sparse_attributes) + len(labels) != len(val.keys())) \
         or (len(sparse_values) + len(labels) != len(val.values())):
         raise TileDBError("Sparse write input data count does not match number of attributes")

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -320,14 +320,13 @@ if (PyUnicode_Check(u.ptr())) {
         auto arr = py::cast<py::array>(pyobj_p);
         sz = arr.nbytes();
         input_p = (const char *)arr.data();
-
       } else if (PyBool_Check(pyobj_p)) {
-  py::bool_ bool_obj = py::cast<py::bool_>(pyobj_p);
-  sz = sizeof(bool);
-  bool bool_value = bool_obj;
-  input_p = reinterpret_cast<const char*>(&bool_value);
-}
-else {
+        py::bool_ bool_obj = py::cast<py::bool_>(pyobj_p);
+        sz = sizeof(bool);
+        bool bool_value = bool_obj;
+        input_p = reinterpret_cast<const char*>(&bool_value);
+      }
+      else {
         // TODO add object type
         TPY_ERROR_LOC("Unexpected object type in buffer conversion");
       }
@@ -407,14 +406,13 @@ else {
         // handle (potentially) var-len embedded arrays
         sz = py::cast<py::array>(obj_p).nbytes();
       } else if (PyBool_Check(obj_p)) {
-  if (idx < 1)
-    first_dtype = py::dtype("bool");
+        if (idx < 1)
+            first_dtype = py::dtype("bool");
 
-  py::bool_ bool_obj = py::cast<py::bool_>(obj_p);
-  sz = sizeof(bool);
-bool bool_value = bool_obj;
+        py::bool_ bool_obj = py::cast<py::bool_>(obj_p);
+        sz = sizeof(bool);
+        bool bool_value = bool_obj;
         input_p = reinterpret_cast<const char*>(&bool_value);}
-
       else {
         auto errmsg =
             std::string("Unexpected object type in string conversion");
@@ -453,7 +451,6 @@ bool bool_value = bool_obj;
         sz = sizeof(bool);
         bool bool_value = bool_obj;
         input_p = reinterpret_cast<const char*>(&bool_value);
-
       }
     else {
         TPY_ERROR_LOC("Unexpected object type in buffer conversion");

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -279,6 +279,14 @@ if (PyUnicode_Check(u.ptr())) {
         }
 
         sz = a.nbytes();
+      } else if (PyBool_Check(o)) {
+        if (idx < 1)
+           first_dtype = py::dtype("bool");
+
+        auto a = py::cast<py::bool_>(o);
+        sz = sizeof(bool);
+        bool bool_value = a;
+        input_p = reinterpret_cast<const char*>(&bool_value);
       } else {
         // TODO write the type in the error here
         // auto o_h = py::reinterpret_borrow<py::object>(o);
@@ -312,7 +320,14 @@ if (PyUnicode_Check(u.ptr())) {
         auto arr = py::cast<py::array>(pyobj_p);
         sz = arr.nbytes();
         input_p = (const char *)arr.data();
-      } else {
+
+      } else if (PyBool_Check(pyobj_p)) {
+  py::bool_ bool_obj = py::cast<py::bool_>(pyobj_p);
+  sz = sizeof(bool);
+  bool bool_value = bool_obj;
+  input_p = reinterpret_cast<const char*>(&bool_value);
+}
+else {
         // TODO add object type
         TPY_ERROR_LOC("Unexpected object type in buffer conversion");
       }
@@ -391,7 +406,16 @@ if (PyUnicode_Check(u.ptr())) {
       } else if (npy_api.PyArray_Check_(obj_p)) {
         // handle (potentially) var-len embedded arrays
         sz = py::cast<py::array>(obj_p).nbytes();
-      } else {
+      } else if (PyBool_Check(obj_p)) {
+  if (idx < 1)
+    first_dtype = py::dtype("bool");
+
+  py::bool_ bool_obj = py::cast<py::bool_>(obj_p);
+  sz = sizeof(bool);
+bool bool_value = bool_obj;
+        input_p = reinterpret_cast<const char*>(&bool_value);}
+
+      else {
         auto errmsg =
             std::string("Unexpected object type in string conversion");
         TPY_ERROR_LOC(errmsg);
@@ -424,10 +448,16 @@ if (PyUnicode_Check(u.ptr())) {
         auto o_a = py::cast<py::array>(obj_h);
         sz = o_a.nbytes();
         input_p = (const char *)o_a.data();
-      } else {
+      } else if (PyBool_Check(obj_p)) {
+        py::bool_ bool_obj = py::cast<py::bool_>(obj_p);
+        sz = sizeof(bool);
+        bool bool_value = bool_obj;
+        input_p = reinterpret_cast<const char*>(&bool_value);
+
+      }
+    else {
         TPY_ERROR_LOC("Unexpected object type in buffer conversion");
       }
-
       memcpy(output_p, input_p, sz);
       // increment the output pointer for the next object
       output_p += sz;

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -452,9 +452,10 @@ if (PyUnicode_Check(u.ptr())) {
         bool bool_value = bool_obj;
         input_p = reinterpret_cast<const char*>(&bool_value);
       }
-    else {
+      else {
         TPY_ERROR_LOC("Unexpected object type in buffer conversion");
       }
+      
       memcpy(output_p, input_p, sz);
       // increment the output pointer for the next object
       output_p += sz;

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -281,12 +281,12 @@ if (PyUnicode_Check(u.ptr())) {
         sz = a.nbytes();
       } else if (PyBool_Check(o)) {
         if (idx < 1)
-           first_dtype = py::dtype("bool");
+          first_dtype = py::dtype("bool");
 
         auto a = py::cast<py::bool_>(o);
         sz = sizeof(bool);
         bool bool_value = a;
-        input_p = reinterpret_cast<const char*>(&bool_value);
+        input_p = reinterpret_cast<const char *>(&bool_value);
       } else {
         // TODO write the type in the error here
         // auto o_h = py::reinterpret_borrow<py::object>(o);
@@ -324,9 +324,8 @@ if (PyUnicode_Check(u.ptr())) {
         py::bool_ bool_obj = py::cast<py::bool_>(pyobj_p);
         sz = sizeof(bool);
         bool bool_value = bool_obj;
-        input_p = reinterpret_cast<const char*>(&bool_value);
-      }
-      else {
+        input_p = reinterpret_cast<const char *>(&bool_value);
+      } else {
         // TODO add object type
         TPY_ERROR_LOC("Unexpected object type in buffer conversion");
       }
@@ -407,13 +406,13 @@ if (PyUnicode_Check(u.ptr())) {
         sz = py::cast<py::array>(obj_p).nbytes();
       } else if (PyBool_Check(obj_p)) {
         if (idx < 1)
-            first_dtype = py::dtype("bool");
+          first_dtype = py::dtype("bool");
 
         py::bool_ bool_obj = py::cast<py::bool_>(obj_p);
         sz = sizeof(bool);
         bool bool_value = bool_obj;
-        input_p = reinterpret_cast<const char*>(&bool_value);}
-      else {
+        input_p = reinterpret_cast<const char *>(&bool_value);
+      } else {
         auto errmsg =
             std::string("Unexpected object type in string conversion");
         TPY_ERROR_LOC(errmsg);
@@ -450,12 +449,11 @@ if (PyUnicode_Check(u.ptr())) {
         py::bool_ bool_obj = py::cast<py::bool_>(obj_p);
         sz = sizeof(bool);
         bool bool_value = bool_obj;
-        input_p = reinterpret_cast<const char*>(&bool_value);
-      }
-      else {
+        input_p = reinterpret_cast<const char *>(&bool_value);
+      } else {
         TPY_ERROR_LOC("Unexpected object type in buffer conversion");
       }
-      
+
       memcpy(output_p, input_p, sz);
       // increment the output pointer for the next object
       output_p += sz;

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -866,8 +866,8 @@ class QueryConditionTest(DiskTestCase):
             A[range(1, len(a) + 1)] = {"a": a}
 
         with tiledb.open(path, "r") as A:
-            for k in A[:]:
-                assert k[0] is True
+            for k in A[:]["a"]:
+                assert k[0] == True
 
 
 class QueryDeleteTest(DiskTestCase):

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -847,19 +847,28 @@ class QueryConditionTest(DiskTestCase):
 
     def test_boolean_insert(self):
         path = self.path("test_boolean_insert")
-        attr=tiledb.Attr("a",dtype=np.bool_,var=True)
+        attr = tiledb.Attr("a", dtype=np.bool_, var=True)
         dom = tiledb.Domain(tiledb.Dim(domain=(1, 10), tile=1, dtype=np.uint32))
-        schema=tiledb.ArraySchema(domain=dom,sparse=True,attrs=[attr])
-        tiledb.Array.create(path,schema)
-        a=np.array(list(
-            [np.array([True],dtype=np.bool_),np.array([True],dtype=np.bool_),np.array([True],dtype=np.bool_),
-             np.array([True],dtype=np.bool_)]),dtype=object,)
-        with tiledb.open(path,'w') as A:
-            A[range(1, len(a)+1)]={"a":a}
+        schema = tiledb.ArraySchema(domain=dom, sparse=True, attrs=[attr])
+        tiledb.Array.create(path, schema)
+        a = np.array(
+            list(
+                [
+                    np.array([True], dtype=np.bool_),
+                    np.array([True], dtype=np.bool_),
+                    np.array([True], dtype=np.bool_),
+                    np.array([True], dtype=np.bool_),
+                ]
+            ),
+            dtype=object,
+        )
+        with tiledb.open(path, "w") as A:
+            A[range(1, len(a) + 1)] = {"a": a}
 
-        with tiledb.open(path,'r') as A:
+        with tiledb.open(path, "r") as A:
             for k in A[:]:
-                assert k[0]==True
+                assert k[0] is True
+
 
 class QueryDeleteTest(DiskTestCase):
     def test_basic_sparse(self):

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -867,7 +867,7 @@ class QueryConditionTest(DiskTestCase):
 
         with tiledb.open(path, "r") as A:
             for k in A[:]["a"]:
-                assert k[0] is True
+                assert k[0] == True  # noqa: E712
 
 
 class QueryDeleteTest(DiskTestCase):

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -867,7 +867,7 @@ class QueryConditionTest(DiskTestCase):
 
         with tiledb.open(path, "r") as A:
             for k in A[:]["a"]:
-                assert k[0] == True
+                assert k[0] is True
 
 
 class QueryDeleteTest(DiskTestCase):

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -845,6 +845,21 @@ class QueryConditionTest(DiskTestCase):
                 == list(enum2.values()).index("bb")
             )
 
+    def test_boolean_insert(self):
+        path = self.path("test_boolean_insert")
+        attr=tiledb.Attr("a",dtype=np.bool_,var=True)
+        dom = tiledb.Domain(tiledb.Dim(domain=(1, 10), tile=1, dtype=np.uint32))
+        schema=tiledb.ArraySchema(domain=dom,sparse=True,attrs=[attr])
+        tiledb.Array.create(path,schema)
+        a=np.array(list(
+            [np.array([True],dtype=np.bool_),np.array([True],dtype=np.bool_),np.array([True],dtype=np.bool_),
+             np.array([True],dtype=np.bool_)]),dtype=object,)
+        with tiledb.open(path,'w') as A:
+            A[range(1, len(a)+1)]={"a":a}
+
+        with tiledb.open(path,'r') as A:
+            for k in A[:]:
+                assert k[0]==True
 
 class QueryDeleteTest(DiskTestCase):
     def test_basic_sparse(self):


### PR DESCRIPTION
This fixes https://github.com/TileDB-Inc/TileDB-Py/issues/1730