### PR TITLE
Correct Nullable String Attributes and All NULL Data

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2311,7 +2311,9 @@ cdef class DenseArrayImpl(Array):
                         attr_val = np.asarray(attr_val)
                         if attr.isnullable and name not in nullmaps:
                             nullmaps[name] = np.array(
-                                [int(v is not None) for v in attr_val], dtype=np.uint8)
+                                [int(v is not None) for v in attr_val], 
+                                dtype=np.uint8
+                            )
                     else:
                         if (np.issubdtype(attr.dtype, np.string_) and not
                             (np.issubdtype(attr_val.dtype, np.string_) or attr_val.dtype == np.dtype('O'))):
@@ -2322,14 +2324,19 @@ cdef class DenseArrayImpl(Array):
                             try:
                                 nullmaps[name] = ~np.ma.masked_invalid(attr_val).mask
                             except Exception as exc:
+                                attr_val = np.asarray(attr_val)
                                 nullmaps[name] = np.array(
-                                    [int(v is not None) for v in attr_val], dtype=np.uint8)
+                                    [int(v is not None) for v in attr_val], 
+                                    dtype=np.uint8
+                                )
 
                             if np.issubdtype(attr.dtype, np.string_):
-                                attr_val = np.array(["" if v is None else v for v in attr_val])
+                                attr_val = np.array(
+                                    ["" if v is None else v for v in attr_val])
                             else:
                                 attr_val = np.nan_to_num(attr_val)
