### PR TITLE
Fix missing dev requirements

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,3 +13,4 @@ wheel >= 0.30
 contextvars ;python_version<"3.7"
 dataclasses ;python_version<"3.7"
 pytest
+-r misc/requirements_test.txt


### PR DESCRIPTION
Requirements such as `pandas` are missing when trying to run `pytest`, even after running `pip install -r requirements_dev.txt`, leading to skipped tests. This fixes it.