### PR TITLE
Additional Support For Nullable Attributes

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1183,7 +1183,8 @@ public:
     py::dict results;
     for (auto &buffer_name : buffers_order_) {
       auto bp = buffers_.at(buffer_name);
-      results[py::str(buffer_name)] = py::make_tuple(bp.data, bp.offsets);
+      results[py::str(buffer_name)] =
+          py::make_tuple(bp.data, bp.offsets, bp.validity);
     }
     return results;
   }

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2309,7 +2309,7 @@ cdef class DenseArrayImpl(Array):
                         
                         if attr.isnullable and name not in nullmaps:
                             nullmaps[name] = ~np.ma.masked_invalid(attr_val).mask
-                        attr_val = np.ascontiguousarray(attr_val, dtype=attr.dtype)
+                        attr_val = np.ascontiguousarray(np.nan_to_num(attr_val), dtype=attr.dtype)
                 except Exception as exc:
                     raise ValueError(f"NumPy array conversion check failed for attr '{name}'") from exc
                 
@@ -2342,8 +2342,8 @@ cdef class DenseArrayImpl(Array):
                                         "typed attribute '{}'!".format(name))
                     
                     if attr.isnullable and name not in nullmaps:
-                        nullmaps[name] = ~np.ma.masked_invalid(val).mask
-                    val = np.ascontiguousarray(val, dtype=attr.dtype)
+                        nullmaps[name] = ~np.ma.fix_invalid(val).mask
+                    val = np.ascontiguousarray(np.nan_to_num(val), dtype=attr.dtype)
             except Exception as exc:
                 raise ValueError(f"NumPy array conversion check failed for attr '{name}'") from exc
             values.append(val)
@@ -2828,7 +2828,7 @@ def _setitem_impl_sparse(self: Array, selection, val, dict nullmaps):
                 
                 if attr.isnullable and name not in nullmaps:
                     nullmaps[name] = ~np.ma.masked_invalid(attr_val).mask
-                attr_val = np.ascontiguousarray(attr_val, dtype=attr.dtype)
+                attr_val = np.ascontiguousarray(np.nan_to_num(attr_val), dtype=attr.dtype)
 
         except Exception as exc:
             raise ValueError(f"NumPy array conversion check failed for attr '{name}'") from exc

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2309,7 +2309,8 @@ cdef class DenseArrayImpl(Array):
                         
                         if attr.isnullable and name not in nullmaps:
                             nullmaps[name] = ~np.ma.masked_invalid(attr_val).mask
-                        attr_val = np.ascontiguousarray(np.nan_to_num(attr_val), dtype=attr.dtype)
+                            attr_val = np.nan_to_num(attr_val)
+                        attr_val = np.ascontiguousarray(attr_val, dtype=attr.dtype)
                 except Exception as exc:
                     raise ValueError(f"NumPy array conversion check failed for attr '{name}'") from exc
                 
@@ -2343,7 +2344,8 @@ cdef class DenseArrayImpl(Array):
                     
                     if attr.isnullable and name not in nullmaps:
                         nullmaps[name] = ~np.ma.fix_invalid(val).mask
-                    val = np.ascontiguousarray(np.nan_to_num(val), dtype=attr.dtype)
+                        val = np.nan_to_num(val)
+                    val = np.ascontiguousarray(val, dtype=attr.dtype)
             except Exception as exc:
                 raise ValueError(f"NumPy array conversion check failed for attr '{name}'") from exc
             values.append(val)
@@ -2828,7 +2830,8 @@ def _setitem_impl_sparse(self: Array, selection, val, dict nullmaps):
                 
                 if attr.isnullable and name not in nullmaps:
                     nullmaps[name] = ~np.ma.masked_invalid(attr_val).mask
-                attr_val = np.ascontiguousarray(np.nan_to_num(attr_val), dtype=attr.dtype)
+                    attr_val = np.nan_to_num(attr_val)
+                attr_val = np.ascontiguousarray(attr_val, dtype=attr.dtype)
 
         except Exception as exc:
             raise ValueError(f"NumPy array conversion check failed for attr '{name}'") from exc

--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_equal
 
 import tiledb
 
-from .common import DiskTestCase, has_pandas
+from .common import DiskTestCase, has_pandas, has_pyarrow
 
 
 class EnumerationTest(DiskTestCase):
@@ -82,47 +82,25 @@ class EnumerationTest(DiskTestCase):
                 assert_array_equal(A.df[:]["attr1"], A[:]["attr1"])
                 assert_array_equal(A.df[:]["attr2"], A[:]["attr2"])
 
+    @pytest.mark.skipif(
+        not has_pyarrow() or not has_pandas(),
+        reason="pyarrow and/or pandas not installed",
+    )
     def test_array_schema_enumeration_nullable(self):
