### PR TITLE
Update cibuildwheel version for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-12, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     env:
       # 11.7 necessary due to: https://github.com/actions/setup-python/issues/682#issuecomment-1604261330

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -16,9 +16,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-12, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
+          - python-version: "3.12"
+            numpy-version: "1.26.4"
           - python-version: "3.11"
             numpy-version: "1.23.2"
           - python-version: "3.10"

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -66,7 +66,7 @@ stages:
         condition: always()
         variables:
           cibw_test_requires: "pytest"
-          USE_CIBW_VERSION: 2.12.3
+          USE_CIBW_VERSION: 2.17.0
         strategy:
           matrix:
             linux_py:
@@ -80,7 +80,6 @@ stages:
               TILEDB_INSTALL: "$(Pipeline.Workspace)/.libtiledb_dist/$(LIBTILEDB_SHA)-macos-x86_64"
               CIBW_ARCHS_MACOS: "x86_64"
               CIBW_SKIP: "cp36-* cp37-* pp*"
-              CIBW_TEST_SKIP: "cp37-*"
               CIBW_BUILD_VERBOSITY: 3
             macOS_arm64_py:
               imageName: "macOS-12"

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -15,9 +15,7 @@ A high level wrapper around the Pybind11 query_condition.cc implementation for
 filtering query results on attribute and dimension values.
 """
 
-QueryConditionNodeElem = Union[
-    ast.Name, ast.Constant, ast.Call, ast.Num, ast.Str, ast.Bytes
-]
+QueryConditionNodeElem = Union[ast.Name, ast.Constant, ast.Call]
 
 
 @dataclass
@@ -280,8 +278,8 @@ class QueryConditionTree(ast.NodeVisitor):
 
             return (
                 isinstance(variable.args[0], ast.Constant)
-                or isinstance(variable.args[0], ast.Str)
-                or isinstance(variable.args[0], ast.Bytes)
+                or isinstance(variable.args[0], ast.Constant)
+                or isinstance(variable.args[0], ast.Constant)
             )
 
         return isinstance(variable, ast.Name)
@@ -326,7 +324,9 @@ class QueryConditionTree(ast.NodeVisitor):
             variable = variable_node.id
         elif isinstance(variable_node, ast.Constant):
             variable = variable_node.value
-        elif isinstance(variable_node, ast.Str) or isinstance(variable_node, ast.Bytes):
+        elif isinstance(variable_node, ast.Constant) or isinstance(
+            variable_node, ast.Constant
+        ):
             # deprecated in 3.8
             variable = variable_node.s
         else:
@@ -363,13 +363,15 @@ class QueryConditionTree(ast.NodeVisitor):
 
         if isinstance(value_node, ast.Constant):
             value = value_node.value
-        elif isinstance(value_node, ast.NameConstant):
+        elif isinstance(value_node, ast.Constant):
             # deprecated in 3.8
             value = value_node.value
-        elif isinstance(value_node, ast.Num):
+        elif isinstance(value_node, ast.Constant):
             # deprecated in 3.8
             value = value_node.n
-        elif isinstance(value_node, ast.Str) or isinstance(value_node, ast.Bytes):
+        elif isinstance(value_node, ast.Constant) or isinstance(
+            value_node, ast.Constant
+        ):
             # deprecated in 3.8
             value = value_node.s
         else:
@@ -491,7 +493,7 @@ class QueryConditionTree(ast.NodeVisitor):
         else:
             if isinstance(node.operand, ast.Constant):
                 node.operand.value *= sign
-            elif isinstance(node.operand, ast.Num):
+            elif isinstance(node.operand, ast.Constant):
                 node.operand.n *= sign
             else:
                 raise TileDBError(
@@ -500,18 +502,18 @@ class QueryConditionTree(ast.NodeVisitor):
 
             return node.operand
 
-    def visit_Num(self, node: ast.Num) -> ast.Num:
+    def visit_Num(self, node: ast.Constant) -> ast.Constant:
         # deprecated in 3.8
         return node
 
-    def visit_Str(self, node: ast.Str) -> ast.Str:
+    def visit_Str(self, node: ast.Constant) -> ast.Constant:
         # deprecated in 3.8
         return node
 
-    def visit_Bytes(self, node: ast.Bytes) -> ast.Bytes:
+    def visit_Bytes(self, node: ast.Constant) -> ast.Constant:
         # deprecated in 3.8
         return node
 
-    def visit_NameConstant(self, node: ast.NameConstant) -> ast.NameConstant:
+    def visit_NameConstant(self, node: ast.Constant) -> ast.Constant:
         # deprecated in 3.8
         return node


### PR DESCRIPTION
Update cibuildwheel version to enable Python 3.12

---

[wip] Also update the toolchain to 14.39 to fix build issues: https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#vcvarsall-syntax

---
- Test build: https://dev.azure.com/isaiahnorton/isaiahnorton/_build/results?buildId=1221&view=logs&j=6816465a-97f1-56bb-6c33-0ae30016aaf5