### PR TITLE
Fix domain equality check

### DIFF
--- a/tiledb/dimension.py
+++ b/tiledb/dimension.py
@@ -133,14 +133,14 @@ class Dim(CtxMixin, lt.Dimension):
     def __eq__(self, other) -> bool:
         if not isinstance(other, Dim):
             return False
-        if (
-            self.name != other.name
-            or self.domain != other.domain
-            or self.tile != other.tile
-            or self.dtype != other.dtype
-        ):
-            return False
-        return True
+        return (
+            self.name == other.name
+            and self.domain == other.domain
+            and self.tile == other.tile
+            and self.dtype == other.dtype
+            and self.isvar == other.isvar
+            and self.filters == other.filters
+        )
 
     def __array__(self, dtype=None, **kw) -> np.array:
         if not self._integer_domain():

--- a/tiledb/domain.py
+++ b/tiledb/domain.py
@@ -40,7 +40,9 @@ class Domain(CtxMixin, lt.Domain):
                         name=name,
                         domain=dim.domain,
                         tile=dim.tile,
+                        filters=dim.filters,
                         dtype=dim.dtype,
+                        var=dim.isvar,
                         ctx=dim._ctx,
                     )
 
@@ -99,20 +101,9 @@ class Domain(CtxMixin, lt.Domain):
         """
         if not isinstance(other, Domain):
             return False
-
-        same_dtype = self._is_homogeneous()
-
-        if same_dtype and self.shape != other.shape:
+        if self.ndim != other.ndim:
             return False
-
-        ndim = self.ndim
-        if ndim != other.ndim:
-            return False
-
-        for i in range(ndim):
-            if self.dim(i) != other.dim(i):
-                return False
-        return True
+        return all(self.dim(index) == other.dim(index) for index in range(self.ndim))
 
     @property
     def ndim(self):

--- a/tiledb/tests/test_dimension.py
+++ b/tiledb/tests/test_dimension.py
@@ -13,12 +13,14 @@ class DimensionTest(unittest.TestCase):
         self.assertEqual(dim.name, "__dim_0", "automatic dimension name is incorrect")
         self.assertEqual(dim.shape, (5,))
         self.assertEqual(dim.tile, 5)
+        self.assertEqual(dim, dim)
 
     def test_dimension(self):
         dim = tiledb.Dim(name="d1", domain=(0, 3), tile=2)
         self.assertEqual(dim.name, "d1")
         self.assertEqual(dim.shape, (4,))
         self.assertEqual(dim.tile, 2)
+        self.assertEqual(dim, dim)
         try:
             assert xml.etree.ElementTree.fromstring(dim._repr_html_()) is not None
         except:
@@ -28,10 +30,12 @@ class DimensionTest(unittest.TestCase):
         filters = [tiledb.GzipFilter(2)]
         dim = tiledb.Dim(name="df", domain=(0, 2), tile=1, filters=filters)
         self.assertEqual(dim.filters, filters)
+        self.assertEqual(dim, dim)
 
         filter_list = tiledb.FilterList(filters)
         dim = tiledb.Dim(name="df", domain=(0, 2), tile=1, filters=filter_list)
         self.assertEqual(dim.filters, filter_list)
+        self.assertEqual(dim, dim)
 
         with self.assertRaises(TypeError):
             tiledb.Dim(name="df", domain=(0, 2), tile=1, filters=1)
@@ -44,6 +48,7 @@ class DimensionTest(unittest.TestCase):
             tile=np.timedelta64(20, "D"),
             dtype=np.datetime64("", "D"),
         )
+        self.assertEqual(dim, dim)
         self.assertEqual(dim.dtype, np.dtype(np.datetime64("", "D")))
         self.assertEqual(dim.tile, np.timedelta64(20, "D"))
         self.assertNotEqual(dim.tile, np.timedelta64(21, "D"))
@@ -69,6 +74,7 @@ class DimensionTest(unittest.TestCase):
             tile=20,
             dtype=np.datetime64("", "D"),
         )
+        self.assertEqual(dim, dim)
         self.assertEqual(dim.dtype, np.dtype(np.datetime64("", "D")))
         self.assertEqual(dim.tile, np.timedelta64(20, "D"))
 
@@ -79,6 +85,7 @@ class DimensionTest(unittest.TestCase):
             tile=5,
             dtype=np.datetime64("", "Y"),
         )
+        self.assertEqual(dim, dim)
         self.assertEqual(dim.dtype, np.dtype(np.datetime64("", "Y")))
         self.assertEqual(dim.tile, np.timedelta64(5, "Y"))
         self.assertTupleEqual(
@@ -92,6 +99,7 @@ class DimensionTest(unittest.TestCase):
             tile=2,
             dtype=np.datetime64("", "D"),
         )
+        self.assertEqual(dim, dim)
         self.assertEqual(dim.tile, np.timedelta64(2, "D"))
         self.assertTupleEqual(
             dim.domain,

--- a/tiledb/tests/test_domain.py
+++ b/tiledb/tests/test_domain.py
@@ -49,6 +49,7 @@ class DomainTest(DiskTestCase):
             dtype=np.datetime64("", "D"),
         )
         dom = tiledb.Domain(dim)
+        self.assertEqual(dom, dom)
         self.assertEqual(dom.dtype, np.datetime64("", "D"))
 
     def test_domain_mixed_names_error(self):
@@ -65,6 +66,7 @@ class DomainTest(DiskTestCase):
         assert dim.dtype == np.bytes_
 
         dom = tiledb.Domain(dim)
+        self.assertEqual(dom, dom)
         dom.dump()
         assert_captured(capfd, "Type: STRING_ASCII")
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -80,8 +80,10 @@ class VersionTest(DiskTestCase):
 
 class ArrayTest(DiskTestCase):
     def create_array_schema(self):
+        filters = tiledb.FilterList([tiledb.ZstdFilter(level=5)])
         domain = tiledb.Domain(
-            tiledb.Dim(domain=(1, 8), tile=2), tiledb.Dim(domain=(1, 8), tile=2)
+            tiledb.Dim(domain=(1, 8), tile=2, filters=filters),
+            tiledb.Dim(domain=(1, 8), tile=2, filters=filters),
         )
         a1 = tiledb.Attr("val", dtype="f8")
         return tiledb.ArraySchema(domain=domain, attrs=(a1,))


### PR DESCRIPTION
Fixes:
* Add checks for matching filters and variable length in `Dim.__eq__`.
* Fix bug where error is thrown when using `Domain.__eq__` on a non-integral sparse domain.
* Fix bug where filters are dropped from dimensions in a domain with all anonymous dimensions.