### PR TITLE
Fix ambiguous capsule calls with pybind11

### DIFF
--- a/tiledb/cc/attribute.cc
+++ b/tiledb/cc/attribute.cc
@@ -69,7 +69,7 @@ void init_attribute(py::module &m) {
 
       .def("__capsule__",
            [](Attribute &attr) {
-             return py::capsule(attr.ptr().get(), "attr", nullptr);
+             return py::capsule(attr.ptr().get(), "attr");
            })
 
       .def_property_readonly("_name", &Attribute::name)

--- a/tiledb/cc/attribute.cc
+++ b/tiledb/cc/attribute.cc
@@ -67,10 +67,9 @@ void init_attribute(py::module &m) {
 
       .def(py::init<const Context &, py::capsule>())
 
-      .def("__capsule__",
-           [](Attribute &attr) {
-             return py::capsule(attr.ptr().get(), "attr");
-           })
+      .def(
+          "__capsule__",
+          [](Attribute &attr) { return py::capsule(attr.ptr().get(), "attr"); })
 
       .def_property_readonly("_name", &Attribute::name)
 

--- a/tiledb/cc/context.cc
+++ b/tiledb/cc/context.cc
@@ -19,12 +19,12 @@ void init_context(py::module &m) {
 
       .def("__capsule__",
            [](Context &ctx) {
-             return py::capsule(ctx.ptr().get(), "ctx", nullptr);
+             return py::capsule(ctx.ptr().get(), "ctx");
            })
 
       .def("__capsule__",
            [](Context &ctx) {
-             return py::capsule(ctx.ptr().get(), "ctx", nullptr);
+             return py::capsule(ctx.ptr().get(), "ctx");
            })
 
       .def("config", &Context::config)
@@ -42,7 +42,7 @@ void init_config(py::module &m) {
 
       .def("__capsule__",
            [](Config &config) {
-             return py::capsule(config.ptr().get(), "config", nullptr);
+             return py::capsule(config.ptr().get(), "config");
            })
 
       .def("set", &Config::set)

--- a/tiledb/cc/context.cc
+++ b/tiledb/cc/context.cc
@@ -18,14 +18,10 @@ void init_context(py::module &m) {
       .def(py::init<py::capsule, bool>())
 
       .def("__capsule__",
-           [](Context &ctx) {
-             return py::capsule(ctx.ptr().get(), "ctx");
-           })
+           [](Context &ctx) { return py::capsule(ctx.ptr().get(), "ctx"); })
 
       .def("__capsule__",
-           [](Context &ctx) {
-             return py::capsule(ctx.ptr().get(), "ctx");
-           })
+           [](Context &ctx) { return py::capsule(ctx.ptr().get(), "ctx"); })
 
       .def("config", &Context::config)
       .def("set_tag", &Context::set_tag)

--- a/tiledb/cc/dimension_label.cc
+++ b/tiledb/cc/dimension_label.cc
@@ -80,7 +80,7 @@ void init_dimension_label(py::module &m) {
 
       .def("__capsule__",
            [](DimensionLabel &dim_label) {
-             return py::capsule(dim_label.ptr().get(), "dim_label", nullptr);
+             return py::capsule(dim_label.ptr().get(), "dim_label");
            })
 
       .def_property_readonly("_label_attr_name",

--- a/tiledb/cc/domain.cc
+++ b/tiledb/cc/domain.cc
@@ -183,7 +183,7 @@ void init_domain(py::module &m) {
 
       .def("__capsule__",
            [](Domain &dom) {
-             return py::capsule(dom.ptr().get(), "dom", nullptr);
+             return py::capsule(dom.ptr().get(), "dom");
            })
 
       .def_property_readonly("_ncell",

--- a/tiledb/cc/domain.cc
+++ b/tiledb/cc/domain.cc
@@ -182,9 +182,7 @@ void init_domain(py::module &m) {
       .def(py::init<const Context &, py::capsule>())
 
       .def("__capsule__",
-           [](Domain &dom) {
-             return py::capsule(dom.ptr().get(), "dom");
-           })
+           [](Domain &dom) { return py::capsule(dom.ptr().get(), "dom"); })
 
       .def_property_readonly("_ncell",
                              [](Domain &dom) { return dom.cell_num(); })

--- a/tiledb/cc/enumeration.cc
+++ b/tiledb/cc/enumeration.cc
@@ -65,7 +65,7 @@ void init_enumeration(py::module &m) {
 
       .def("__capsule__",
            [](Enumeration &enmr) {
-             return py::capsule(enmr.ptr().get(), "enmr", nullptr);
+             return py::capsule(enmr.ptr().get(), "enmr");
            })
 
       .def_property_readonly("name", &Enumeration::name)

--- a/tiledb/cc/filter.cc
+++ b/tiledb/cc/filter.cc
@@ -122,7 +122,7 @@ void init_filter(py::module &m) {
 
       .def("__capsule__",
            [](FilterList &filterlist) {
-             return py::capsule(filterlist.ptr().get(), "fl", nullptr);
+             return py::capsule(filterlist.ptr().get(), "fl");
            })
 
       .def_property("_chunksize", &FilterList::max_chunk_size,

--- a/tiledb/cc/schema.cc
+++ b/tiledb/cc/schema.cc
@@ -173,7 +173,7 @@ void init_schema(py::module &m) {
 
       .def("__capsule__",
            [](ArraySchema &schema) {
-             return py::capsule(schema.ptr().get(), "schema", nullptr);
+             return py::capsule(schema.ptr().get(), "schema");
            })
 
       .def("_dump", &ArraySchema::dump)

--- a/tiledb/cc/subarray.cc
+++ b/tiledb/cc/subarray.cc
@@ -554,7 +554,7 @@ void init_subarray(py::module &m) {
 
       .def("__capsule__",
            [](Subarray &subarray) {
-             return py::capsule(subarray.ptr().get(), "subarray", nullptr);
+             return py::capsule(subarray.ptr().get(), "subarray");
            })
 
       .def("_add_dim_range",

--- a/tiledb/query_condition.cc
+++ b/tiledb/query_condition.cc
@@ -58,7 +58,7 @@ public:
 
   shared_ptr<QueryCondition> ptr() { return qc_; }
 
-  py::capsule __capsule__() { return py::capsule(&qc_, "qc", nullptr); }
+  py::capsule __capsule__() { return py::capsule(&qc_, "qc"); }
 
   void set_use_enumeration(bool use_enumeration) {
     QueryConditionExperimental::set_use_enumeration(ctx_, *qc_,


### PR DESCRIPTION
I got multiple errors like this:
```error: call of overloaded ‘capsule(std::__shared_ptr<tiledb_subarray_t, __gnu_cxx::_S_atomic>::element_type*, const char [9], std::nullptr_t)’ is ambiguous```
when building fresh with latest pybind on ubuntu22, `m6id.4xlarge` ec2 machine.

Not sure this is the correct fix, just fixed all the errors to get myself a successful build and thought effort shouldn't go to waste in case it's the correct approach.