### PR TITLE
Release 0.21.4 against TileDB 2.15.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,14 @@
+# Release 0.21.4
+
+## TileDB Embedded updates
+
+* TileDB-Py 0.21.3 includes TileDB Embedded [2.15.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.15.3)
+
 # Release 0.21.3
 
 ## TileDB Embedded updates
 
-* TileDB-Py 0.21.2 includes TileDB Embedded [2.15.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.15.2)
+* TileDB-Py 0.21.3 includes TileDB Embedded [2.15.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.15.2)
 
 ## Improvements
 

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,9 +6,9 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.21.3
-        LIBTILEDB_VERSION: 2.15.2
-        LIBTILEDB_SHA: 90f30ebfa0fc596076df382e146c9525767a39ce
+        TILEDBPY_VERSION: 0.21.4
+        LIBTILEDB_VERSION: 2.15.3
+        LIBTILEDB_SHA: 689bea02c3ab28a908d79ebfd1d744f0e5ea5415
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import Extension, find_packages, setup
 ### DO NOT USE ON CI
 
 # Target branch: Note that this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.15.2"
+TILEDB_VERSION = "2.15.3"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = os.environ.get("TILEDB_VERSION") or TILEDB_VERSION


### PR DESCRIPTION
```
In [9]: tiledb.version(), tiledb.libtiledb.version()
Out[9]: ((0, 21, 4), (2, 15, 3))
```