### PR TITLE
Fix vfs readinto when buff is not bytes

### DIFF
--- a/tiledb/tests/test_vfs.py
+++ b/tiledb/tests/test_vfs.py
@@ -217,28 +217,6 @@ class TestVFS(DiskTestCase):
         self.assertEqual(fio.readinto(test_bytes), 10)
         self.assertEqual(test_bytes, buffer)
 
-        # Test readinto with random np.float32
-        fio.seek(0)
-        test_np_array = np.empty(10, dtype=np.float32)
-        n_bytes = fio.readinto(test_np_array)
-        self.assertEqual(n_bytes, 10)
-        self.assertEqual(test_np_array.tobytes()[:n_bytes], buffer)
-
-        # Test readinto with np.int32 buffer trying to write bytes that cannot be converted to int32
-        buffer = b"012\x00\x01"
-        with tiledb.FileIO(vfs, self.path("foo"), mode="wb") as fio:
-            fio.write(buffer)
-            fio.flush()
-            self.assertEqual(fio.tell(), len(buffer))
-
-        fio = tiledb.FileIO(vfs, self.path("foo"), mode="rb")
-
-        fio.seek(0)
-        test_np_array = np.empty(5, dtype=np.int32)
-        n_bytes = fio.readinto(test_np_array)
-        self.assertEqual(n_bytes, 5)
-        self.assertEqual(test_np_array.tobytes()[:n_bytes], buffer)
-
         # Reading from the end should return empty
         fio.seek(0)
         fio.read()
@@ -255,6 +233,33 @@ class TestVFS(DiskTestCase):
         with tiledb.FileIO(vfs, rand_uri, "rb") as f2:
             txtio = io.TextIOWrapper(f2, encoding="utf-8")
             self.assertEqual(txtio.readlines(), lines)
+
+    def test_sc42569_vfs_memoryview(self):
+        # This test is to ensure that giving np.ndarray buffer to readinto works
+        # when trying to write bytes that cannot be converted to float32 or int32
+        vfs = tiledb.VFS()
+
+        buffer = b"012\x00\x01"
+        with tiledb.FileIO(vfs, self.path("foo"), mode="wb") as fio:
+            fio.write(buffer)
+            fio.flush()
+            self.assertEqual(fio.tell(), len(buffer))
+
+        fio = tiledb.FileIO(vfs, self.path("foo"), mode="rb")
+
+        # Test readinto with np.float32
+        fio.seek(0)
+        test_np_array = np.empty(5, dtype=np.float32)
+        n_bytes = fio.readinto(test_np_array)
+        self.assertEqual(n_bytes, 5)
+        self.assertEqual(test_np_array.tobytes()[:n_bytes], buffer)
+
+        # Test readinto with np.int32
+        fio.seek(0)
+        test_np_array = np.empty(5, dtype=np.int32)
+        n_bytes = fio.readinto(test_np_array)
+        self.assertEqual(n_bytes, 5)
+        self.assertEqual(test_np_array.tobytes()[:n_bytes], buffer)
 
     def test_ls(self):
         basepath = self.path("test_vfs_ls")

--- a/tiledb/tests/test_vfs.py
+++ b/tiledb/tests/test_vfs.py
@@ -217,6 +217,13 @@ class TestVFS(DiskTestCase):
         self.assertEqual(fio.readinto(test_bytes), 10)
         self.assertEqual(test_bytes, buffer)
 
+        # Test readinto with random np.float32
+        fio.seek(0)
+        test_np_array = np.empty(10, dtype=np.float32)
+        n_bytes = fio.readinto(test_np_array)
+        self.assertEqual(n_bytes, 10)
+        self.assertEqual(test_np_array.tobytes()[:n_bytes], buffer)
+
         # Reading from the end should return empty
         fio.seek(0)
         fio.read()

--- a/tiledb/tests/test_vfs.py
+++ b/tiledb/tests/test_vfs.py
@@ -224,6 +224,21 @@ class TestVFS(DiskTestCase):
         self.assertEqual(n_bytes, 10)
         self.assertEqual(test_np_array.tobytes()[:n_bytes], buffer)
 
