### PR TITLE
Exclude .pytest_cache and .hypothesis files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers=[
 dynamic = ["version", "dependencies"]
 
 [tool.setuptools.packages.find]
-exclude = ["*.pyc"]
+exclude = ["*.pyc", ".pytest_cache/*", ".hypothesis/*"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements_wheel.txt"}


### PR DESCRIPTION
Tested using:
```
pipx run build
tar -tzf dist/tiledb-0.27.1.dev2.tar.gz | grep -E '(\.pytest_cache|\.hypothesis)'\n
unzip -l dist/tiledb-0.27.1.dev2-cp312-cp312-macosx_14_0_arm64.whl | grep -E '(\.pytest_cache|\.hypothesis)'\n
```

They both return nothing.