### PR TITLE
Support New Set Membership Query Condition

### DIFF
--- a/tiledb/query_condition.cc
+++ b/tiledb/query_condition.cc
@@ -66,10 +66,9 @@ public:
   }
 
   template <typename T>
-  static PyQueryCondition create(py::object pyctx,
-                                 const std::string &field_name,
-                                 const std::vector<T> &values,
-                                 tiledb_query_condition_op_t op) {
+  static PyQueryCondition
+  create(py::object pyctx, const std::string &field_name,
+         const std::vector<T> &values, tiledb_query_condition_op_t op) {
     auto pyqc = PyQueryCondition(pyctx);
 
     const Context ctx = std::as_const(pyqc.ctx_);
@@ -175,59 +174,59 @@ void init_query_condition(py::module &m) {
 
       .def_static(
           "create_string",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<std::string> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create))
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<std::string> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_uint64",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<uint64_t> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create))
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<uint64_t> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_int64",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<int64_t> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create))
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<int64_t> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_uint32",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<uint32_t> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create))
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<uint32_t> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_int32",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<int32_t> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create))
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<int32_t> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_uint16",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<uint16_t> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create))
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<uint16_t> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_int8",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<int8_t> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create))
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<int8_t> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_uint16",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<uint16_t> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create))
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<uint16_t> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_int8",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<int8_t> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create))
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<int8_t> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_float32",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<float> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create))
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<float> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create))
       .def_static(
           "create_float64",
-          static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<double> &, tiledb_query_condition_op_t)>(
-              &PyQueryCondition::create));
+          static_cast<PyQueryCondition (*)(
+              py::object, const std::string &, const std::vector<double> &,
+              tiledb_query_condition_op_t)>(&PyQueryCondition::create));
 
   py::enum_<tiledb_query_condition_op_t>(m, "tiledb_query_condition_op_t",
                                          py::arithmetic())

--- a/tiledb/query_condition.cc
+++ b/tiledb/query_condition.cc
@@ -68,13 +68,14 @@ public:
   template <typename T>
   static PyQueryCondition create(py::object pyctx,
                                  const std::string &field_name,
-                                 const std::vector<T> &values) {
+                                 const std::vector<T> &values,
+                                 tiledb_query_condition_op_t op) {
     auto pyqc = PyQueryCondition(pyctx);
 
     const Context ctx = std::as_const(pyqc.ctx_);
 
     auto set_membership_qc =
-        QueryConditionExperimental::create(ctx, field_name, values, TILEDB_IN);
+        QueryConditionExperimental::create(ctx, field_name, values, op);
 
     pyqc.qc_ = std::make_shared<QueryCondition>(std::move(set_membership_qc));
 
@@ -175,57 +176,57 @@ void init_query_condition(py::module &m) {
       .def_static(
           "create_string",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<std::string> &)>(
+                                           const std::vector<std::string> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create))
       .def_static(
           "create_uint64",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<uint64_t> &)>(
+                                           const std::vector<uint64_t> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create))
       .def_static(
           "create_int64",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<int64_t> &)>(
+                                           const std::vector<int64_t> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create))
       .def_static(
           "create_uint32",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<uint32_t> &)>(
+                                           const std::vector<uint32_t> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create))
       .def_static(
           "create_int32",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<int32_t> &)>(
+                                           const std::vector<int32_t> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create))
       .def_static(
           "create_uint16",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<uint16_t> &)>(
+                                           const std::vector<uint16_t> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create))
       .def_static(
           "create_int8",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<int8_t> &)>(
+                                           const std::vector<int8_t> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create))
       .def_static(
           "create_uint16",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<uint16_t> &)>(
+                                           const std::vector<uint16_t> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create))
       .def_static(
           "create_int8",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<int8_t> &)>(
+                                           const std::vector<int8_t> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create))
       .def_static(
           "create_float32",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<float> &)>(
+                                           const std::vector<float> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create))
       .def_static(
           "create_float64",
           static_cast<PyQueryCondition (*)(py::object, const std::string &,
-                                           const std::vector<double> &)>(
+                                           const std::vector<double> &, tiledb_query_condition_op_t)>(
               &PyQueryCondition::create));
 
   py::enum_<tiledb_query_condition_op_t>(m, "tiledb_query_condition_op_t",
@@ -237,6 +238,7 @@ void init_query_condition(py::module &m) {
       .value("TILEDB_EQ", TILEDB_EQ)
       .value("TILEDB_NE", TILEDB_NE)
       .value("TILEDB_IN", TILEDB_IN)
+      .value("TILEDB_NOT_IN", TILEDB_NOT_IN)
       .export_values();
 
   py::enum_<tiledb_query_condition_combination_op_t>(

--- a/tiledb/query_condition.cc
+++ b/tiledb/query_condition.cc
@@ -65,10 +65,25 @@ public:
                                                     use_enumeration);
   }
 
-  PyQueryCondition
-  combine(PyQueryCondition rhs,
-          tiledb_query_condition_combination_op_t combination_op) const {
+  template <typename T>
+  static PyQueryCondition create(py::object pyctx,
+                                 const std::string &field_name,
+                                 const std::vector<T> &values) {
+    auto pyqc = PyQueryCondition(pyctx);
 
+    const Context ctx = std::as_const(pyqc.ctx_);
+
+    auto set_membership_qc =
+        QueryConditionExperimental::create(ctx, field_name, values, TILEDB_IN);
+
+    pyqc.qc_ = std::make_shared<QueryCondition>(std::move(set_membership_qc));
+
+    return pyqc;
+  }
+
+  PyQueryCondition
+  combine(PyQueryCondition qc,
+          tiledb_query_condition_combination_op_t combination_op) const {
     auto pyqc = PyQueryCondition(nullptr, ctx_.ptr().get());
 
     tiledb_query_condition_t *combined_qc = nullptr;
@@ -76,8 +91,8 @@ public:
         tiledb_query_condition_alloc(ctx_.ptr().get(), &combined_qc));
 
     ctx_.handle_error(tiledb_query_condition_combine(
-        ctx_.ptr().get(), qc_->ptr().get(), rhs.qc_->ptr().get(),
-        combination_op, &combined_qc));
+        ctx_.ptr().get(), qc_->ptr().get(), qc.qc_->ptr().get(), combination_op,
+        &combined_qc));
 
     pyqc.qc_ = std::shared_ptr<QueryCondition>(
         new QueryCondition(pyqc.ctx_, combined_qc));