+        # Test readinto with np.int32 buffer trying to write bytes that cannot be converted to int32
+        buffer = b"012\x00\x01"
+        with tiledb.FileIO(vfs, self.path("foo"), mode="wb") as fio:
+            fio.write(buffer)
+            fio.flush()
+            self.assertEqual(fio.tell(), len(buffer))
+
+        fio = tiledb.FileIO(vfs, self.path("foo"), mode="rb")
+
+        fio.seek(0)
+        test_np_array = np.empty(5, dtype=np.int32)
+        n_bytes = fio.readinto(test_np_array)
+        self.assertEqual(n_bytes, 5)
+        self.assertEqual(test_np_array.tobytes()[:n_bytes], buffer)
+
         # Reading from the end should return empty
         fio.seek(0)
         fio.read()

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -494,6 +494,7 @@ class FileIO(io.RawIOBase):
 
         :param buff bytes:
         """
+        buff = memoryview(buff).cast("b")
         size = len(buff)
         if not self.readable():
             raise IOError("Cannot read from write-only FileIO handle")
@@ -507,7 +508,7 @@ class FileIO(io.RawIOBase):
 
         buff_temp = self._fh._read(self._offset, nbytes)
         self._offset += nbytes
-        buff[: len(buff_temp)] = buff_temp
+        buff[: len(buff_temp)] = memoryview(buff_temp).cast("b")
         return len(buff_temp)
 
     def readinto1(self, b):

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -3,6 +3,8 @@ import os
 from types import TracebackType
 from typing import List, Optional, Type, Union
 
+import numpy as np
+
 import tiledb.cc as lt
 
 from .ctx import Config, Ctx, default_ctx
@@ -488,7 +490,7 @@ class FileIO(io.RawIOBase):
         self._offset += nbytes
         return nbytes
 
-    def readinto(self, buff: bytes) -> int:
+    def readinto(self, buff: np.ndarray) -> int:
         """
         Read bytes into a pre-allocated, writable bytes-like object b, and return the number of bytes read.
 


### PR DESCRIPTION
Trying to ingest an Hamamatsu CMU-1.ndpi https://openslide.cs.cmu.edu/download/openslide-testdata/Hamamatsu/ image using `tiledb.bioimg`:

```
from tiledb.bioimg import from_bioimg
import tiledb
vfs = tiledb.VFS()
with vfs.open('CMU-1.ndpi') as src:
    from_bioimg(src, "test_bioimg")
```

was giving the following error:

```
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/.venv/lib/python3.9/site-packages/IPython/core/interactiveshell.py", line 3508, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "&lt;ipython-input-5-f900874cbef5&gt;", line 2, in &lt;module&gt;
    from_bioimg(src, "/Users/agis/tiledb_dev/TileDB-BioImaging/tests/data/cmu1_failed_v2.ndpi.tdb")
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/tiledb/bioimg/wrappers.py", line 35, in from_bioimg
    return OMETiffConverter.to_tiledb(
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/tiledb/bioimg/converters/base.py", line 357, in to_tiledb
    reader = cls._ImageReaderType(
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/tiledb/bioimg/converters/ome_tiff.py", line 34, in __init__
    self._tiff = tifffile.TiffFile(input_path, is_ndpi=True)
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/.venv/lib/python3.9/site-packages/tifffile/tifffile.py", line 4301, in __init__
    self.pages = TiffPages(self)
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/.venv/lib/python3.9/site-packages/tifffile/tifffile.py", line 7420, in __init__
    page = TiffPage(self.parent, index=pageindex)
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/.venv/lib/python3.9/site-packages/tifffile/tifffile.py", line 8407, in __init__
    mcustarts = tags.valueof(65426)
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/.venv/lib/python3.9/site-packages/tifffile/tifffile.py", line 11655, in valueof
    return tag.value
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/.venv/lib/python3.9/site-packages/tifffile/tifffile.py", line 11217, in value
    value = TiffTag._read_value(
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/.venv/lib/python3.9/site-packages/tifffile/tifffile.py", line 11135, in _read_value
    value = readfunc(fh, tiff.byteorder, dtype, count, tiff.offsetsize)
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/.venv/lib/python3.9/site-packages/tifffile/tifffile.py", line 19621, in read_numpy
    return fh.read_array(
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/.venv/lib/python3.9/site-packages/tifffile/tifffile.py", line 14747, in read_array
    n = self._fh.readinto(result)  # type: ignore
  File "/Users/agis/tiledb_dev/TileDB-BioImaging/.venv/lib/python3.9/site-packages/tiledb/vfs.py", line 506, in readinto
    buff[: len(buff_temp)] = b
```

The input buffer `buff` and the buffer obtained from the file handle `buff_temp` are now casted to bytes-like format, enhancing compatibility with various bytes-like objects. These changes ensure safer and more flexible handling.