### PR TITLE
Update HISTORY for 0.26.4 against TileDB 2.20.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+# Release 0.26.4
+
+## Bug Fixes
+
+* Fix VFS `read`, `seek` with numpy integer sizes. [#1927](https://github.com/TileDB-Inc/TileDB-Py/pull/1927)
+* Remove erroneous `_ctx` check for GroupMetadata [#1925](https://github.com/TileDB-Inc/TileDB-Py/pull/1925)
+
 # Release 0.26.3
 
 ## Improvements

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,7 +6,7 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.26.3
+        TILEDBPY_VERSION: 0.26.4
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA
         LIBTILEDB_VERSION: "2.20.1"
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA


### PR DESCRIPTION
Update HISTORY for 0.26.4 against TileDB 2.20.1