### PR TITLE
Do not flush VFS files on closing.

### DIFF
--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -352,7 +352,6 @@ class FileIO(io.RawIOBase):
         exc_val: Optional[BaseException],
         exc_tb: Optional[TracebackType],
     ) -> bool:
-        self.flush()
         self._fh._close()
 
     @property


### PR DESCRIPTION
The Core does the flushing by itself if needed.

https://github.com/TileDB-Inc/TileDB/blob/5efd7f53df6646c3b5894b0f7b06e1314f68c214/tiledb/sm/filesystem/vfs_file_handle.cc#L69-L70

https://github.com/TileDB-Inc/TileDB/blob/5efd7f53df6646c3b5894b0f7b06e1314f68c214/tiledb/sm/filesystem/vfs.cc#L1455-L1462