### PR TITLE
Use object equality check in buffer conversion; fixes sc-33742

### DIFF
--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -498,7 +498,7 @@ public:
       }
     } else if (issubdtype(input_dtype, py::dtype("bytes"))) {
       convert_bytes();
-    } else if (!input_dtype.is(py::dtype("O"))) {
+    } else if (!input_dtype.equal(py::dtype("O"))) {
       // TODO TPY_ERROR_LOC
       throw std::runtime_error("expected object array");
     } else {

--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -7,56 +7,53 @@ import pytest
 
 import tiledb
 
-from .common import DiskTestCase
-
 pd = pytest.importorskip("pandas")
 tm = pd._testing
 
 
-class AttrDataTest(DiskTestCase):
-    @hp.settings(deadline=None, verbosity=hp.Verbosity.verbose)
-    @hp.given(st.binary())
-    @pytest.mark.parametrize("mode", ["np", "df"])
-    def test_bytes_npdf(self, mode, data):
-        start = time.time()
+@pytest.mark.parametrize("mode", ["np", "df"])
+@hp.settings(deadline=None, verbosity=hp.Verbosity.verbose)
+@hp.given(st.binary())
+def test_bytes_npdf(checked_path, mode, data):
+    start = time.time()
 
-        uri = "mem://" + self.path()
-        hp.note(f"!!! self.path() '{uri}' time: {time.time() - start}")
+    uri = "mem://" + checked_path.path()
+    hp.note(f"!!! path '{uri}' time: {time.time() - start}")
 
-        array = np.array([data], dtype="S0")
+    array = np.array([data], dtype="S0")
 
-        start_ingest = time.time()
+    start_ingest = time.time()
+    if mode == "np":
+        with tiledb.from_numpy(uri, array) as A:
+            pass
+    else:
+        series = pd.Series(array)
+        df = pd.DataFrame({"": series})
+        # NOTE: ctx required here for mem://
+        tiledb.from_pandas(uri, df, sparse=False, ctx=tiledb.default_ctx())
+
+    hp.note(f"{mode} ingest time: {time.time() - start_ingest}")
+
+    # DEBUG
+    tiledb.stats_enable()
+    tiledb.stats_reset()
+    # END DEBUG
+
+    with tiledb.open(uri) as A:
         if mode == "np":
-            with tiledb.from_numpy(uri, array) as A:
-                pass
+            np.testing.assert_array_equal(A.multi_index[:][""], array)
         else:
-            series = pd.Series(array)
-            df = pd.DataFrame({"": series})
-            # NOTE: ctx required here for mem://
-            tiledb.from_pandas(uri, df, sparse=False, ctx=tiledb.default_ctx())
+            tm.assert_frame_equal(A.df[:], df)
 
-        hp.note(f"{mode} ingest time: {time.time() - start_ingest}")
+    hp.note(tiledb.stats_dump(print_out=False))
 
-        # DEBUG
-        tiledb.stats_enable()
-        tiledb.stats_reset()
-        # END DEBUG
+    # DEBUG
+    tiledb.stats_disable()
 
-        with tiledb.open(uri) as A:
-            if mode == "np":
-                np.testing.assert_array_equal(A.multi_index[:][""], array)
-            else:
-                tm.assert_frame_equal(A.df[:], df)
-
-        hp.note(tiledb.stats_dump(print_out=False))
-
-        # DEBUG
-        tiledb.stats_disable()
-
-        duration = time.time() - start
-        hp.note(f"!!! test_bytes_{mode} duration: {duration}")
-        if duration > 2:
-            # Hypothesis setup is (maybe) causing deadline exceeded errors
-            # https://github.com/TileDB-Inc/TileDB-Py/issues/1194
-            # Set deadline=None and use internal timing instead.
-            pytest.fail(f"!!! {mode} function body duration exceeded 2s: {duration}")
+    duration = time.time() - start
+    hp.note(f"!!! test_bytes_{mode} duration: {duration}")
+    if duration > 2:
+        # Hypothesis setup is (maybe) causing deadline exceeded errors
+        # https://github.com/TileDB-Inc/TileDB-Py/issues/1194
+        # Set deadline=None and use internal timing instead.
+        pytest.fail(f"!!! {mode} function body duration exceeded 2s: {duration}")

--- a/tiledb/tests/test_multi_index-hp.py
+++ b/tiledb/tests/test_multi_index-hp.py
@@ -81,9 +81,11 @@ class TestMultiIndexPropertySparse:
 
         return uri
 
-    @pytest.mark.parametrize("order", ["C", "F", "U"])
-    @given(st.lists(bounded_ntuple(length=2, min_value=-100, max_value=100)))
-    def test_multi_index_two_way_query(self, order, sparse_array_1d, ranges):
+    @given(
+        order=st.sampled_from(["C", "F", "U"]),
+        ranges=st.lists(bounded_ntuple(length=2, min_value=-100, max_value=100)),
+    )
+    def test_multi_index_two_way_query(self, order, ranges, sparse_array_1d):
         """This test checks the result of "direct" range queries using PyQuery
         against the result of `multi_index` on the same ranges."""
 


### PR DESCRIPTION
The test here fails when run with dask distributed. The array is passed through dask serialization, and the buffer conversion fails because the dtype object in the npbuffer.cc line modified here returns False. This is because the array's dtype is not === to the dtype("O") object in the parent process after serialization.