-                                attr_val = np.array([0 if v is None else v for v in attr_val])
+                                attr_val = np.array(
+                                    [0 if v is None else v for v in attr_val])
                         attr_val = np.ascontiguousarray(attr_val, dtype=attr.dtype)
                 except Exception as exc:
                     raise ValueError(f"NumPy array conversion check failed for attr '{name}'") from exc

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -152,12 +152,15 @@ cdef _write_array(
 
         if attr.isvar:
             try:
-                if(np.issubdtype(attr.dtype, np.unicode_) 
-                    or np.issubdtype(attr.dtype, np.string_) 
-                    or np.issubdtype(attr.dtype, np.bytes_)):
-                    attr_val = np.array(["" if v is None else v for v in values[i]])
+                if attr.isnullable:
+                    if(np.issubdtype(attr.dtype, np.unicode_) 
+                        or np.issubdtype(attr.dtype, np.string_) 
+                        or np.issubdtype(attr.dtype, np.bytes_)):
+                        attr_val = np.array(["" if v is None else v for v in values[i]])
+                    else:
+                        attr_val = np.nan_to_num(values[i])
                 else:
-                    attr_val = np.nan_to_num(values[i])
+                    attr_val = values[i]
                 buffer, offsets = array_to_buffer(attr_val, True, False)
             except Exception as exc:
                 raise type(exc)(f"Failed to convert buffer for attribute: '{attr.name}'") from exc

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -413,13 +413,37 @@ class ArrayTest(DiskTestCase):
                 A[:] = {"a1": data1, "a2": data2}
 
         with tiledb.open(uri, "r") as A:
-            # print()
-            # print(A.df[:])
             expected_validity1 = [False, False, True, False, False]
             assert_array_equal(A[:]["a1"].mask, expected_validity1)
             assert_array_equal(A.df[:]["a1"].isna(), expected_validity1)
 
             expected_validity2 = [False, False, True, True, False]
+            assert_array_equal(A[:]["a2"].mask, expected_validity2)
+            assert_array_equal(A.df[:]["a2"].isna(), expected_validity2)
+            
+        with tiledb.open(uri, "w") as A:
+            dims = pa.array([1, 2, 3, 4, 5])
+            data1 = pa.array([None, None, None, None, None])
+            data2 = pa.array([None, None, None, None, None])
+            if pass_df:
+                dims = dims.to_pandas()
+                data1 = data1.to_pandas()
+                data2 = data2.to_pandas()
+            
+            print(data1)
+            print(type(data1))
+
+            if sparse:
+                A[dims] = {"a1": data1, "a2": data2}
+            else:
+                A[:] = {"a1": data1, "a2": data2}
+        
+        with tiledb.open(uri, "r") as A:
+            expected_validity1 = [True, True, True, True, True]
+            assert_array_equal(A[:]["a1"].mask, expected_validity1)
+            assert_array_equal(A.df[:]["a1"].isna(), expected_validity1)
+
+            expected_validity2 = [True, True, True, True, True]
             assert_array_equal(A[:]["a2"].mask, expected_validity2)
             assert_array_equal(A.df[:]["a2"].isna(), expected_validity2)
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -420,7 +420,7 @@ class ArrayTest(DiskTestCase):
             expected_validity2 = [False, False, True, True, False]
             assert_array_equal(A[:]["a2"].mask, expected_validity2)
             assert_array_equal(A.df[:]["a2"].isna(), expected_validity2)
-            
+
         with tiledb.open(uri, "w") as A:
             dims = pa.array([1, 2, 3, 4, 5])
             data1 = pa.array([None, None, None, None, None])
@@ -434,7 +434,7 @@ class ArrayTest(DiskTestCase):
                 A[dims] = {"a1": data1, "a2": data2}
             else:
                 A[:] = {"a1": data1, "a2": data2}
-        
+
         with tiledb.open(uri, "r") as A:
             expected_validity1 = [True, True, True, True, True]
             assert_array_equal(A[:]["a1"].mask, expected_validity1)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -429,9 +429,6 @@ class ArrayTest(DiskTestCase):
                 dims = dims.to_pandas()
                 data1 = data1.to_pandas()
                 data2 = data2.to_pandas()
-            
-            print(data1)
-            print(type(data1))
 
             if sparse:
                 A[dims] = {"a1": data1, "a2": data2}

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -393,26 +393,35 @@ class ArrayTest(DiskTestCase):
 
         uri = self.path("test_array_write_nullable")
         dom = tiledb.Domain(tiledb.Dim("d", domain=(1, 5), dtype="int64"))
-        att = tiledb.Attr("a", dtype="int8", nullable=True)
-        schema = tiledb.ArraySchema(domain=dom, attrs=[att], sparse=sparse)
+        att1 = tiledb.Attr("a1", dtype="int8", nullable=True)
+        att2 = tiledb.Attr("a2", dtype="str", nullable=True)
+        schema = tiledb.ArraySchema(domain=dom, attrs=[att1, att2], sparse=sparse)
         tiledb.Array.create(uri, schema)
 
         with tiledb.open(uri, "w") as A:
             dims = pa.array([1, 2, 3, 4, 5])
-            data = pa.array([1.0, 2.0, None, 0, 1.0])
+            data1 = pa.array([1.0, 2.0, None, 0, 1.0])
+            data2 = pa.array(["a", "b", None, None, "c"])
             if pass_df:
                 dims = dims.to_pandas()
-                data = data.to_pandas()
+                data1 = data1.to_pandas()
+                data2 = data2.to_pandas()
 
             if sparse:
-                A[dims] = data
+                A[dims] = {"a1": data1, "a2": data2}
             else:
-                A[:] = data
+                A[:] = {"a1": data1, "a2": data2}
 
         with tiledb.open(uri, "r") as A:
-            expected_validity = [False, False, True, False, False]
-            assert_array_equal(A[:]["a"].mask, expected_validity)
-            assert_array_equal(A.df[:]["a"].isna(), expected_validity)
+            # print()
+            # print(A.df[:])
+            expected_validity1 = [False, False, True, False, False]
+            assert_array_equal(A[:]["a1"].mask, expected_validity1)
+            assert_array_equal(A.df[:]["a1"].isna(), expected_validity1)
+
+            expected_validity2 = [False, False, True, True, False]
+            assert_array_equal(A[:]["a2"].mask, expected_validity2)
+            assert_array_equal(A.df[:]["a2"].isna(), expected_validity2)
 
 
 class DenseArrayTest(DiskTestCase):


### PR DESCRIPTION
* `np.nan_to_num` cannot be used on string arrays
* We should hold off on merging this PR until we get https://github.com/single-cell-data/TileDB-SOMA/pull/1834 passing, and the confirm that [this](https://github.com/TileDB-Inc/TileDB-Py/pull/1848#issuecomment-1781413424) repro script passes