### PR TITLE
Specify datetime format in tests

### DIFF
--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -3,6 +3,7 @@ import glob
 import os
 import random
 import string
+import sys
 import uuid
 
 import numpy as np
@@ -380,6 +381,10 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         with tiledb.open(uri) as B:
             tm.assert_frame_equal(df, B.df[:])
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="requires Python 3.8 or higher. date_format argument is not supported in 3.7 and below",
+    )
     def test_dataframe_csv_rt1(self):
         def rand_dtype(dtype, size):
             nbytes = size * np.dtype(dtype).itemsize
@@ -687,6 +692,10 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         tmp_array2 = os.path.join(tmp_dir, "array2")
         tiledb.from_csv(tmp_array2, tmp_csv, sparse=False)
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="requires Python 3.8 or higher. date_format argument is not supported in 3.7 and below",
+    )
     def test_csv_col_to_sparse_dims(self):
         df = make_dataframe_basic3(20)
 
@@ -760,6 +769,10 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             cmp_df = df.set_index("int_vals").sort_values(by="time")
             tm.assert_frame_equal(res_df, cmp_df)
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="requires Python 3.8 or higher. date_format argument is not supported in 3.7 and below",
+    )
     def test_dataframe_csv_schema_only(self):
         col_size = 10
         df = make_dataframe_basic3(col_size)
@@ -869,6 +882,10 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             df_bk.sort_index(level="time", inplace=True)
             tm.assert_frame_equal(df_bk, df_combined)
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="requires Python 3.8 or higher. date_format argument is not supported in 3.7 and below",
+    )
     def test_dataframe_csv_chunked(self):
         col_size = 200
         df = make_dataframe_basic3(col_size)
@@ -951,6 +968,10 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             df_idx_res = A.query(coords=False).df[int(ned[0]) : int(ned[1])]
             tm.assert_frame_equal(df_idx_res, df.reset_index(drop=True))
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="requires Python 3.8 or higher. date_format argument is not supported in 3.7 and below",
+    )
     def test_csv_fillna(self):
         if pytest.tiledb_vfs == "s3":
             pytest.skip(

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -409,7 +409,12 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
 
         csv_array_uri = os.path.join(uri, "tiledb_csv")
         tiledb.from_csv(
-            csv_array_uri, csv_uri, index_col=0, parse_dates=[1], sparse=False
+            csv_array_uri,
+            csv_uri,
+            index_col=0,
+            parse_dates=[1],
+            date_format="%Y-%m-%d %H:%M:%S.%f",
+            sparse=False,
         )
 
         df_from_array = tiledb.open_dataframe(csv_array_uri)
@@ -420,7 +425,12 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         with tiledb.FileIO(tiledb.VFS(), csv_uri, "rb") as fio:
             csv_array_uri2 = os.path.join(csv_array_uri + "_2")
             tiledb.from_csv(
-                csv_array_uri2, csv_uri, index_col=0, parse_dates=[1], sparse=False
+                csv_array_uri2,
+                csv_uri,
+                index_col=0,
+                parse_dates=[1],
+                sparse=False,
+                date_format="%Y-%m-%d %H:%M:%S.%f",
             )
 
             df_from_array2 = tiledb.open_dataframe(csv_array_uri2)
@@ -697,6 +707,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             sparse=True,
             index_col=["time", "double_range"],
             parse_dates=["time"],
+            date_format="%Y-%m-%d %H:%M:%S.%f",
         )
 
         df_bk = tiledb.open_dataframe(tmp_array)
@@ -734,6 +745,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             tmp_csv2,
             index_col=["int_vals"],
             parse_dates=["time"],
+            date_format="%Y-%m-%d %H:%M:%S.%f",
             sparse=True,
             allows_duplicates=True,
             float_precision="round_trip",
@@ -784,6 +796,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
                 tmp_csv,
                 index_col=["time", "double_range"],
                 parse_dates=["time"],
+                date_format="%Y-%m-%d %H:%M:%S.%f",
                 mode="schema_only",
                 capacity=1001,
                 sparse=True,
@@ -876,7 +889,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             tmp_csv,
             index_col=["double_range"],
             parse_dates=["time"],
-            date_spec={"time": "%Y-%m-%dT%H:%M:%S.%f"},
+            date_format="%Y-%m-%d %H:%M:%S.%f",
             chunksize=10,
             sparse=True,
             quotechar='"',
@@ -893,7 +906,12 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         # Test dense chunked
         tmp_array_dense = os.path.join(tmp_dir, "array_dense")
         tiledb.from_csv(
-            tmp_array_dense, tmp_csv, parse_dates=["time"], sparse=False, chunksize=25
+            tmp_array_dense,
+            tmp_csv,
+            parse_dates=["time"],
+            date_format="%Y-%m-%d %H:%M:%S.%f",
+            sparse=False,
+            chunksize=25,
         )
 
         with tiledb.open(tmp_array_dense) as A:
@@ -1016,6 +1034,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             csv_paths,
             index_col=["time"],
             parse_dates=["time"],
+            date_format="%Y-%m-%d %H:%M:%S.%f",
             chunksize=25,
             sparse=True,
         )


### PR DESCRIPTION
The `tiledb.from_csv` and `tiledb.from_pandas` functions have been causing intermittent errors when running the unit tests with the message:

```
UserWarning: Could not infer format, so each element will be parsed individually, falling back to `dateutil`. To ensure parsing is consistent and as-expected, please specify a format.
```
Example failure: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/7911328196/job/21595351207#step:10:1029

This is solved by explicitly passing `date_format` argument into each `from_{csv,pandas}` call.

Please note that the `date_format` argument is not available for Python 3.7 and below, so tests containing it should be skipped.