### PR TITLE
Minor fix docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = {file = "requirements_wheel.txt"}
 homepage = "https://github.com/TileDB-Inc/TileDB-Py"
 
 [tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "dirty-tag"
+version_file = "tiledb/_generated_version.py"
 
 [tool.pytest.ini_options]
 python_classes = "*Test*"

--- a/setup.py
+++ b/setup.py
@@ -789,13 +789,7 @@ elif TILEDB_PATH != "":
     ext_attr_update("tiledb_path", TILEDB_PATH)
 
 setup(
-    name="tiledb",
     platforms=["any"],
-    use_scm_version={
-        "version_scheme": "guess-next-dev",
-        "local_scheme": "dirty-tag",
-        "write_to": "tiledb/_generated_version.py",
-    },
     ext_modules=__extensions,
     setup_requires=setup_requires(),
     install_requires=install_requires(),

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -494,7 +494,7 @@ class FileIO(io.RawIOBase):
         """
         Read bytes into a pre-allocated, writable bytes-like object b, and return the number of bytes read.
 
-        :param buff bytes:
+        :param buff np.ndarray: A pre-allocated, writable bytes-like object
         """
         buff = memoryview(buff).cast("b")
         size = len(buff)


### PR DESCRIPTION
Fixes readinto() description for the docs and moves more metadata into pyproject.toml.