### PR TITLE
Add wrapping for ls_recursive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import Extension, find_packages, setup
 # - this is for builds-from-source
 # - release builds are controlled by `misc/azure-release.yml`
 # - this should be set to the current core release, not `dev`
-TILEDB_VERSION = "dev"
+TILEDB_VERSION = "2.22.0-rc0"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = (

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import Extension, find_packages, setup
 # - this is for builds-from-source
 # - release builds are controlled by `misc/azure-release.yml`
 # - this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.22.0-rc1"
+TILEDB_VERSION = "2.22.0"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = (

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import Extension, find_packages, setup
 # - this is for builds-from-source
 # - release builds are controlled by `misc/azure-release.yml`
 # - this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.22.0-rc0"
+TILEDB_VERSION = "2.22.0-rc1"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = (

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import Extension, find_packages, setup
 # - this is for builds-from-source
 # - release builds are controlled by `misc/azure-release.yml`
 # - this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.20.1"
+TILEDB_VERSION = "dev"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = (

--- a/tiledb/cc/vfs.cc
+++ b/tiledb/cc/vfs.cc
@@ -1,11 +1,11 @@
 #include <tiledb/tiledb>
 #include <tiledb/tiledb_experimental>
 
+#include <pybind11/functional.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
-#include <pybind11/functional.h>
 
 #include "common.h"
 

--- a/tiledb/cc/vfs.cc
+++ b/tiledb/cc/vfs.cc
@@ -1,9 +1,11 @@
 #include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
+#include <pybind11/functional.h>
 
 #include "common.h"
 
@@ -41,6 +43,7 @@ void init_vfs(py::module &m) {
       .def("_copy_file", &VFS::copy_file)
 
       .def("_ls", &VFS::ls)
+      .def_static("_ls_recursive", &VFSExperimental::ls_recursive)
       .def("_touch", &VFS::touch);
 }
 

--- a/tiledb/cc/vfs.cc
+++ b/tiledb/cc/vfs.cc
@@ -43,25 +43,34 @@ void init_vfs(py::module &m) {
       .def("_copy_file", &VFS::copy_file)
 
       .def("_ls", &VFS::ls)
-      .def("_ls_recursive",
-        // 1. the user provides a callback, the user callback is passed to the C++ function. Return an empty vector.
-        // 2. no callback is passed and a default callback is used. The default callback just appends each path gathered. Return the paths.
-        [](VFS& vfs, std::string uri, py::object callback) {
-          tiledb::Context ctx;
-          if (callback.is_none()) {
-            std::vector<std::string> paths;
-            tiledb::VFSExperimental::ls_recursive(ctx, vfs, uri, [&](const std::string_view path, uint64_t object_size) -> bool {
-              paths.push_back(std::string(path));
-              return true;
-            });
-            return paths;
-          } else {
-            tiledb::VFSExperimental::ls_recursive(ctx, vfs, uri, [&](const std::string_view path, uint64_t object_size) -> bool {
-              return callback(path, object_size).cast<bool>();
-          });
-          return std::vector<std::string>();
-        }
-      })
+      .def(
+          "_ls_recursive",
+          // 1. the user provides a callback, the user callback is passed to the
+          // C++ function. Return an empty vector.
+          // 2. no callback is passed and a default callback is used. The
+          // default callback just appends each path gathered. Return the paths.
+          [](VFS &vfs, std::string uri, py::object callback) {
+            tiledb::Context ctx;
+            if (callback.is_none()) {
+              std::vector<std::string> paths;
+              tiledb::VFSExperimental::ls_recursive(
+                  ctx, vfs, uri,
+                  [&](const std::string_view path,
+                      uint64_t object_size) -> bool {
+                    paths.push_back(std::string(path));
+                    return true;
+                  });
+              return paths;
+            } else {
+              tiledb::VFSExperimental::ls_recursive(
+                  ctx, vfs, uri,
+                  [&](const std::string_view path,
+                      uint64_t object_size) -> bool {
+                    return callback(path, object_size).cast<bool>();
+                  });
+              return std::vector<std::string>();
+            }
+          })
       .def("_touch", &VFS::touch);
 }
 

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1067,8 +1067,14 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_ctx_t * ctx,
         tiledb_vfs_t * vfs,
         const char * path,
-        int (*callback)(const char *, void *) noexcept,
-        void * data)
+        void * data) nogil
+
+    int tiledb_vfs_ls_recursive(
+        tiledb_ctx_t * ctx,
+        tiledb_vfs_t * vfs,
+        const char * uri,
+        int (*callback)(const char *, uint64_t, void *),
+        void * data) nogil
 
     int tiledb_vfs_move_file(
         tiledb_ctx_t* ctx,

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1069,13 +1069,6 @@ cdef extern from "tiledb/tiledb.h":
         const char * path,
         void * data) nogil
 
-    int tiledb_vfs_ls_recursive(
-        tiledb_ctx_t * ctx,
-        tiledb_vfs_t * vfs,
-        const char * uri,
-        int (*callback)(const char *, uint64_t, void *),
-        void * data) nogil
-
     int tiledb_vfs_move_file(
         tiledb_ctx_t* ctx,
         tiledb_vfs_t* vfs,

--- a/tiledb/tests/test_vfs.py
+++ b/tiledb/tests/test_vfs.py
@@ -346,8 +346,10 @@ class TestVFS(DiskTestCase):
             set(expected),
             set(
                 map(
-                    # keep only the part after basepath
-                    lambda x: x.split(basepath)[1][1:],
+                    # # Keep only the paths after the basepath and normalize them to work on all platforms
+                    lambda x: os.path.normpath(
+                        x.split("test_vfs_ls_recursive/")[1]
+                    ).replace("\\", "/"),
                     self.vfs.ls_recursive(basepath),
                 )
             ),
@@ -366,8 +368,10 @@ class TestVFS(DiskTestCase):
             set(expected),
             set(
                 map(
-                    # keep only the part after basepath
-                    lambda x: x.split(basepath)[1][1:],
+                    # Keep only the paths after the basepath and normalize them to work on all platforms
+                    lambda x: os.path.normpath(
+                        x.split("test_vfs_ls_recursive/")[1]
+                    ).replace("\\", "/"),
                     callback_results,
                 )
             ),
@@ -378,8 +382,10 @@ class TestVFS(DiskTestCase):
             set(expected),
             set(
                 map(
-                    # keep only the part after basepath
-                    lambda x: x.split(basepath)[1][1:],
+                    # Keep only the paths after the basepath and normalize them to work on all platforms
+                    lambda x: os.path.normpath(
+                        x.split("test_vfs_ls_recursive/")[1]
+                    ).replace("\\", "/"),
                     self.vfs.ls(basepath, recursive=True),
                 )
             ),

--- a/tiledb/tests/test_vfs.py
+++ b/tiledb/tests/test_vfs.py
@@ -270,7 +270,7 @@ class TestVFS(DiskTestCase):
         basepath = self.path("test_vfs_ls")
         self.vfs.create_dir(basepath)
         for id in (1, 2, 3):
-            dir = os.path.join(basepath, "dir" + str(id))
+            dir = os.path.join(basepath, f"dir{id}")
             self.vfs.create_dir(dir)
             fname = os.path.join(basepath, "file_" + str(id))
             with tiledb.FileIO(self.vfs, fname, "wb") as fio:
@@ -297,12 +297,12 @@ class TestVFS(DiskTestCase):
         self.vfs.create_dir(basepath)
         # Create a nested directory structure to test recursive listing
         for id in (1, 2, 3):
-            dir = os.path.join(basepath, "dir" + str(id))
+            dir = os.path.join(basepath, f"dir{id}")
             self.vfs.create_dir(dir)
             for id2 in (1, 2, 3):
-                dir2 = os.path.join(dir, "dir" + str(id2))
+                dir2 = os.path.join(dir, f"dir{id2}")
                 self.vfs.create_dir(dir2)
-                fname = os.path.join(dir, "file_" + str(id2))
+                fname = os.path.join(dir, f"dir{id2}")
                 with tiledb.FileIO(self.vfs, fname, "wb") as fio:
                     fio.write(b"")
         expected = [

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -287,16 +287,27 @@ class VFS(lt.VFS):
         """
         return self._copy_file(_to_path_str(old_uri), _to_path_str(new_uri))
 
-    def ls(self, uri: _AnyPath) -> List[str]:
+    def ls(self, uri: _AnyPath, recursive: bool = False) -> List[str]:
         """Retrieves the children in directory `uri`. This function is
         non-recursive, i.e., it focuses in one level below `uri`.
 
         :param str uri: Input URI of the directory
+        :param bool recursive: If True, recursively list all children in the directory
         :rtype: List[str]
         :return: The children in directory `uri`
 
         """
-        return self._ls(_to_path_str(uri))
+        if recursive:
+            children = []
+
+            def callback(name, _):
+                children.append(name)
+                return True
+
+            self.ls_recursive(uri, callback)
+            return children
+        else:
+            return self._ls(_to_path_str(uri))
 
     def ls_recursive(self, uri: _AnyPath, callback: Callable[[str, int], bool]):
         """Recursively lists objects at the input URI, invoking the provided callback

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -298,18 +298,13 @@ class VFS(lt.VFS):
 
         """
         if recursive:
-            children = []
+            return VFS._ls_recursive(self, _to_path_str(uri), None)
 
-            def callback(name, _):
-                children.append(name)
-                return True
+        return self._ls(_to_path_str(uri))
 
-            self.ls_recursive(uri, callback)
-            return children
-        else:
-            return self._ls(_to_path_str(uri))
-
-    def ls_recursive(self, uri: _AnyPath, callback: Callable[[str, int], bool]):
+    def ls_recursive(
+        self, uri: _AnyPath, callback: Optional[Callable[[str, int], bool]] = None
+    ):
         """Recursively lists objects at the input URI, invoking the provided callback
         on each entry gathered. The callback is passed the data pointer provided
         on each invocation and is responsible for writing the collected results
@@ -323,7 +318,7 @@ class VFS(lt.VFS):
         :param callback: Callback function to invoke on each entry
 
         """
-        return VFS._ls_recursive(self._ctx, self, _to_path_str(uri), callback)
+        return VFS._ls_recursive(self, _to_path_str(uri), callback)
 
     def touch(self, uri: _AnyPath):
         """Touches a file with the input URI, i.e., creates a new empty file.

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -1,7 +1,7 @@
 import io
 import os
 from types import TracebackType
-from typing import List, Optional, Type, Union
+from typing import Callable, List, Optional, Type, Union
 
 import numpy as np
 
@@ -297,6 +297,22 @@ class VFS(lt.VFS):
 
         """
         return self._ls(_to_path_str(uri))
+
+    def ls_recursive(self, uri: _AnyPath, callback: Callable[[str, int], bool]):
+        """Recursively lists objects at the input URI, invoking the provided callback
+        on each entry gathered. The callback is passed the data pointer provided
+        on each invocation and is responsible for writing the collected results
+        into this structure. If the callback returns True, the walk will continue.
+        If False, the walk will stop. If an error is thrown, the walk will stop and
+        the error will be propagated to the caller using std::throw_with_nested.
+
+        Currently only S3 is supported, and the `path` must be a valid S3 URI.
+
+        :param str uri: Input URI of the directory
+        :param callback: Callback function to invoke on each entry
+
+        """
+        return VFS._ls_recursive(self._ctx, self, _to_path_str(uri), callback)
 
     def touch(self, uri: _AnyPath):
         """Touches a file with the input URI, i.e., creates a new empty file.


### PR DESCRIPTION
- Add pybind11 wrapping for ls_recursive
- Connect to the high-level VFS.ls API as a keyword argument
- Test

