### PR TITLE
Add Support For `SchemaEvolution` on Enumerations

### DIFF
--- a/tiledb/schema_evolution.py
+++ b/tiledb/schema_evolution.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 import tiledb
 
-from .main import ArraySchemaEvolution as ASE
 from .enumeration import Enumeration
+from .main import ArraySchemaEvolution as ASE
 
 
 class ArraySchemaEvolution:
@@ -29,7 +29,7 @@ class ArraySchemaEvolution:
         only applied when `ArraySchemaEvolution.array_evolve` is called."""
 
         self.ase.drop_attribute(attr_name)
-    
+
     def add_enumeration(self, enmr: Enumeration):
         """Add the given enumeration to the schema evolution plan.
         Note: this function does not apply any changes; the changes are
@@ -43,7 +43,7 @@ class ArraySchemaEvolution:
         only applied when `ArraySchemaEvolution.array_evolve` is called."""
 
         self.ase.drop_enumeration(enmr_name)
-    
+
     def array_evolve(self, uri: str):
         """Apply ArraySchemaEvolution actions to Array at given URI."""
 

--- a/tiledb/schema_evolution.py
+++ b/tiledb/schema_evolution.py
@@ -3,6 +3,7 @@ from typing import Optional
 import tiledb
 
 from .main import ArraySchemaEvolution as ASE
+from .enumeration import Enumeration
 
 
 class ArraySchemaEvolution:
@@ -28,7 +29,21 @@ class ArraySchemaEvolution:
         only applied when `ArraySchemaEvolution.array_evolve` is called."""
 
         self.ase.drop_attribute(attr_name)
+    
+    def add_enumeration(self, enmr: Enumeration):
+        """Add the given enumeration to the schema evolution plan.
+        Note: this function does not apply any changes; the changes are
+        only applied when `ArraySchemaEvolution.array_evolve` is called."""
 
+        self.ase.add_enumeration(enmr)
+
+    def drop_enumeration(self, enmr_name: str):
+        """Drop the given enumeration (by name) in the schema evolution.
+        Note: this function does not apply any changes; the changes are
+        only applied when `ArraySchemaEvolution.array_evolve` is called."""
+
+        self.ase.drop_enumeration(enmr_name)
+    
     def array_evolve(self, uri: str):
         """Apply ArraySchemaEvolution actions to Array at given URI."""
 

--- a/tiledb/tests/test_schema_evolution.py
+++ b/tiledb/tests/test_schema_evolution.py
@@ -116,6 +116,7 @@ def test_schema_evolution_timestamp(tmp_path):
 
     assert 123456789 in get_schema_timestamps(schema_uri)
 
+
 def test_schema_evolution_with_enmr(tmp_path):
     ctx = tiledb.default_ctx()
     se = tiledb.ArraySchemaEvolution(ctx)
@@ -138,7 +139,7 @@ def test_schema_evolution_with_enmr(tmp_path):
 
     with tiledb.open(uri, "w") as A:
         A[:] = data1
-        
+
     with tiledb.open(uri) as A:
         assert not A.schema.has_attr("a3")
 
@@ -148,22 +149,22 @@ def test_schema_evolution_with_enmr(tmp_path):
     with pytest.raises(tiledb.TileDBError) as excinfo:
         se.array_evolve(uri)
     assert " Attribute refers to an unknown enumeration" in str(excinfo.value)
-    
+
     se.add_enumeration(tiledb.Enumeration("e3", True, np.arange(0, 8)))
     se.array_evolve(uri)
-    
+
     with tiledb.open(uri) as A:
         assert A.schema.has_attr("a3")
         assert A.attr("a3").enum_label == "e3"
-    
+
     se.drop_enumeration("e3")
-    
+
     with pytest.raises(tiledb.TileDBError) as excinfo:
         se.array_evolve(uri)
     assert "the enumeration has not been loaded" in str(excinfo.value)
-    
+
     se.drop_attribute("a3")
     se.array_evolve(uri)
-    
+
     with tiledb.open(uri) as A:
         assert not A.schema.has_attr("a3")


### PR DESCRIPTION
This PR adds `SchemaEvolution.add_enumeration` and `SchemaEvolution.drop_enumeration`. The bindings were done in a previous PR but never added to `SchemaEvolution`.