### PR TITLE
Remove upper bound on pybind11

### DIFF
--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -12,7 +12,7 @@ numpy>=1.23.2 ; python_version >= "3.11"
 
 cmake >= 3.23
 cython < 3.0
-pybind11 < 2.11.0
+pybind11
 setuptools>=42
 setuptools_scm >= 1.5.4
 wheel >= 0.30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 
-requires = ["setuptools>=42", "wheel", "pybind11<2.11.0", "Cython<3.0"]
+requires = ["setuptools>=42", "wheel", "pybind11", "Cython<3.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@ numpy >= 1.16.5
 build
 cmake >= 3.23
 cython < 3.0
-pybind11 < 2.11.0
+pybind11
 setuptools>=42
 setuptools_scm >= 1.5.4
 wheel >= 0.30


### PR DESCRIPTION
Unblock the conda-forge migration to Python 3.12

xref: https://github.com/conda-forge/tiledb-py-feedstock/pull/199#issuecomment-1954502654, https://github.com/TileDB-Inc/TileDB-Py/pull/1805, https://github.com/TileDB-Inc/TileDB-Py/commit/d7d7019ea713b6bb56fbf2460920896f94952846