### PR TITLE
Cast enum values to enum dtype

### DIFF
--- a/tiledb/enumeration.py
+++ b/tiledb/enumeration.py
@@ -105,8 +105,8 @@ class Enumeration(CtxMixin, lt.Enumeration):
         if self.dtype.kind in "US" and values.dtype.kind not in "US":
             raise lt.TileDBError("Passed in enumeration must be string type")
 
-        if np.issubdtype(self.dtype.kind, np.integer) and not np.issubdtype(
-            values.dtype.kind, np.integer
+        if np.issubdtype(self.dtype, np.integer) and not np.issubdtype(
+            values.dtype, np.integer
         ):
             raise lt.TileDBError("Passed in enumeration must be integer type")
 

--- a/tiledb/enumeration.py
+++ b/tiledb/enumeration.py
@@ -90,11 +90,11 @@ class Enumeration(CtxMixin, lt.Enumeration):
         :rtype: NDArray
         """
         if self.dtype.kind == "U":
-            return np.array(super().str_values())
+            return np.array(super().str_values(), dtype=np.str_)
         elif self.dtype.kind == "S":
             return np.array(super().str_values(), dtype=np.bytes_)
         else:
-            return super().values()
+            return np.array(super().values(), dtype=self.dtype)
 
     def extend(self, values: Sequence[Any]) -> Enumeration:
         """Add additional values to the enumeration.

--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -139,7 +139,7 @@ class EnumerationTest(DiskTestCase):
             assert enmr.dtype.kind == enmr.values().dtype.kind == dtype.kind
         else:
             assert enmr.dtype == enmr.values().dtype == dtype
-            
+
         # with values
         enmr = tiledb.Enumeration("e", False, values=values)
         if dtype in (np.dtype("S"), np.dtype("U")):

--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -116,3 +116,34 @@ class EnumerationTest(DiskTestCase):
             expected_validity = [False, False, True, False, False]
             assert_array_equal(A[:]["a"].mask, expected_validity)
             assert_array_equal(A.df[:]["a"].isna(), expected_validity)
+
+    @pytest.mark.parametrize(
+        "dtype, values",
+        [
+            (np.int8, np.array([1, 2, 3], np.int8)),
+            (np.uint8, np.array([1, 2, 3], np.uint8)),
+            (np.int16, np.array([1, 2, 3], np.int16)),
+            (np.uint16, np.array([1, 2, 3], np.uint16)),
+            (np.int32, np.array([1, 2, 3], np.int32)),
+            (np.uint32, np.array([1, 2, 3], np.uint32)),
+            (np.int64, np.array([1, 2, 3], np.int64)),
+            (np.uint64, np.array([1, 2, 3], np.uint64)),
+            (np.dtype("S"), np.array(["a", "b", "c"], np.dtype("S"))),
+            (np.dtype("U"), np.array(["a", "b", "c"], np.dtype("U"))),
+        ],
+    )
+    def test_enum_dtypes(self, dtype, values):
+        # empty
+        enmr = tiledb.Enumeration("e", False, dtype=dtype)
+        if dtype in (np.dtype("S"), np.dtype("U")):
+            assert enmr.dtype.kind == enmr.values().dtype.kind == dtype.kind
+        else:
+            assert enmr.dtype == enmr.values().dtype == dtype
+            
+        # with values
+        enmr = tiledb.Enumeration("e", False, values=values)
+        if dtype in (np.dtype("S"), np.dtype("U")):
+            assert enmr.dtype.kind == enmr.values().dtype.kind == dtype.kind
+        else:
+            assert enmr.dtype == enmr.values().dtype == dtype
+            assert_array_equal(enmr.values(), values)

--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -133,14 +133,23 @@ class EnumerationTest(DiskTestCase):
         ],
     )
     def test_enum_dtypes(self, dtype, values):
-        # empty
+        # create empty
         enmr = tiledb.Enumeration("e", False, dtype=dtype)
         if dtype in (np.dtype("S"), np.dtype("U")):
             assert enmr.dtype.kind == enmr.values().dtype.kind == dtype.kind
         else:
             assert enmr.dtype == enmr.values().dtype == dtype
+            assert_array_equal(enmr.values(), [])
+            
+        # then extend with values
+        enmr = enmr.extend(values)
+        if dtype in (np.dtype("S"), np.dtype("U")):
+            assert enmr.dtype.kind == enmr.values().dtype.kind == dtype.kind
+        else:
+            assert enmr.dtype == enmr.values().dtype == dtype
+            assert_array_equal(enmr.values(), values)
 
-        # with values
+        # create with values
         enmr = tiledb.Enumeration("e", False, values=values)
         if dtype in (np.dtype("S"), np.dtype("U")):
             assert enmr.dtype.kind == enmr.values().dtype.kind == dtype.kind

--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -140,7 +140,7 @@ class EnumerationTest(DiskTestCase):
         else:
             assert enmr.dtype == enmr.values().dtype == dtype
             assert_array_equal(enmr.values(), [])
-            
+
         # then extend with values
         enmr = enmr.extend(values)
         if dtype in (np.dtype("S"), np.dtype("U")):

--- a/tiledb/tests/test_schema_evolution.py
+++ b/tiledb/tests/test_schema_evolution.py
@@ -174,7 +174,12 @@ def test_schema_evolution_with_enmr(tmp_path):
 
 @pytest.mark.parametrize(
     "type,data",
-    (("int", [0]), ("bool", [True, False]), ("str", ["abc", "defghi", "jk"])),
+    (
+        ("int", [0]),
+        ("bool", [True, False]),
+        ("str", ["abc", "defghi", "jk"]),
+        ("bytes", [b"abc", b"defghi", b"jk"]),
+    ),
 )
 def test_schema_evolution_extend_enmr(tmp_path, type, data):
     uri = str(tmp_path)


### PR DESCRIPTION
For empty enumerations, since we did not explicitly cast the empty numpy array, it was automatically casted to a dtype of float64