### PR TITLE
Safe repr for `Group`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Next
 
+## Bug Fixes
+
+* Add safe `Group.__repr__` []()
+
 ## Improvements
 
 * Warn when `os.fork()` is used in the presence of a Tiledb context [#1876](https://github.com/TileDB-Inc/TileDB-Py/pull/1876/files).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 
-* Add safe `Group.__repr__` []()
+* Add safe `Group.__repr__` [#1890](https://github.com/TileDB-Inc/TileDB-Py/pull/1890)
 
 ## Improvements
 

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -392,7 +392,7 @@ class Group(CtxMixin, lt.Group):
         # use safe repr if pybind11 constructor failed
         if self._ctx is None:
             return object.__repr__(self)
-        
+
         return self._dump(True)
 
     def __enter__(self):

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -389,6 +389,10 @@ class Group(CtxMixin, lt.Group):
         return self._has_member(member)
 
     def __repr__(self):
+        # use safe repr if pybind11 constructor failed
+        if self._ctx is None:
+            return object.__repr__(self)
+        
         return self._dump(True)
 
     def __enter__(self):

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -341,11 +341,10 @@ class GroupTest(GroupTestCase):
 
             with tiledb.Group(group_uri, config=cfg) as G:
                 assert len(G) == sz
-    
+
     def test_group_does_not_exist(self):
         with self.assertRaises(tiledb.TileDBError):
             tiledb.Group("does-not-exist")
-
 
 
 class GroupMetadataTest(GroupTestCase):
@@ -621,4 +620,3 @@ class GroupMetadataTest(GroupTestCase):
         tiledb.Group.vacuum_metadata(path)
 
         assert len(vfs.ls(meta_path)) == 1
-    

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -341,6 +341,11 @@ class GroupTest(GroupTestCase):
 
             with tiledb.Group(group_uri, config=cfg) as G:
                 assert len(G) == sz
+    
+    def test_group_does_not_exist(self):
+        with self.assertRaises(tiledb.TileDBError):
+            tiledb.Group("does-not-exist")
+
 
 
 class GroupMetadataTest(GroupTestCase):
@@ -616,3 +621,4 @@ class GroupMetadataTest(GroupTestCase):
         tiledb.Group.vacuum_metadata(path)
 
         assert len(vfs.ls(meta_path)) == 1
+    


### PR DESCRIPTION
See https://github.com/TileDB-Inc/TileDB-Py/pull/1545/ for a full explanation. This just needed to be added for the `Group` class as well.