### PR TITLE
Use `with_metadata` instead of argument to `pa.schema` constructor

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Release 0.23.3
+
+* Pandas 2+ fix: use `pa.schema.with_metadata`, replacing passing metadata to `pa.schema` constructor
+
 # Release 0.23.2
 
 ## Bug Fixes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,12 @@
 # Release 0.23.3
 
-* Pandas 2+ fix: use `pa.schema.with_metadata`, replacing passing metadata to `pa.schema` constructor
+* Pandas 2+ fix: use `pa.schema.with_metadata`, replacing passing metadata to `pa.schema` constructor [#1858](https://github.com/TileDB-Inc/TileDB-Py/pull/1858)
 
 # Release 0.23.2
 
 ## Bug Fixes
 
-* Correct `Enumeration.extend` to handle integers, include Booleans, of different sizes
+* Correct `Enumeration.extend` to handle integers, include Booleans, of different sizes [#1850](https://github.com/TileDB-Inc/TileDB-Py/pull/1850)
 
 # Release 0.23.2
 

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -471,7 +471,7 @@ class DataFrameIndexer(_BaseIndexer):
                 ).encode()
             }
 
-            table = table.cast(pyarrow.schema(pa_schema, metadata=metadata))
+            table = table.cast(pyarrow.schema(pa_schema).with_metadata(metadata))
 
             if self.query.return_arrow:
                 return table


### PR DESCRIPTION
* Pandas 2.0 has deprecated many functions including passing the metadata as an argument to the `pa.schema` constructor. This has been replaced with a separate call to `with_metadata`