### PR TITLE
[WIP] add GEOM_WKB and GEOM_WKT types to python API

### DIFF
--- a/tiledb/cc/common.cc
+++ b/tiledb/cc/common.cc
@@ -47,6 +47,10 @@ std::unordered_map<tiledb_datatype_t, std::string> _tdb_to_np_name_dtype = {
 #if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 10
     {TILEDB_BOOL, "bool"},
 #endif
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 21
+    {TILEDB_GEOM_WKB, "byte"},
+    {TILEDB_GEOM_WKT, "S1"},
+#endif
 };
 
 std::unordered_map<std::string, tiledb_datatype_t> _np_name_to_tdb_dtype = {

--- a/tiledb/cc/enum.cc
+++ b/tiledb/cc/enum.cc
@@ -62,7 +62,9 @@ void init_enums(py::module &m) {
       .value("TIME_PS", TILEDB_TIME_PS)
       .value("TIME_FS", TILEDB_TIME_FS)
       .value("TIME_AS", TILEDB_TIME_AS)
-      .value("BLOB", TILEDB_BLOB);
+      .value("BLOB", TILEDB_BLOB)
+      .value("GEOM_WKB", TILEDB_GEOM_WKB)
+      .value("GEOM_WKT", TILEDB_GEOM_WKT);
 
   py::enum_<tiledb_array_type_t>(m, "ArrayType")
       .value("DENSE", TILEDB_DENSE)

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -230,6 +230,12 @@ py::dtype tiledb_dtype(tiledb_datatype_t type, uint32_t cell_val_num) {
     case TILEDB_BOOL:
       return py::dtype("bool");
 #endif
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 21
+    case TILEDB_GEOM_WKB:
+      return py::dtype("byte");
+    case TILEDB_GEOM_WKT:
+      return py::dtype("S1");
+#endif
 
     case TILEDB_ANY:
       break;


### PR DESCRIPTION
These new types represent spatial geometries. They were merged to `dev` in https://github.com/TileDB-Inc/TileDB/pull/4640 but won't be released until 1.21.

This PR is mainly to allow downstream python applications an opportunity to experiment with the types prior to release.

WIP, please don't merge.