### PR TITLE
Release 0.25.1 Against 2.19.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,12 +1,14 @@
-# Next
+# Release 0.25.1
+
+* TileDB-Py 0.25.1 includes TileDB Embedded [2.19.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.19.0)
 
 ## Improvements
 
 * Warn when `os.fork()` is used in the presence of a Tiledb context [#1876](https://github.com/TileDB-Inc/TileDB-Py/pull/1876/files).
 
-# Release 0.24.0
+# Release 0.25.0 [BROKEN]
 
-* TileDB-Py 0.25.0 includes TileDB Embedded [2.19.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.19.0)
+* This release is broken for conda packages and 0.25.1 must be used instead; PyPI wheels are OK but still recommended to use 0.25.1
 
 ## Improvements
 

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,7 +6,7 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.25.0
+        TILEDBPY_VERSION: 0.25.1
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA
         LIBTILEDB_VERSION: 2.19.0
         LIBTILEDB_SHA: fa30a88abc5504ed8387e25937744afcd3802232


### PR DESCRIPTION
* 0.25.0 will be need to be deprecated as the conda package depends on the wrong version of libtiledb

```
(tiledb-clean) vivian@mangonada:~/drop$ python
Python 3.10.13 (main, Sep 11 2023, 13:44:35) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tiledb
>>> tiledb.version()
(0, 25, 1)
>>> tiledb.libtiledb.version()
(2, 19, 0)
```

- [ ] Upload new PyPI wheels
- [ ] Update libtiledb dependency in `meta.yaml`
- [ ] Mark broken conda package: https://github.com/nguyenv/admin-requests/compare/main...mark-tiledb-py-0.25.0-as-broken
- [ ] Yank on PyPI