### PR TITLE
Enable GCS in osx-arm64 release build

### DIFF
--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -34,7 +34,6 @@ stages:
               imageName: "macOS-12"
               CMAKE_OSX_ARCHITECTURES: "arm64"
               MACOSX_DEPLOYMENT_TARGET: 11
-              TILEDB_GCS: OFF
               BUILD_MAGIC_MACOS_UNIVERSAL: "ON"
               TILEDB_INSTALL: "$(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)-macos-arm64"
             windows_libtiledb:


### PR DESCRIPTION
GCS currently disabled in PyPI wheels, this PR enables.

x-ref https://github.com/TileDB-Inc/TileDB-Py/issues/1262#issuecomment-1937329349