### PR TITLE
Skip `test_consolidation_and_vac_no_config` For libtiledb < 2.18.0

### DIFF
--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -591,6 +591,7 @@ class GroupMetadataTest(GroupTestCase):
 
         assert len(vfs.ls(meta_path)) == 1
 
+    @pytest.mark.skipif(tiledb.libtiledb.version() < (2, 18, 0))
     def test_consolidation_and_vac_no_config(self):
         vfs = tiledb.VFS()
         path = self.path("test_consolidation_and_vac")

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -591,7 +591,10 @@ class GroupMetadataTest(GroupTestCase):
 
         assert len(vfs.ls(meta_path)) == 1
 
-    @pytest.mark.skipif(tiledb.libtiledb.version() < (2, 18, 0))
+    @pytest.mark.skipif(
+        tiledb.libtiledb.version() < (2, 18, 0),
+        reason="Group consolidation and vacuuming not available < 2.18",
+    )
     def test_consolidation_and_vac_no_config(self):
         vfs = tiledb.VFS()
         path = self.path("test_consolidation_and_vac")


### PR DESCRIPTION
Reported in internal channel: https://tiledb.slack.com/archives/C052CFC4D2Q/p1701187714576329