### PR TITLE
Release the GIL while consolidating

### DIFF
--- a/tiledb/cc/array.cc
+++ b/tiledb/cc/array.cc
@@ -57,12 +57,12 @@ void init_array(py::module &m) {
       .def("consolidate",
            py::overload_cast<const Context &, const std::string &,
                              Config *const>(&Array::consolidate),
-                             py::call_guard<py::gil_scoped_release>())
+           py::call_guard<py::gil_scoped_release>())
       .def("consolidate",
            py::overload_cast<const Context &, const std::string &,
                              tiledb_encryption_type_t, const std::string &,
                              Config *const>(&Array::consolidate),
-                             py::call_guard<py::gil_scoped_release>())
+           py::call_guard<py::gil_scoped_release>())
       //(void (Array::*)(const Context&, const std::string&,
       //                 tiledb_encryption_type_t, const std::string&,
       //                 Config* const)&Array::consolidate)&Array::consolidate)

--- a/tiledb/cc/array.cc
+++ b/tiledb/cc/array.cc
@@ -56,11 +56,13 @@ void init_array(py::module &m) {
       .def("close", &Array::close)
       .def("consolidate",
            py::overload_cast<const Context &, const std::string &,
-                             Config *const>(&Array::consolidate))
+                             Config *const>(&Array::consolidate),
+                             py::call_guard<py::gil_scoped_release>())
       .def("consolidate",
            py::overload_cast<const Context &, const std::string &,
                              tiledb_encryption_type_t, const std::string &,
-                             Config *const>(&Array::consolidate))
+                             Config *const>(&Array::consolidate),
+                             py::call_guard<py::gil_scoped_release>())
       //(void (Array::*)(const Context&, const std::string&,
       //                 tiledb_encryption_type_t, const std::string&,
       //                 Config* const)&Array::consolidate)&Array::consolidate)


### PR DESCRIPTION
I stumbled over this while attempting to log stats during consolidation. Turns out when we don't release the gil the background thread can't run.