-        uri = self.path("test_array_schema_enumeration")
-        dom = tiledb.Domain(tiledb.Dim(domain=(1, 8), tile=1))
-        enum1 = tiledb.Enumeration("enmr1", False, np.arange(3) * 10)
-        enum2 = tiledb.Enumeration("enmr2", False, ["a", "bb", "ccc"])
-        attr1 = tiledb.Attr("attr1", dtype=np.int32, enum_label="enmr1")
-        attr2 = tiledb.Attr("attr2", dtype=np.int32, enum_label="enmr2")
-        attr3 = tiledb.Attr("attr3", dtype=np.int32)
-        schema = tiledb.ArraySchema(
-            domain=dom, attrs=(attr1, attr2, attr3), enums=(enum1, enum2)
-        )
+        import pyarrow as pa
+
+        uri = self.path("test_array_schema_enumeration_nullable")
+        enmr = tiledb.Enumeration("e", False, ["alpha", "beta", "gamma"])
+        dom = tiledb.Domain(tiledb.Dim("d", domain=(0, 2147483646), dtype="int64"))
+        att = tiledb.Attr("a", dtype="int8", nullable=True, enum_label="e")
+        schema = tiledb.ArraySchema(domain=dom, attrs=[att], enums=[enmr], sparse=True)
         tiledb.Array.create(uri, schema)
 
-        data1 = np.random.randint(0, 3, 8)
-        data2 = np.random.randint(0, 3, 8)
-        data3 = np.random.randint(0, 3, 8)
-
         with tiledb.open(uri, "w") as A:
-            A[:] = {"attr1": data1, "attr2": data2, "attr3": data3}
+            dims = pa.array([1, 2, 3, 4, 5])
+            data = pa.array([1.0, 2.0, None, 0, 1.0])
+            A[dims] = data
 
         with tiledb.open(uri, "r") as A:
-            assert A.enum("enmr1") == enum1
-            assert attr1.enum_label == "enmr1"
-            assert A.attr("attr1").enum_label == "enmr1"
-
-            assert A.enum("enmr2") == enum2
-            assert attr2.enum_label == "enmr2"
-            assert A.attr("attr2").enum_label == "enmr2"
-
-            with self.assertRaises(tiledb.TileDBError) as excinfo:
-                assert A.enum("enmr3") == []
-            assert " No enumeration named 'enmr3'" in str(excinfo.value)
-            assert attr3.enum_label is None
-            assert A.attr("attr3").enum_label is None
-
-            if has_pandas():
-                assert_array_equal(A.df[:]["attr1"].cat.codes, data1)
-                assert_array_equal(A.df[:]["attr2"].cat.codes, data2)
-
-                assert_array_equal(A.df[:]["attr1"], A.multi_index[:]["attr1"])
-                assert_array_equal(A.df[:]["attr2"], A.multi_index[:]["attr2"])
-
-                assert_array_equal(A.df[:]["attr1"], A[:]["attr1"])
-                assert_array_equal(A.df[:]["attr2"], A[:]["attr2"])
+            assert_array_equal(A[:]["a"].mask, [False, False, True, False, False])
+            assert_array_equal(A[:]["a"], A.df[:]["a"])


### PR DESCRIPTION
**Background**

As detailed in sc-34754, this fixes a bug found by a customer using the TileDB-SOMA Python API where the `SOMADataFrame` containing an enumerated nullable attribute was not being readback correctly. This highlights a larger deficit in the TileDB-Py codebase in which we have [little support](https://docs.tiledb.com/main/how-to/arrays/writing-arrays/nullable-attributes) for writing nullable attributes outside of utilizing `tiledb.from_pandas` with Pandas's `ExtensionDtype`.

**Changes**

- This PR supports writing Pyarrow arrays and Pandas dataframes that contain nullable values (`pd.NA`, `pa.na`, `None`, etc.). 
- Nullable attributes are now represented in Numpy as [masked arrays](https://numpy.org/doc/stable/reference/maskedarray.html). 
- `PyQuery` results now also return the validity buffer.
- Note that in Pyarrow, the validity values represent 0 = invalid, 1 = valid, whereas in Numpy, this is inverted and mask values represent 0 = valid, 1 = invalid.

**Future Proposals**

- Support writing `numpy.ma` for nullable attributes.

```
with tiledb.open(uri, "w') as A:
   A[:] = np.ma.array(data, mask)
```

- Support writing with built-in sequences (eg. `list`, `tuple`). Internally, we check if the attribute `.isnullable()` and then cast using `np.ma.masked_invalid()`.

```
with tiledb.open(uri, "w') as A:
   A[:] = [1, 2, None, 3]
```