@@ -112,7 +127,6 @@ void init_query_condition(py::module &m) {
            static_cast<void (PyQueryCondition::*)(
                const string &, const string &, tiledb_query_condition_op_t)>(
                &PyQueryCondition::init))
-
       .def("init_uint64",
            static_cast<void (PyQueryCondition::*)(const string &, uint64_t,
                                                   tiledb_query_condition_op_t)>(
@@ -145,7 +159,6 @@ void init_query_condition(py::module &m) {
            static_cast<void (PyQueryCondition::*)(const string &, int8_t,
                                                   tiledb_query_condition_op_t)>(
                &PyQueryCondition::init))
-
       .def("init_float32",
            static_cast<void (PyQueryCondition::*)(const string &, float,
                                                   tiledb_query_condition_op_t)>(
@@ -157,7 +170,63 @@ void init_query_condition(py::module &m) {
 
       .def("__capsule__", &PyQueryCondition::__capsule__)
 
-      .def("combine", &PyQueryCondition::combine);
+      .def("combine", &PyQueryCondition::combine)
+
+      .def_static(
+          "create_string",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<std::string> &)>(
+              &PyQueryCondition::create))
+      .def_static(
+          "create_uint64",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<uint64_t> &)>(
+              &PyQueryCondition::create))
+      .def_static(
+          "create_int64",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<int64_t> &)>(
+              &PyQueryCondition::create))
+      .def_static(
+          "create_uint32",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<uint32_t> &)>(
+              &PyQueryCondition::create))
+      .def_static(
+          "create_int32",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<int32_t> &)>(
+              &PyQueryCondition::create))
+      .def_static(
+          "create_uint16",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<uint16_t> &)>(
+              &PyQueryCondition::create))
+      .def_static(
+          "create_int8",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<int8_t> &)>(
+              &PyQueryCondition::create))
+      .def_static(
+          "create_uint16",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<uint16_t> &)>(
+              &PyQueryCondition::create))
+      .def_static(
+          "create_int8",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<int8_t> &)>(
+              &PyQueryCondition::create))
+      .def_static(
+          "create_float32",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<float> &)>(
+              &PyQueryCondition::create))
+      .def_static(
+          "create_float64",
+          static_cast<PyQueryCondition (*)(py::object, const std::string &,
+                                           const std::vector<double> &)>(
+              &PyQueryCondition::create));
 
   py::enum_<tiledb_query_condition_op_t>(m, "tiledb_query_condition_op_t",
                                          py::arithmetic())
