### PR TITLE
Fix reading DeltaFilter and DoubleDeltaFilter options for FilterList

### DIFF
--- a/tiledb/cc/filter.cc
+++ b/tiledb/cc/filter.cc
@@ -97,7 +97,8 @@ void init_filter(py::module &m) {
                return py::cast(value);
              }
              case TILEDB_COMPRESSION_REINTERPRET_DATATYPE: {
-               return py::cast(filter.get_option<uint8_t>(option));
+               auto value = filter.get_option<uint8_t>(option);
+               return py::cast(static_cast<tiledb_datatype_t>(value));
              }
              default:
                TPY_ERROR_LOC("Unrecognized filter option to _get_option");

--- a/tiledb/filter.py
+++ b/tiledb/filter.py
@@ -277,10 +277,15 @@ class DeltaFilter(CompressionFilter):
 
     """
 
+    options = (
+        lt.FilterOption.COMPRESSION_LEVEL,
+        lt.FilterOption.COMPRESSION_REINTERPRET_DATATYPE,
+    )
+
     def __init__(
         self,
         level: int = -1,
-        reinterp_dtype: Optional[np.dtype] = None,
+        reinterp_dtype: Optional[Union[np.dtype, lt.DataType]] = None,
         ctx: Optional[Ctx] = None,
     ):
         if not isinstance(level, int):
@@ -332,10 +337,15 @@ class DoubleDeltaFilter(CompressionFilter):
 
     """
 
+    options = (
+        lt.FilterOption.COMPRESSION_LEVEL,
+        lt.FilterOption.COMPRESSION_REINTERPRET_DATATYPE,
+    )
+
     def __init__(
         self,
         level: int = -1,
-        reinterp_dtype: Optional[np.dtype] = None,
+        reinterp_dtype: Optional[Union[np.dtype, lt.DataType]] = None,
         ctx: Optional[Ctx] = None,
     ):
         if not isinstance(level, int):

--- a/tiledb/tests/test_filters.py
+++ b/tiledb/tests/test_filters.py
@@ -184,14 +184,14 @@ class TestFilterTest(DiskTestCase):
             assert_allclose(data, A[:][""], rtol=1, atol=1)
 
     @pytest.mark.parametrize(
-        "attr_dtype,reinterp_dtype",
+        "attr_dtype,reinterp_dtype,expected_reinterp_dtype",
         [
-            (np.uint64, None),
-            (np.float64, np.uint64),
-            (np.float64, tiledb.cc.DataType.UINT64),
+            (np.uint64, None, None),
+            (np.float64, np.uint64, np.uint64),
+            (np.float64, tiledb.cc.DataType.UINT64, np.uint64),
         ],
     )
-    def test_delta_filter(self, attr_dtype, reinterp_dtype):
+    def test_delta_filter(self, attr_dtype, reinterp_dtype, expected_reinterp_dtype):
         path = self.path("test_delta_filter")
 
         dom = tiledb.Domain(tiledb.Dim(name="row", domain=(0, 9), dtype=np.uint64))
@@ -200,8 +200,12 @@ class TestFilterTest(DiskTestCase):
             filter = tiledb.DeltaFilter()
         else:
             filter = tiledb.DeltaFilter(reinterp_dtype=reinterp_dtype)
+        assert filter.reinterp_dtype == expected_reinterp_dtype
 
         attr = tiledb.Attr(dtype=attr_dtype, filters=tiledb.FilterList([filter]))
+
+        assert attr.filters[0].reinterp_dtype == expected_reinterp_dtype
+
         schema = tiledb.ArraySchema(domain=dom, attrs=[attr], sparse=False)
         tiledb.Array.create(path, schema)
 
@@ -217,14 +221,16 @@ class TestFilterTest(DiskTestCase):
             assert_array_equal(res, data)
 
     @pytest.mark.parametrize(
-        "attr_dtype,reinterp_dtype",
+        "attr_dtype,reinterp_dtype,expected_reinterp_dtype",
         [
-            (np.uint64, None),
-            (np.float64, np.uint64),
-            (np.float64, tiledb.cc.DataType.UINT64),
+            (np.uint64, None, None),
+            (np.float64, np.uint64, np.uint64),
+            (np.float64, tiledb.cc.DataType.UINT64, np.uint64),
         ],
     )
-    def test_double_delta_filter(self, attr_dtype, reinterp_dtype):
+    def test_double_delta_filter(
+        self, attr_dtype, reinterp_dtype, expected_reinterp_dtype
+    ):
         path = self.path("test_delta_filter")
 
         dom = tiledb.Domain(tiledb.Dim(name="row", domain=(0, 9), dtype=np.uint64))
@@ -233,8 +239,10 @@ class TestFilterTest(DiskTestCase):
             filter = tiledb.DoubleDeltaFilter()
         else:
             filter = tiledb.DoubleDeltaFilter(reinterp_dtype=reinterp_dtype)
+        assert filter.reinterp_dtype == expected_reinterp_dtype
 
         attr = tiledb.Attr(dtype=attr_dtype, filters=tiledb.FilterList([filter]))
+        assert attr.filters[0].reinterp_dtype == expected_reinterp_dtype
         schema = tiledb.ArraySchema(domain=dom, attrs=[attr], sparse=False)
         tiledb.Array.create(path, schema)
 


### PR DESCRIPTION
The option for reinterpret datatype was not being copied back into the DeltaFilter and DoubleDeltaFilter when accessing them as part of the FilterList. This only affected the Python layer. The C++ backend for the filters still had the full options set.