### PR TITLE
Don't package .pyc files in wheels and generate PyPi compatible version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ classifiers=[
 ]
 dynamic = ["version", "dependencies"]
 
+[tool.setuptools.packages.find]
+exclude = ["*.pyc"]
+
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements_wheel.txt"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ homepage = "https://github.com/TileDB-Inc/TileDB-Py"
 
 [tool.setuptools_scm]
 version_scheme = "guess-next-dev"
-local_scheme = "dirty-tag"
+local_scheme = "no-local-version"
 version_file = "tiledb/_generated_version.py"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
- How I tested it:
```
pipx run build
unzip -l dist/tiledb-0.26.4.dev4-cp312-cp312-macosx_14_0_arm64.whl | grep '\.pyc$'
tar -tzf dist/tiledb-0.26.4.dev4.tar.gz | grep '\.pyc$'
pipx run build --sdist
tar -tzf dist/tiledb-0.26.4.dev5.tar.gz | grep '\.pyc$'
```

They all return nothing.

- A change that has to be done was not to append the local version identifier to the version number. This approach ensures cleaner version numbers that rely solely on tags, without incorporating any local version data. Consequently, versions generated during the CI build will be compatible with PyPI. Previously, a 'dirty-tag' was being used: https://github.com/TileDB-Inc/TileDB-Py/blob/0b14a6eb623fc2a2c202c3da6e638e9a3668925a/setup.py#L796 resulting in errors like this when running `pipx run build`.

```
CMake Error at CMakeLists.txt:75 (message):
  CMAKE_CURRENT_SOURCE_DIR contains a REGEX character and may break CMakeList
  processing.  Please use; a different path, or set
  TILEDB_ALLOW_REGEX_CHAR_PATH to override.:

    '/private/var/folders/gw/5rx7wg1d6397n6nwy86qjf7c0000gn/T/build-via-sdist-xh28l5wh/tiledb-0.26.4.dev3+dirty/build/TileDB-2.20.1'


-- Configuring incomplete, errors occurred!
make[2]: *** [tiledb-prefix/src/tiledb-stamp/tiledb-configure] Error 1
make[1]: *** [CMakeFiles/tiledb.dir/all] Error 2
make: *** [all] Error 2
Traceback (most recent call last):
  File "/Users/agis/anaconda3/envs/read_docs/lib/python3.8/site-packages/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
    main()
  File "/Users/agis/anaconda3/envs/read_docs/lib/python3.8/site-packages/pyproject_hooks/_in_process/_in_process.py", line 335, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
  File "/Users/agis/anaconda3/envs/read_docs/lib/python3.8/site-packages/pyproject_hooks/_in_process/_in_process.py", line 251, in build_wheel
    return _build_backend().build_wheel(wheel_directory, config_settings,
  File "/private/var/folders/gw/5rx7wg1d6397n6nwy86qjf7c0000gn/T/build-env-hdrdn7qf/lib/python3.8/site-packages/setuptools/build_meta.py", line 410, in build_wheel
    return self._build_with_temp_dir(
  File "/private/var/folders/gw/5rx7wg1d6397n6nwy86qjf7c0000gn/T/build-env-hdrdn7qf/lib/python3.8/site-packages/setuptools/build_meta.py", line 395, in _build_with_temp_dir
    self.run_setup()
  File "/private/var/folders/gw/5rx7wg1d6397n6nwy86qjf7c0000gn/T/build-env-hdrdn7qf/lib/python3.8/site-packages/setuptools/build_meta.py", line 311, in run_setup
    exec(code, locals())
  File "<string>", line 793, in <module>
  File "/private/var/folders/gw/5rx7wg1d6397n6nwy86qjf7c0000gn/T/build-env-hdrdn7qf/lib/python3.8/site-packages/setuptools/__init__.py", line 104, in setup
    return distutils.core.setup(**attrs)
  File "/private/var/folders/gw/5rx7wg1d6397n6nwy86qjf7c0000gn/T/build-env-hdrdn7qf/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 185, in setup
    return run_commands(dist)
  File "/private/var/folders/gw/5rx7wg1d6397n6nwy86qjf7c0000gn/T/build-env-hdrdn7qf/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
    dist.run_commands()
  File "/private/var/folders/gw/5rx7wg1d6397n6nwy86qjf7c0000gn/T/build-env-hdrdn7qf/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
    self.run_command(cmd)
  File "/private/var/folders/gw/5rx7wg1d6397n6nwy86qjf7c0000gn/T/build-env-hdrdn7qf/lib/python3.8/site-packages/setuptools/dist.py", line 967, in run_command
    super().run_command(command)
  File "/private/var/folders/gw/5rx7wg1d6397n6nwy86qjf7c0000gn/T/build-env-hdrdn7qf/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
    cmd_obj.run()
  File "<string>", line 516, in run
  File "<string>", line 324, in find_or_install_libtiledb
  File "<string>", line 286, in build_libtiledb
  File "/Users/agis/anaconda3/envs/read_docs/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['make', '-j12']' returned non-zero exit status 2.

ERROR Backend subprocess exited when trying to invoke build_wheel

``` 

