### PR TITLE
Ignore `DeprecationWarning` Emitted From pyarrow/pandas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ filterwarnings = [
     "error",
     "default::pytest.PytestWarning",
     "default::DeprecationWarning:distributed",
+    # Pyarrow emits a warning regarding use of deprecated Pandas function
+    # Remove this once we bump Pyarrow version
+    "ignore:Passing a BlockManager to DataFrame is deprecated:DeprecationWarning"
 ]
 
 [tool.ruff]

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -969,7 +969,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         # Test roundtrip a Int64Dtype in newer pandas versions
         tmp_csv2 = os.path.join(tmp_dir, "generated.csv")
         df2 = pd.DataFrame({"v": pd.Series(np.int64(df["v"]), dtype=pd.Int64Dtype())})
-        df2["v"][4] = None
+        df2.loc[4] = None
 
         with tiledb.FileIO(self.vfs, tmp_csv2, "wb") as fio:
             df2.to_csv(fio, index=False)

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -569,7 +569,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         tm.assert_frame_equal(df, df_copy)
 
         # update the value in the original dataframe to match what we expect on read-back
-        df["v"][4] = -1
+        df.loc[4] = -1
         df_bk = tiledb.open_dataframe(uri)
         tm.assert_frame_equal(df_bk, df)
 
@@ -941,7 +941,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
 
         def check_array(path, df):
             # update the value in the original dataframe to match what we expect on read-back
-            df["v"][4] = 0
+            df.loc[4] = 0
 
             df_bk = tiledb.open_dataframe(path)
             tm.assert_frame_equal(df_bk, df)


### PR DESCRIPTION
- ~I would like to just add a `pytest.ini` file to silence `DeprecationWarnings` that emit the message `Passing a BlockManager to DataFrame is deprecated`. This seems to somewhat work as tests are now passing but seems to skip entire test files which is not what I intended. I would like the tests to run, allow PyArrow to emit the warning, but silence them when testing.~
- `pytest.ini` was overriding options already set in `pyproject.toml`