### PR TITLE
Fix an online-help typo, and clarify

### DIFF
--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -293,7 +293,7 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
 
     @property
     def version(self) -> int:
-        """The array's scehma version.
+        """The array's schema (storage) version.
 
         :rtype: int
         :raises :py:exc:`tiledb.TileDBError`


### PR DESCRIPTION
Raised by @bkmartinjr on Slack -- it needs to be clearer what version this is. Also, we have a typo.