### PR TITLE
TileDB-Py 0.28.0 against TileDB 2.22.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,26 @@
+# Release 0.28.0
+
+## TileDB Embedded updates
+
+* TileDB-Py 0.28.0 includes TileDB Embedded [2.22.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.22.0)
+
+## Improvements
+
+* Update type signature for VFS::readinto by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1937
+* Show enumerated value-types in enum-printer by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1936
+* Add wrapping for new consolidation plan API by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1935
+* Add test for Group constructor invalid uri object type by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1941
+* Update doc for tiledb.consolidate by @ihnorton in https://github.com/TileDB-Inc/TileDB-Py/pull/1946
+* Improve documentation of from_numpy function by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1942
+
+## Build system changes
+
+* Exclude .pytest_cache and .hypothesis files by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1932
+* Remove modular building option by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1938
+* Fix wrong version number for Python API docs by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1947
+* Remove conditional code for TileDB < 2.16 by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1949
+* Update nightly test target to 2.21 by @ihnorton in https://github.com/TileDB-Inc/TileDB-Py/pull/1950
+
 # Release 0.27.1
 
 ## TileDB Embedded updates

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,12 +6,11 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.27.1
+        TILEDBPY_VERSION: 0.28.0
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA
-        LIBTILEDB_VERSION: "2.21.1"
+        LIBTILEDB_VERSION: "2.22.0"
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA
-        LIBTILEDB_SHA: acd5c50ecc50bb64c4786508c145febb156f3525
-      # kick the hash
+        LIBTILEDB_SHA: d252feaa295bc59d91780ed7ab7d947f1fcb2d0a104ff25c062dac5663051089
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -10,7 +10,7 @@ stages:
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA
         LIBTILEDB_VERSION: "2.22.0"
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA
-        LIBTILEDB_SHA: d252feaa295bc59d91780ed7ab7d947f1fcb2d0a104ff25c062dac5663051089
+        LIBTILEDB_SHA: 52e981ee9ce92eaceaf13a79a5a95820eca0673b
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import Extension, find_packages, setup
 # - this is for builds-from-source
 # - release builds are controlled by `misc/azure-release.yml`
 # - this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.21.1"
+TILEDB_VERSION = "2.22.0"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = (


### PR DESCRIPTION
TileDB-Py 0.28.0 against TileDB 2.22.0

---
wheel test build on this branch: https://github.com/TileDB-Inc/TileDB-Py/pull/new/release-test-0.28.0-2.22.0