### PR TITLE
Update HISTORY for 0.23.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,14 @@
+# Release 0.23.2
+
+* TileDB-Py 0.23.2 includes TileDB Embedded [2.17.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.3)
+
+## Improvements
+
+* Add support for enumeration extension API. [#1847](https://github.com/TileDB-Inc/TileDB-Py/pull/1847)
+* Support new set membership query condition. [#1837](https://github.com/TileDB-Inc/TileDB-Py/pull/1837)
+* Create `ArraySchemaEvolution` for new operation. [#1839](https://github.com/TileDB-Inc/TileDB-Py/pull/1839)
+* Add sparse dimension label example. [#1843](https://github.com/TileDB-Inc/TileDB-Py/pull/1843)
+
 # Release 0.23.1
 
 * TileDB-Py 0.23.1 includes TileDB Embedded [2.17.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.17.1)

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,10 +6,10 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.23.1
+        TILEDBPY_VERSION: 0.23.2
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA
-        LIBTILEDB_VERSION: 2.17.1
-        LIBTILEDB_SHA: 7c8c73b819b2b02f1ce8a982824400c203853d22
+        LIBTILEDB_VERSION: 2.17.3
+        LIBTILEDB_SHA: 0c2de5830bdce30cc0488053636eaa26129bffb0
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"


### PR DESCRIPTION
Wheel test: https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=35977&view=results

```
In [1]: import tiledb
tiledb.ver
In [2]: tiledb.version(), tiledb.libtiledb.version()
Out[2]: ((0, 23, 2), (2, 17, 3))
```