### PR TITLE
Fix build with Cython 3 - it no longer adds implicit noexcept to callbacks

### DIFF
--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -11,7 +11,7 @@ numpy>=1.23.2 ; python_version >= "3.11"
 #-------------------------------
 
 cmake >= 3.23
-cython < 3.0
+cython
 pybind11
 setuptools >= 64
 setuptools_scm >= 8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11", "Cython<3.0"]
+requires = ["setuptools>=42", "wheel", "pybind11", "Cython"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ numpy >= 1.16.5
 # ------------------------------------------------
 build
 cmake >= 3.23
-cython < 3.0
+cython
 pybind11
 setuptools >= 64
 setuptools_scm >= 8

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -711,7 +711,7 @@ cdef extern from "tiledb/tiledb.h":
     int tiledb_query_submit_async(
         tiledb_ctx_t* ctx,
         tiledb_query_t* query,
-        void* (*callback)(void*),
+        void* (*callback)(void*) noexcept,
         void* callback_data)
 
     int tiledb_query_get_status(
@@ -979,13 +979,13 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_ctx_t* ctx,
         const char* path,
         tiledb_walk_order_t order,
-        int (*callback)(const char*, tiledb_object_t, void*),
+        int (*callback)(const char*, tiledb_object_t, void*) noexcept,
         void* data)
 
     int tiledb_object_ls(
         tiledb_ctx_t* ctx,
         const char* path,
-        int (*callback)(const char*, tiledb_object_t, void*),
+        int (*callback)(const char*, tiledb_object_t, void*) noexcept,
         void* data)
 
     # VFS
@@ -1067,7 +1067,7 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_ctx_t * ctx,
         tiledb_vfs_t * vfs,
         const char * path,
-        int (*callback)(const char *, void *),
+        int (*callback)(const char *, void *) noexcept,
         void * data)
 
     int tiledb_vfs_move_file(

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -3732,7 +3732,7 @@ def move(old_uri, new_uri, ctx=None):
         check_error(ctx, rc)
     return
 
-cdef int walk_callback(const char* path_ptr, tiledb_object_t obj, void* pyfunc):
+cdef int walk_callback(const char* path_ptr, tiledb_object_t obj, void* pyfunc) noexcept:
     objtype = None
     if obj == TILEDB_GROUP:
         objtype = "group"


### PR DESCRIPTION
Fix build with Cython 3 - it no longer adds implicit noexcept to callbacks