### PR TITLE
Use safe repr if `ArraySchema` was not properly constructed

### DIFF
--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -31,6 +31,7 @@ _string_to_tiledb_order.update(
     }
 )
 
+
 class ArraySchema(CtxMixin, lt.ArraySchema):
     """
     Schema class for TileDB dense / sparse array representations
@@ -407,7 +408,7 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
         # not construct properly
         if self._ctx is None or not self._check():
             return object.__repr__(self)
-            
+
         # TODO support/use __qualname__
         output = io.StringIO()
         output.write("ArraySchema(\n")

--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -411,7 +411,7 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
             self._check()
         except lt.TileDBError:
             return object.__repr__(self)
-        
+
         if self._ctx is None:
             return object.__repr__(self)
 

--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -28,6 +28,7 @@ _string_to_tiledb_order.update(
         "R": lt.LayoutType.COL_MAJOR,
         "H": lt.LayoutType.HILBERT,
         "U": lt.LayoutType.UNORDERED,
+        None: lt.LayoutType.ROW_MAJOR,  # default (fixed in SC-27374)
     }
 )
 
@@ -406,7 +407,12 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
     def __repr__(self):
         # use safe repr if pybind11 constructor failed or the array schema did
         # not construct properly
-        if self._ctx is None or not self._check():
+        try:
+            self._check()
+        except lt.TileDBError:
+            return object.__repr__(self)
+        
+        if self._ctx is None:
             return object.__repr__(self)
 
         # TODO support/use __qualname__

--- a/tiledb/attribute.py
+++ b/tiledb/attribute.py
@@ -259,6 +259,10 @@ class Attr(CtxMixin, lt.Attribute):
         return self._get_enumeration_name(self._ctx)
 
     def __repr__(self):
+        # use safe repr if pybind11 constructor failed
+        if self._ctx is None:
+            return object.__repr__(self)
+        
         filters_str = ""
         if self.filters:
             filters_str = ", filters=FilterList(["

--- a/tiledb/attribute.py
+++ b/tiledb/attribute.py
@@ -262,7 +262,7 @@ class Attr(CtxMixin, lt.Attribute):
         # use safe repr if pybind11 constructor failed
         if self._ctx is None:
             return object.__repr__(self)
-        
+
         filters_str = ""
         if self.filters:
             filters_str = ", filters=FilterList(["

--- a/tiledb/dimension.py
+++ b/tiledb/dimension.py
@@ -85,6 +85,10 @@ class Dim(CtxMixin, lt.Dimension):
                 self._filters = FilterList(filters)
 
     def __repr__(self) -> str:
+        # use safe repr if pybind11 constructor failed
+        if self._ctx is None:
+            return object.__repr__(self)
+        
         filters_str = ""
         if self.filters:
             filters_str = ", filters=FilterList(["

--- a/tiledb/dimension.py
+++ b/tiledb/dimension.py
@@ -88,7 +88,7 @@ class Dim(CtxMixin, lt.Dimension):
         # use safe repr if pybind11 constructor failed
         if self._ctx is None:
             return object.__repr__(self)
-        
+
         filters_str = ""
         if self.filters:
             filters_str = ", filters=FilterList(["

--- a/tiledb/domain.py
+++ b/tiledb/domain.py
@@ -67,7 +67,7 @@ class Domain(CtxMixin, lt.Domain):
         # use safe repr if pybind11 constructor failed
         if self._ctx is None:
             return object.__repr__(self)
-        
+
         dims = ",\n       ".join(repr(self.dim(i)) for i in range(self.ndim))
         return "Domain({0!s})".format(dims)
 

--- a/tiledb/domain.py
+++ b/tiledb/domain.py
@@ -64,6 +64,10 @@ class Domain(CtxMixin, lt.Domain):
             self._add_dim(d)
 
     def __repr__(self):
+        # use safe repr if pybind11 constructor failed
+        if self._ctx is None:
+            return object.__repr__(self)
+        
         dims = ",\n       ".join(repr(self.dim(i)) for i in range(self.ndim))
         return "Domain({0!s})".format(dims)
 

--- a/tiledb/enumeration.py
+++ b/tiledb/enumeration.py
@@ -127,6 +127,10 @@ class Enumeration(CtxMixin, lt.Enumeration):
         )
 
     def __repr__(self):
+        # use safe repr if pybind11 constructor failed
+        if self._ctx is None:
+            return object.__repr__(self)
+        
         return f"Enumeration(name='{self.name}', cell_val_num={self.cell_val_num}, ordered={self.ordered}, values={list(self.values())})"
 
     def _repr_html_(self):

--- a/tiledb/enumeration.py
+++ b/tiledb/enumeration.py
@@ -130,7 +130,7 @@ class Enumeration(CtxMixin, lt.Enumeration):
         # use safe repr if pybind11 constructor failed
         if self._ctx is None:
             return object.__repr__(self)
-        
+
         return f"Enumeration(name='{self.name}', cell_val_num={self.cell_val_num}, ordered={self.ordered}, values={list(self.values())})"
 
     def _repr_html_(self):

--- a/tiledb/filter.py
+++ b/tiledb/filter.py
@@ -18,6 +18,10 @@ class Filter(CtxMixin, lt.Filter):
         super().__init__(ctx, type)
 
     def __repr__(self) -> str:
+        # use safe repr if pybind11 constructor failed
+        if self._ctx is None:
+            return object.__repr__(self)
+        
         output = io.StringIO()
         output.write(f"{type(self).__name__}(")
         if hasattr(self, "_attrs_"):

--- a/tiledb/filter.py
+++ b/tiledb/filter.py
@@ -21,7 +21,7 @@ class Filter(CtxMixin, lt.Filter):
         # use safe repr if pybind11 constructor failed
         if self._ctx is None:
             return object.__repr__(self)
-        
+
         output = io.StringIO()
         output.write(f"{type(self).__name__}(")
         if hasattr(self, "_attrs_"):

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -233,7 +233,7 @@ class Group(CtxMixin, lt.Group):
             # use safe repr if pybind11 constructor failed
             if self._ctx is None:
                 return object.__repr__(self)
-            
+
             return str(dict(self._iter(keys_only=False)))
 
         def setdefault(self, key, default=None):

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -230,6 +230,10 @@ class Group(CtxMixin, lt.Group):
                 yield key
 
         def __repr__(self):
+            # use safe repr if pybind11 constructor failed
+            if self._ctx is None:
+                return object.__repr__(self)
+            
             return str(dict(self._iter(keys_only=False)))
 
         def setdefault(self, key, default=None):

--- a/tiledb/tests/test_array_schema.py
+++ b/tiledb/tests/test_array_schema.py
@@ -74,6 +74,16 @@ class ArraySchemaTest(DiskTestCase):
 
         with self.assertRaises(tiledb.TileDBError):
             tiledb.ArraySchema(domain=dom, attrs=(att,))
+    
+    def test_dense_array_schema_invalid_cell_and_tile_order(self):
+        dom = tiledb.Domain(tiledb.Dim(domain=(1, 8), tile=2, dtype=np.float64))
+        att = tiledb.Attr("val", dtype=np.float64)
+
+        with self.assertRaises(ValueError):
+            tiledb.ArraySchema(domain=dom, attrs=(att,), cell_order="invalid")
+            
+        with self.assertRaises(ValueError):
+            tiledb.ArraySchema(domain=dom, attrs=(att,), tile_order="invalid")
 
     def test_sparse_schema(self):
         # create dimensions

--- a/tiledb/tests/test_array_schema.py
+++ b/tiledb/tests/test_array_schema.py
@@ -74,14 +74,14 @@ class ArraySchemaTest(DiskTestCase):
 
         with self.assertRaises(tiledb.TileDBError):
             tiledb.ArraySchema(domain=dom, attrs=(att,))
-    
+
     def test_dense_array_schema_invalid_cell_and_tile_order(self):
         dom = tiledb.Domain(tiledb.Dim(domain=(1, 8), tile=2, dtype=np.float64))
         att = tiledb.Attr("val", dtype=np.float64)
 
         with self.assertRaises(ValueError):
             tiledb.ArraySchema(domain=dom, attrs=(att,), cell_order="invalid")
-            
+
         with self.assertRaises(ValueError):
             tiledb.ArraySchema(domain=dom, attrs=(att,), tile_order="invalid")
 


### PR DESCRIPTION
- We cannot rely solely on checking if the context exists for the `ArraySchema`. We call the parent `lt.ArraySchema` constructor at the beginning of `__init__` which does set a valid context and creates the Pybind11 object. Then we set the other schema properties onto that object. If any of the other properties the user passed in are invalid (like the `cell_order` or `tile_order`), then simply checking the existence of a context does not work. Fortunately with the `ArraySchema`, there is an `lt.ArraySchema._check` to ensure if it a properly constructor schema
- I am not sure what happened, but the safe reprs which were added in https://github.com/TileDB-Inc/TileDB-Py/pull/1545 all disappeared. I'm assuming a PR was not merged correctly after #1545, but they have now been restored