@@ -167,6 +236,7 @@ void init_query_condition(py::module &m) {
       .value("TILEDB_GE", TILEDB_GE)
       .value("TILEDB_EQ", TILEDB_EQ)
       .value("TILEDB_NE", TILEDB_NE)
+      .value("TILEDB_IN", TILEDB_IN)
       .export_values();
 
   py::enum_<tiledb_query_condition_combination_op_t>(

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -216,7 +216,7 @@ class QueryConditionTree(ast.NodeVisitor):
                 )
 
             variable = node.left.id
-            values = [val.value for val in self.visit(rhs)]
+            values = [self.get_value_from_node(val) for val in self.visit(rhs)]
 
             if self.array.schema.has_attr(variable):
                 enum_label = self.array.attr(variable).enum_label

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -215,14 +215,20 @@ class QueryConditionTree(ast.NodeVisitor):
                     "`in` operator syntax must be written as `variable in ['l', 'i', 's', 't']`"
                 )
 
-            consts = self.visit(rhs)
-            result = self.aux_visit_Compare(
-                self.visit(node.left), qc.TILEDB_EQ, consts[0]
-            )
+            variable = node.left.id
+            values = [val.value for val in self.visit(rhs)]
 
-            for val in consts[1:]:
-                value = self.aux_visit_Compare(self.visit(node.left), qc.TILEDB_EQ, val)
-                result = result.combine(value, qc.TILEDB_OR)
+            if self.array.schema.has_attr(variable):
+                enum_label = self.array.attr(variable).enum_label
+                if enum_label is not None:
+                    dt = self.array.enum(enum_label).dtype
+                else:
+                    dt = self.array.attr(variable).dtype
+            else:
+                dt = self.array.schema.attr_or_dim_dtype(variable)
+
+            dtype = "string" if dt.kind in "SUa" else dt.name
+            result = self.create_pyqc(dtype)(self.ctx, node.left.id, values)
 
         return result
 
@@ -400,6 +406,20 @@ class QueryConditionTree(ast.NodeVisitor):
             raise TileDBError(f"PyQueryCondition.{init_fn_name}() not found.")
 
         return getattr(pyqc, init_fn_name)
+
+    def create_pyqc(self, dtype: str) -> Callable:
+        if dtype != "string":
+            if np.issubdtype(dtype, np.datetime64):
+                dtype = "int64"
+            elif np.issubdtype(dtype, bool):
+                dtype = "uint8"
+
+        create_fn_name = f"create_{dtype}"
+
+        if not hasattr(qc.PyQueryCondition, create_fn_name):
+            raise TileDBError(f"PyQueryCondition.{create_fn_name}() not found.")
+
+        return getattr(qc.PyQueryCondition, create_fn_name)
 
     def visit_BinOp(self, node: ast.BinOp) -> qc.PyQueryCondition:
         try:

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -179,7 +179,7 @@ class QueryConditionTree(ast.NodeVisitor):
 
     def visit_In(self, node):
         return node
-    
+
     def visit_NotIn(self, node):
         return node
 

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -546,6 +546,10 @@ class QueryConditionTest(DiskTestCase):
 
             result = A.query(cond="S in ['8']")[:]
             assert len(result["S"]) == 0
+            
+            result = A.query(cond="U not in [5, 6, 7]")[:]
+            for val in result["U"]:
+                assert val not in [5, 6, 7]
 
     def test_in_operator_dense(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=False)) as A:
@@ -573,6 +577,10 @@ class QueryConditionTest(DiskTestCase):
 
             result = A.query(cond="S in ['8']")[:]
             assert len(self.filter_dense(result["S"], S_mask)) == 0
+            
+            result = A.query(cond="U not in [5, 6, 7]")[:]
+            for val in self.filter_dense(result["U"], U_mask):
+                assert val not in [5, 6, 7]
 
     @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_dense_datetime(self):

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -546,7 +546,7 @@ class QueryConditionTest(DiskTestCase):
 
             result = A.query(cond="S in ['8']")[:]
             assert len(result["S"]) == 0
-            
+
             result = A.query(cond="U not in [5, 6, 7]")[:]
             for val in result["U"]:
                 assert val not in [5, 6, 7]
@@ -577,7 +577,7 @@ class QueryConditionTest(DiskTestCase):
 
             result = A.query(cond="S in ['8']")[:]
             assert len(self.filter_dense(result["S"], S_mask)) == 0
-            
+
             result = A.query(cond="U not in [5, 6, 7]")[:]
             for val in self.filter_dense(result["U"], U_mask):
                 assert val not in [5, 6, 7]


### PR DESCRIPTION
* Switch out the old set membership internal code with new faster method in core
* No visible changes to the user

TODO

- [X] John will provide data to check new code against large cell-single dataset
- [x] Support `not in`