### PR TITLE
Switch to TileDB-Inc/github-actions/open-issue

### DIFF
--- a/.github/disabled-workflows/release.yml
+++ b/.github/disabled-workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       #MACOSX_DEPLOYMENT_TARGET: "10.15"
     steps:
       - name: Checkout TileDB-Py `dev`
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: TileDB Python CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/daily-test-build-issue-template.md
+++ b/.github/workflows/daily-test-build-issue-template.md
@@ -1,9 +1,0 @@
----
-title: Nightly GitHub Actions Build Fail
-assignees: nguyenv, ihnorton
-labels: bug
----
-
-The nightly GitHub Actions build failed on {{ date | date('ddd, MMMM Do YYYY') }}.
-See run for more details:
-https://github.com/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     # runs every day at 5:00 UTC (1:00AM EST / Midnight CST)
     - cron: "0 5 * * *"
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -81,16 +81,16 @@ jobs:
         run: pytest -vv
 
   create_issue_on_fail:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     needs: test
     if: failure() || cancelled()
     steps:
-      - name: Checkout TileDB-Py `dev`
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - name: Create Issue if Build Fails
-        uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: TileDB-Inc/github-actions/open-issue@main
         with:
-          filename: .github/workflows/daily-test-build-issue-template.md
-          update_existing: true
+          name: nightly build with earilest supported numpy
+          label: bug,nightly-failure
+          assignee: nguyenv,ihnorton

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -36,7 +36,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-11' && contains(fromJson('["3.7", "3.8"]'), matrix.python-version) && '11.7' || '10.15' }}
     steps:
       - name: Checkout TileDB-Py `dev`
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -62,7 +62,7 @@ jobs:
         run: python -m pip install numpy==${{ matrix.numpy-version }}
 
       - name: Checkout TileDB-Py `dev`
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: python -m pip install --upgrade -r misc/requirements_ci.txt
@@ -87,7 +87,7 @@ jobs:
     needs: test
     if: failure() || cancelled()
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Create Issue if Build Fails
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -62,7 +62,7 @@ jobs:
         if: matrix.os == 'macos-11'
 
       - name: Checkout TileDB-Py `dev`
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: python -m pip install --upgrade -r misc/requirements_ci.txt
@@ -88,7 +88,7 @@ jobs:
     needs: test
     if: failure() || cancelled()
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Create Issue if Build Fails
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -36,8 +36,6 @@ jobs:
         uninstall_pandas: [true, false]
       fail-fast: false
 
-    permissions:
-      issues: write
     env:
       TILEDB_VERSION: ${{ matrix.libtiledb_version }}
       MACOSX_DEPLOYMENT_TARGET: "10.15"
@@ -84,16 +82,16 @@ jobs:
         run: pytest -vv
 
   create_issue_on_fail:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     needs: test
     if: failure() || cancelled()
     steps:
-      - name: Checkout TileDB-Py `dev`
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - name: Create Issue if Build Fails
-        uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: TileDB-Inc/github-actions/open-issue@main
         with:
-          filename: .github/workflows/daily-test-build-issue-template.md
-          update_existing: true
+          name: nightly build
+          label: bug,nightly-failure
+          assignee: nguyenv,ihnorton

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,6 @@
 name: TileDB Python Linting
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:

--- a/.github/workflows/issue-if-azure-fail-template.md
+++ b/.github/workflows/issue-if-azure-fail-template.md
@@ -1,9 +1,0 @@
----
-title: Nightly Azure Wheel Fail
-assignees: nguyenv, ihnorton
-labels: bug
----
-
-The nightly Azure wheel build failed on {{ date | date('ddd, MMMM Do YYYY') }}.
-See run for more details:
-https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=${{ env.AZURE_BUILD_ID }}&view=results

--- a/.github/workflows/issue-if-azure-fail.yml
+++ b/.github/workflows/issue-if-azure-fail.yml
@@ -1,6 +1,6 @@
 name: Create Issue if Build Fails on Azure
 
-on: [repository_dispatch]
+on: [repository_dispatch, workflow_dispatch]
 
 jobs:
   clean-branch:

--- a/.github/workflows/issue-if-azure-fail.yml
+++ b/.github/workflows/issue-if-azure-fail.yml
@@ -19,15 +19,15 @@ jobs:
           branches: "azure-wheel-test-${{ steps.date.outputs.date }}-against-${{ env.LIBTILEDB_SHA }}"
 
   notify-fail:
+    permissions:
+      issues: write
     if: github.event.action == 'failed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Create Issue if Build Fails
-        uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AZURE_BUILD_ID: ${{ github.event.client_payload.data.build_id }}
+        uses: TileDB-Inc/github-actions/open-issue@main
         with:
-          filename: .github/workflows/issue-if-azure-fail-template.md
-          update_existing: true
+          name: nightly Azure wheel
+          label: bug,nightly-azure-failure
+          assignee: nguyenv,ihnorton

--- a/.github/workflows/issue-if-azure-fail.yml
+++ b/.github/workflows/issue-if-azure-fail.yml
@@ -6,7 +6,7 @@ jobs:
   clean-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%a-%Y-%m-%d')"
@@ -24,7 +24,7 @@ jobs:
     if: github.event.action == 'failed'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Create Issue if Build Fails
         uses: TileDB-Inc/github-actions/open-issue@main
         with:


### PR DESCRIPTION
Follow up to https://github.com/TileDB-Inc/TileDB-Py/pull/1813. The new GitHub action [open-issue](https://github.com/TileDB-Inc/github-actions/tree/main/open-issue) comments on existing open Issues, instead of overwriting like the current action.

Before merging, someone with admin access to this repo needs to:

- [x] Create the Issue label `nightly-failure`
- [x] Create the Issue label `nightly-azure-failure`
- [x] Add the label `nightly-failure` to #1817 (but make sure to keep the label `bug`, the action is expecting both of them)

cc: @ihnorton, @nguyenv 
xref: https://github.com/TileDB-Inc/github-actions/pull/4, https://github.com/TileDB-Inc/TileDB-Py/issues/1817