### PR TITLE
Append nightly failure updates if an open Issue exists

### DIFF
--- a/.github/workflows/daily-test-build-issue-template.md
+++ b/.github/workflows/daily-test-build-issue-template.md
@@ -1,8 +1,9 @@
 ---
-title: Nightly GitHub Actions Build Fail on {{ date | date('ddd, MMMM Do YYYY') }}
+title: Nightly GitHub Actions Build Fail
 assignees: nguyenv, ihnorton
 labels: bug
 ---
 
+The nightly GitHub Actions build failed on {{ date | date('ddd, MMMM Do YYYY') }}.
 See run for more details:
 https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -94,3 +94,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/workflows/daily-test-build-issue-template.md
+          update_existing: true

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -96,3 +96,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           filename: .github/workflows/daily-test-build-issue-template.md
+          update_existing: true

--- a/.github/workflows/issue-if-azure-fail-template.md
+++ b/.github/workflows/issue-if-azure-fail-template.md
@@ -1,8 +1,9 @@
 ---
-title: Nightly Azure Wheel Fail on {{ date | date('ddd, MMMM Do YYYY') }}
+title: Nightly Azure Wheel Fail
 assignees: nguyenv, ihnorton
 labels: bug
 ---
 
+The nightly Azure wheel build failed on {{ date | date('ddd, MMMM Do YYYY') }}.
 See run for more details:
 https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=${{ env.AZURE_BUILD_ID }}&view=results

--- a/.github/workflows/issue-if-azure-fail.yml
+++ b/.github/workflows/issue-if-azure-fail.yml
@@ -30,3 +30,4 @@ jobs:
           AZURE_BUILD_ID: ${{ github.event.client_payload.data.build_id }}
         with:
           filename: .github/workflows/issue-if-azure-fail-template.md
+          update_existing: true


### PR DESCRIPTION
This PR updates all the nightly GitHub Actions workflows to append to an existing open Issue instead of always creating a new one.

The action [JasonEtco/create-an-issue](https://github.com/JasonEtco/create-an-issue) requires that the existing open Issue has the [exact same title](https://github.com/JasonEtco/create-an-issue/blob/main/action.yml#L20):

>  Update an open existing issue with the same title if it exists

I haven't tested this on my fork yet. If you approve of the strategy, I'll generate some spurious build errors on my fork to confirm it works as expected.

If you'd prefer to adopt this appending behavior but still keep the date of the initial build failure in the Issue title, we could switch to using the `gh` cli approach I have used in the past (eg [in TileDB-MariaDB](https://github.com/TileDB-Inc/TileDB-MariaDB/blob/master/scripts/nightly/open-issue.sh)). I'm able to allow different titles because I instead search for open Issues with the specific label [nightly-failure](https://github.com/TileDB-Inc/TileDB-MariaDB/issues?q=is%3Aissue+label%3Anightly-failure+is%3Aclosed)