### PR TITLE
Remove modular building option

### DIFF
--- a/tiledb/indexing.pyx
+++ b/tiledb/indexing.pyx
@@ -1,7 +1,3 @@
-IF TILEDBPY_MODULAR:
-  include "common.pxi"
-  from .libtiledb cimport *
-
 from libc.stdio cimport printf
 
 import weakref

--- a/tiledb/libmetadata.pyx
+++ b/tiledb/libmetadata.pyx
@@ -1,8 +1,3 @@
-IF TILEDBPY_MODULAR:
-    include "common.pxi"
-    from .libtiledb import *
-    from .libtiledb cimport *
-
 import weakref
 from collections.abc import MutableMapping
 

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1,9 +1,6 @@
 from libc.stdint cimport uint32_t, uint64_t
 from libc.stdio cimport FILE
-
-IF TILEDBPY_MODULAR:
-    from .indexing cimport DomainIndexer
-
+include "indexing.pxd"
 include "common.pxi"
 
 cdef extern from "Python.h":
@@ -1237,5 +1234,3 @@ cdef class ReadQuery(object):
 cdef class Metadata(object):
     cdef object array_ref
 
-IF (not TILEDBPY_MODULAR):
-    include "indexing.pxd"

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -6,6 +6,8 @@ from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_IsValid, PyCapsul
 from cpython.version cimport PY_MAJOR_VERSION
 
 include "common.pxi"
+include "indexing.pyx"
+include "libmetadata.pyx"
 import io
 import warnings
 import collections.abc
@@ -26,17 +28,6 @@ from .vfs import VFS
 
 # https://docs.scipy.org/doc/numpy/reference/c-api.array.html#c.import_array
 np.import_array()
-
-
-###############################################################################
-#    MODULAR IMPORTS                                                 #
-###############################################################################
-
-IF TILEDBPY_MODULAR:
-    from .indexing import DomainIndexer
-ELSE:
-    include "indexing.pyx"
-    include "libmetadata.pyx"
 
 ###############################################################################
 #    Utility/setup                                                            #


### PR DESCRIPTION
Removes the `--modular` option when building TileDB-Py.