### PR TITLE
Work around NumPy issue with `dtype.kind` of unsigned ints

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Release 0.23.3
+
+* Pandas 2+ fix: use `pa.schema.with_metadata`, replacing passing metadata to `pa.schema` constructor
+
 # Release 0.23.2
 
 ## Bug Fixes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,12 @@
 # Release 0.23.3
 
-* Pandas 2+ fix: use `pa.schema.with_metadata`, replacing passing metadata to `pa.schema` constructor
+* Pandas 2+ fix: use `pa.schema.with_metadata`, replacing passing metadata to `pa.schema` constructor [#1858](https://github.com/TileDB-Inc/TileDB-Py/pull/1858)
 
 # Release 0.23.2
 
 ## Bug Fixes
 
-* Correct `Enumeration.extend` to handle integers, include Booleans, of different sizes
+* Correct `Enumeration.extend` to handle integers, include Booleans, of different sizes [#1850](https://github.com/TileDB-Inc/TileDB-Py/pull/1850)
 
 # Release 0.23.2
 

--- a/tiledb/enumeration.py
+++ b/tiledb/enumeration.py
@@ -105,8 +105,8 @@ class Enumeration(CtxMixin, lt.Enumeration):
         if self.dtype.kind in "US" and values.dtype.kind not in "US":
             raise lt.TileDBError("Passed in enumeration must be string type")
 
-        if np.issubdtype(self.dtype.kind, np.integer) and not np.issubdtype(
-            values.dtype.kind, np.integer
+        if np.issubdtype(self.dtype, np.integer) and not np.issubdtype(
+            values.dtype, np.integer
         ):
             raise lt.TileDBError("Passed in enumeration must be integer type")
 

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -471,7 +471,7 @@ class DataFrameIndexer(_BaseIndexer):
                 ).encode()
             }
 
-            table = table.cast(pyarrow.schema(pa_schema, metadata=metadata))
+            table = table.cast(pyarrow.schema(pa_schema).with_metadata(metadata))
 
             if self.query.return_arrow:
                 return table


### PR DESCRIPTION
Finding:

```
>>> np.issubdtype(np.asarray([1,2,3],dtype=np.int32).dtype, np.integer)
True

>>> np.issubdtype(np.asarray([1,2,3],dtype=np.uint32).dtype, np.integer)
True

>>> np.issubdtype(np.asarray([1,2,3],dtype=np.int32).dtype.kind, np.integer)
True

>>> np.issubdtype(np.asarray([1,2,3],dtype=np.uint32).dtype.kind, np.integer)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/numpy/core/numerictypes.py", line 416, in issubdtype
    arg1 = dtype(arg1).type
TypeError: data type 'u' not understood
```

So we should just do the first two, not the second two.

Found by @bkmartinjr in a TileDB-SOMA context: https://gist.github.com/johnkerl/3beaf565041a4acdbd534cba0e53bdae

I'll turn that gist into a TileDB-SOMA-Py unit-test case.