### PR TITLE
Remove Python 3.7 CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
     env:
       # 11.7 necessary due to: https://github.com/actions/setup-python/issues/682#issuecomment-1604261330
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-12' && matrix.python-version == '3.8' ? '11.7' : '11' }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-12' && matrix.python-version == '3.8' && '11.7' || '11' }}
       #MACOSX_DEPLOYMENT_TARGET: "10.11"
       # On windows-2019 we are using the Visual Studio generator, which is multi-config and places the build artifacts in a subdirectory
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-12, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     env:
       # 11.7 necessary due to: https://github.com/actions/setup-python/issues/682#issuecomment-1604261330
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-12' && contains(fromJSON('["3.7", "3.8"]'), matrix.python-version) && '11.7' || '11' }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-12' && matrix.python-version == '3.8' ? '11.7' : '11' }}
       #MACOSX_DEPLOYMENT_TARGET: "10.11"
       # On windows-2019 we are using the Visual Studio generator, which is multi-config and places the build artifacts in a subdirectory
     steps:
@@ -44,13 +44,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - run: rm -rf $RUNNER_TOOL_CACHE/Python/3.7.17
-        if: matrix.os == 'macos-12' && matrix.python-version == '3.7'
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.7.17
-        if: matrix.os == 'macos-12' && matrix.python-version == '3.7'
 
       - name: Print Python version
         run: |

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-12, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
           - python-version: "3.11"
@@ -27,14 +27,12 @@ jobs:
             numpy-version: "1.19.3"
           - python-version: "3.8"
             numpy-version: "1.17.3"
-          - python-version: "3.7"
-            numpy-version: "1.16.5"
       fail-fast: false
     env:
       TILEDB_VERSION: ${{ github.event.inputs.libtiledb_version }}
       # 11.7 necessary due to: https://github.com/actions/setup-python/issues/682#issuecomment-1604261330
       #MACOSX_DEPLOYMENT_TARGET: "10.15"
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-11' && contains(fromJson('["3.7", "3.8"]'), matrix.python-version) && '11.7' || '11' }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-12' && matrix.python-version == '3.8' ? '11.7' : '11' }}
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
     steps:
       - name: Checkout TileDB-Py `dev`

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -71,7 +71,7 @@ stages:
           matrix:
             linux_py:
               imageName: "ubuntu-latest"
-              CIBW_SKIP: "cp36-* *_i686 pp* *musllinux*"
+              CIBW_SKIP: "cp36-* cp37-* *_i686 pp* *musllinux*"
               CIBW_BUILD_VERBOSITY: 3
               CIBW_ARCHS_MACOS: ""
             macOS_py:
@@ -79,7 +79,7 @@ stages:
               MACOSX_DEPLOYMENT_TARGET: 11
               TILEDB_INSTALL: "$(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)-macos-x86_64"
               CIBW_ARCHS_MACOS: "x86_64"
-              CIBW_SKIP: "cp36-* pp*"
+              CIBW_SKIP: "cp36-* cp37-* pp*"
               CIBW_TEST_SKIP: "cp37-*"
               CIBW_BUILD_VERBOSITY: 3
             macOS_arm64_py:
@@ -92,7 +92,7 @@ stages:
               CIBW_SKIP: "cp36-* cp37-* pp*"
             windows_py:
               imageName: "windows-latest"
-              CIBW_SKIP: "cp36-* *-win32 pp*"
+              CIBW_SKIP: "cp36-* cp37-* *-win32 pp*"
               CIBW_BUILD_VERBOSITY: 3
               CIBW_ARCHS_MACOS: ""
         pool:


### PR DESCRIPTION
Removing Python 3.7 CI jobs from all GitHub workflows.