### PR TITLE
Fix Filestore unable to read sizes smaller than offset

### DIFF
--- a/tiledb/filestore.py
+++ b/tiledb/filestore.py
@@ -67,7 +67,7 @@ class Filestore:
 
         if size == -1:
             size = len(self)
-        size = max(size - offset, 0)
+        size = min(size, len(self) - offset)
 
         return lt.Filestore._buffer_export(
             self._ctx,

--- a/tiledb/tests/test_filestore.py
+++ b/tiledb/tests/test_filestore.py
@@ -35,11 +35,32 @@ class FilestoreTest(DiskTestCase):
         schema.attr(0).dump()
         assert_captured(capfd, "Type: BLOB")
 
-        data = b"buffer"
-
         fs = tiledb.Filestore(path)
         fs.write(data)
         assert bytes(data) == fs.read()
+
+    def test_small_buffer(self, capfd):
+        path = self.path("test_small_buffer")
+        # create a 4 byte array
+        data = b"abcd"
+
+        fs = tiledb.Filestore(path)
+
+        with self.assertRaises(tiledb.TileDBError):
+            fs.write(data)
+
+        schema = tiledb.ArraySchema.from_file()
+        tiledb.Array.create(path, schema)
+
+        assert schema.attr(0).name == "contents"
+        assert schema.attr(0).dtype == np.bytes_
+
+        schema.attr(0).dump()
+        assert_captured(capfd, "Type: BLOB")
+
+        fs = tiledb.Filestore(path)
+        fs.write(data)
+        assert data[3:4] == fs.read(offset=3, size=1)
 
     def test_uri(self, text_fname):
         path = self.path("test_uri")


### PR DESCRIPTION
In `Filestore` class, in the `read()` method this line `size = max(size - offset, 0)` does not cover the case of trying to read a size that is smaller than the offset. Consider a 4 byte file. If we want to read the last byte (offset 3, size 1) this check sets the size to 0 incorrectly.

Changing it to `size = min(size, len(self) - offset)` ensures that we read either the specified size or the remaining length of the file store starting from the offset, whichever is smaller.