### PR TITLE
Make timestamp overrides optional in tests and add faketime test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,14 @@ jobs:
       - name: "Check build directory"
         run: ls -Rl
 
+      - name: "Install libfaketime (linux and macOS)"
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-12'
+        run: |
+          git clone https://github.com/wolfcw/libfaketime/
+          cd libfaketime
+          sudo make install
+          cd ..
+
       - name: "Run tests"
         run: pytest -vv --showlocals
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import Extension, find_packages, setup
 # - this is for builds-from-source
 # - release builds are controlled by `misc/azure-release.yml`
 # - this should be set to the current core release, not `dev`
-TILEDB_VERSION = "dev"
+TILEDB_VERSION = "2.22.0"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = (

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import Extension, find_packages, setup
 # - this is for builds-from-source
 # - release builds are controlled by `misc/azure-release.yml`
 # - this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.21.1"
+TILEDB_VERSION = "dev"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = (

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -258,7 +258,7 @@ class SOMA919Test(DiskTestCase):
     We've distilled @atolopko-czi's gist example using the TileDB-Py API directly.
     """
 
-    def run_test(self):
+    def run_test(self, use_timestamps):
         import tempfile
 
         import numpy as np
@@ -267,13 +267,17 @@ class SOMA919Test(DiskTestCase):
 
         root_uri = tempfile.mkdtemp()
 
-        # this tiledb.Ctx is how we set the write timestamps for tiledb.Group
-        group_ctx100 = tiledb.Ctx(
-            {
-                "sm.group.timestamp_start": 100,
-                "sm.group.timestamp_end": 100,
-            }
-        )
+        if use_timestamps:
+            group_ctx100 = tiledb.Ctx(
+                {
+                    "sm.group.timestamp_start": 100,
+                    "sm.group.timestamp_end": 100,
+                }
+            )
+            timestamp = 100
+        else:
+            group_ctx100 = tiledb.Ctx()
+            timestamp = None
 
         # create the group and add a dummy subgroup "causes_bug"
         tiledb.Group.create(root_uri, ctx=group_ctx100)
@@ -284,7 +288,7 @@ class SOMA919Test(DiskTestCase):
         # add an array to the group (in a separate write operation)
         with tiledb.Group(root_uri, mode="w", ctx=group_ctx100) as expt:
             df_path = os.path.join(root_uri, "df")
-            tiledb.from_numpy(df_path, np.ones((100, 100)), timestamp=100)
+            tiledb.from_numpy(df_path, np.ones((100, 100)), timestamp=timestamp)
             expt.add(name="df", uri=df_path)
 
         # check our view of the group at current time;
@@ -301,12 +305,13 @@ class SOMA919Test(DiskTestCase):
         tiledb.libtiledb.version() < (2, 15, 0),
         reason="SOMA919 fix implemented in libtiledb 2.15",
     )
-    def test_soma919(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_soma919(self, use_timestamps):
         N = 100
         fails = 0
         for i in range(N):
             try:
-                self.run_test()
+                self.run_test(use_timestamps)
             except AssertionError:
                 fails += 1
         if fails > 0:

--- a/tiledb/tests/test_fragments.py
+++ b/tiledb/tests/test_fragments.py
@@ -22,7 +22,8 @@ class FragmentInfoTest(DiskTestCase):
         with self.assertRaises(tiledb.TileDBError):
             tiledb.array_fragments("does_not_exist")
 
-    def test_array_fragments(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_array_fragments(self, use_timestamps):
         fragments = 3
 
         A = np.zeros(fragments)
@@ -34,10 +35,15 @@ class FragmentInfoTest(DiskTestCase):
 
         tiledb.DenseArray.create(uri, schema)
 
-        for fragment_idx in range(fragments):
-            timestamp = fragment_idx + 1
-            with tiledb.DenseArray(uri, mode="w", timestamp=timestamp) as T:
-                T[fragment_idx : fragment_idx + 1] = fragment_idx
+        if use_timestamps:
+            for fragment_idx in range(fragments):
+                timestamp = fragment_idx + 1
+                with tiledb.DenseArray(uri, mode="w", timestamp=timestamp) as T:
+                    T[fragment_idx : fragment_idx + 1] = fragment_idx
+        else:
+            for fragment_idx in range(fragments):
+                with tiledb.DenseArray(uri, mode="w") as T:
+                    T[fragment_idx : fragment_idx + 1] = fragment_idx
 
         fi = tiledb.array_fragments(uri)
 
@@ -47,7 +53,8 @@ class FragmentInfoTest(DiskTestCase):
         assert fi.has_consolidated_metadata == (False, False, False)
         assert fi.nonempty_domain == (((0, 0),), ((1, 1),), ((2, 2),))
         assert fi.sparse == (False, False, False)
-        assert fi.timestamp_range == ((1, 1), (2, 2), (3, 3))
+        if use_timestamps:  # timestamps cannot be predicted if not used on write
+            assert fi.timestamp_range == ((1, 1), (2, 2), (3, 3))
         assert fi.to_vacuum == ()
         assert hasattr(fi, "version")  # don't pin to a specific version
 
@@ -56,7 +63,8 @@ class FragmentInfoTest(DiskTestCase):
             assert frag.has_consolidated_metadata is False
             assert frag.nonempty_domain == ((idx, idx),)
             assert frag.sparse is False
-            assert frag.timestamp_range == (idx + 1, idx + 1)
+            if use_timestamps:  # timestamps cannot be predicted if not used on write
+                assert frag.timestamp_range == (idx + 1, idx + 1)
             assert hasattr(frag, "version")  # don't pin to a specific version
             try:
                 assert xml.etree.ElementTree.fromstring(frag._repr_html_()) is not None
@@ -70,7 +78,8 @@ class FragmentInfoTest(DiskTestCase):
         except:
             pytest.fail(f"Could not parse fi._repr_html_(). Saw {fi._repr_html_()}")
 
-    def test_array_fragments_var(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_array_fragments_var(self, use_timestamps):
         fragments = 3
 
         uri = self.path("test_array_fragments_var")
@@ -86,18 +95,28 @@ class FragmentInfoTest(DiskTestCase):
         tiledb.SparseArray.create(uri, schema)
 
         for fragment_idx in range(fragments):
-            timestamp = fragment_idx + 1
 
             data = np.array(
                 [
-                    np.array([timestamp] * 1, dtype=np.int32),
-                    np.array([timestamp] * 2, dtype=np.int32),
-                    np.array([timestamp] * 3, dtype=np.int32),
+                    np.array(
+                        [fragment_idx + 1] * 1,
+                        dtype=np.int32,
+                    ),
+                    np.array(
+                        [fragment_idx + 1] * 2,
+                        dtype=np.int32,
+                    ),
+                    np.array(
+                        [fragment_idx + 1] * 3,
+                        dtype=np.int32,
+                    ),
                 ],
                 dtype="O",
             )
 
-            with tiledb.SparseArray(uri, mode="w", timestamp=timestamp) as T:
+            with tiledb.SparseArray(
+                uri, mode="w", timestamp=fragment_idx + 1 if use_timestamps else None
+            ) as T:
                 T[["zero", "one", "two"]] = data
 
         fragments_info = tiledb.array_fragments(uri)
@@ -110,7 +129,8 @@ class FragmentInfoTest(DiskTestCase):
         for frag in fragments_info:
             self.assertEqual(frag.nonempty_domain, (("one", "zero"),))
 
-    def test_dense_fragments(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_dense_fragments(self, use_timestamps):
         fragments = 3
 
         A = np.zeros(fragments)
@@ -123,45 +143,48 @@ class FragmentInfoTest(DiskTestCase):
         tiledb.DenseArray.create(uri, schema)
 
         for fragment_idx in range(fragments):
-            timestamp = fragment_idx + 1
+            timestamp = fragment_idx + 1 if use_timestamps else None
             with tiledb.DenseArray(uri, mode="w", timestamp=timestamp) as T:
                 T[fragment_idx : fragment_idx + 1] = fragment_idx
 
             fragment_info = PyFragmentInfo(uri, schema, False, tiledb.default_ctx())
             self.assertEqual(fragment_info.get_num_fragments(), fragment_idx + 1)
 
-        all_expected_uris = []
-        for fragment_idx in range(fragments):
-            timestamp = fragment_idx + 1
+        if use_timestamps:  # asserts are not predictable without timestamps
+            all_expected_uris = []
+            for fragment_idx in range(fragments):
+                timestamp = fragment_idx + 1
+
+                self.assertEqual(
+                    fragment_info.get_timestamp_range()[fragment_idx],
+                    (timestamp, timestamp),
+                )
+
+                expected_uri = f"__{timestamp}_{timestamp}"
+                actual_uri = fragment_info.get_uri()[fragment_idx]
+
+                all_expected_uris.append(expected_uri)
+
+                self.assertTrue(expected_uri in actual_uri)
+                self.assertTrue(
+                    actual_uri.endswith(str(fragment_info.get_version()[fragment_idx]))
+                )
+                self.assertFalse(fragment_info.get_sparse()[fragment_idx])
+
+            all_actual_uris = fragment_info.get_uri()
+            for actual_uri, expected_uri in zip(all_actual_uris, all_expected_uris):
+                self.assertTrue(expected_uri in actual_uri)
+                self.assertTrue(
+                    actual_uri.endswith(str(fragment_info.get_version()[fragment_idx]))
+                )
 
             self.assertEqual(
-                fragment_info.get_timestamp_range()[fragment_idx],
-                (timestamp, timestamp),
+                fragment_info.get_timestamp_range(), ((1, 1), (2, 2), (3, 3))
             )
+            self.assertEqual(fragment_info.get_sparse(), (False, False, False))
 
-            expected_uri = f"__{timestamp}_{timestamp}"
-            actual_uri = fragment_info.get_uri()[fragment_idx]
-
-            all_expected_uris.append(expected_uri)
-
-            # use .contains because the protocol can vary
-            self.assertTrue(expected_uri in actual_uri)
-            self.assertTrue(
-                actual_uri.endswith(str(fragment_info.get_version()[fragment_idx]))
-            )
-            self.assertFalse(fragment_info.get_sparse()[fragment_idx])
-
-        all_actual_uris = fragment_info.get_uri()
-        for actual_uri, expected_uri in zip(all_actual_uris, all_expected_uris):
-            self.assertTrue(expected_uri in actual_uri)
-            self.assertTrue(
-                actual_uri.endswith(str(fragment_info.get_version()[fragment_idx]))
-            )
-
-        self.assertEqual(fragment_info.get_timestamp_range(), ((1, 1), (2, 2), (3, 3)))
-        self.assertEqual(fragment_info.get_sparse(), (False, False, False))
-
-    def test_sparse_fragments(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_sparse_fragments(self, use_timestamps):
         fragments = 3
 
         A = np.zeros(fragments)
@@ -174,45 +197,48 @@ class FragmentInfoTest(DiskTestCase):
         tiledb.SparseArray.create(uri, schema)
 
         for fragment_idx in range(fragments):
-            timestamp = fragment_idx + 1
+            timestamp = fragment_idx + 1 if use_timestamps else None
             with tiledb.SparseArray(uri, mode="w", timestamp=timestamp) as T:
                 T[fragment_idx] = fragment_idx
 
             fragment_info = PyFragmentInfo(uri, schema, False, tiledb.default_ctx())
             self.assertEqual(fragment_info.get_num_fragments(), fragment_idx + 1)
 
-        all_expected_uris = []
-        for fragment_idx in range(fragments):
-            timestamp = fragment_idx + 1
+        if use_timestamps:  # asserts are not predictable without timestamps
+            all_expected_uris = []
+            for fragment_idx in range(fragments):
+                timestamp = fragment_idx + 1
+
+                self.assertEqual(
+                    fragment_info.get_timestamp_range()[fragment_idx],
+                    (timestamp, timestamp),
+                )
+
+                if uri[0] != "/":
+                    uri = "/" + uri.replace("\\", "/")
+
+                expected_uri = f"/__{timestamp}_{timestamp}"
+                actual_uri = fragment_info.get_uri()[fragment_idx]
+
+                all_expected_uris.append(expected_uri)
+
+                self.assertTrue(expected_uri in actual_uri)
+                self.assertTrue(
+                    actual_uri.endswith(str(fragment_info.get_version()[fragment_idx]))
+                )
+                self.assertTrue(fragment_info.get_sparse()[fragment_idx])
+
+            all_actual_uris = fragment_info.get_uri()
+            for actual_uri, expected_uri in zip(all_actual_uris, all_expected_uris):
+                self.assertTrue(expected_uri in actual_uri)
+                self.assertTrue(
+                    actual_uri.endswith(str(fragment_info.get_version()[fragment_idx]))
+                )
 
             self.assertEqual(
-                fragment_info.get_timestamp_range()[fragment_idx],
-                (timestamp, timestamp),
+                fragment_info.get_timestamp_range(), ((1, 1), (2, 2), (3, 3))
             )
-
-            if uri[0] != "/":
-                uri = "/" + uri.replace("\\", "/")
-
-            expected_uri = f"/__{timestamp}_{timestamp}"
-            actual_uri = fragment_info.get_uri()[fragment_idx]
-
-            all_expected_uris.append(expected_uri)
-
-            self.assertTrue(expected_uri in actual_uri)
-            self.assertTrue(
-                actual_uri.endswith(str(fragment_info.get_version()[fragment_idx]))
-            )
-            self.assertTrue(fragment_info.get_sparse()[fragment_idx])
-
-        all_actual_uris = fragment_info.get_uri()
-        for actual_uri, expected_uri in zip(all_actual_uris, all_expected_uris):
-            self.assertTrue(expected_uri in actual_uri)
-            self.assertTrue(
-                actual_uri.endswith(str(fragment_info.get_version()[fragment_idx]))
-            )
-
-        self.assertEqual(fragment_info.get_timestamp_range(), ((1, 1), (2, 2), (3, 3)))
-        self.assertEqual(fragment_info.get_sparse(), (True, True, True))
+            self.assertEqual(fragment_info.get_sparse(), (True, True, True))
 
     def test_nonempty_domain(self):
         uri = self.path("test_nonempty_domain")
@@ -408,7 +434,8 @@ class FragmentInfoTest(DiskTestCase):
             "tiledb.libtiledb.version() < (2, 5, 0)"
         ),
     )
-    def test_get_mbr(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_get_mbr(self, use_timestamps):
         fragments = 3
 
         uri = self.path("test_get_mbr")
@@ -419,7 +446,9 @@ class FragmentInfoTest(DiskTestCase):
 
         for fragi in range(fragments):
             timestamp = fragi + 1
-            with tiledb.open(uri, mode="w", timestamp=timestamp) as T:
+            with tiledb.open(
+                uri, mode="w", timestamp=timestamp if use_timestamps else None
+            ) as T:
                 T[np.array(range(0, fragi + 1))] = [fragi] * (fragi + 1)
 
         expected_mbrs = ((((0, 0),),), (((0, 1),),), (((0, 2),),))
@@ -453,7 +482,8 @@ class FragmentInfoTest(DiskTestCase):
             "tiledb.libtiledb.version() < (2, 5, 0)"
         ),
     )
-    def test_get_var_sized_dim_mbrs(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_get_var_sized_dim_mbrs(self, use_timestamps):
         fragments = 3
 
         uri = self.path("test_get_var_sized_dim_mbrs")
@@ -464,7 +494,9 @@ class FragmentInfoTest(DiskTestCase):
 
         for fragi in range(fragments):
             timestamp = fragi + 1
-            with tiledb.open(uri, mode="w", timestamp=timestamp) as T:
+            with tiledb.open(
+                uri, mode="w", timestamp=timestamp if use_timestamps else None
+            ) as T:
                 coords = [chr(i) * (fragi + 1) for i in range(97, fragi + 98)]
                 T[np.array(coords)] = [fragi] * (fragi + 1)
 
@@ -497,7 +529,8 @@ class CreateArrayFromFragmentsTest(DiskTestCase):
     @pytest.mark.skipif(
         sys.platform == "win32", reason="VFS.copy() does not run on windows"
     )
-    def test_create_array_from_fragments(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_create_array_from_fragments(self, use_timestamps):
         dshape = (1, 3)
         num_frags = 10
 
@@ -509,7 +542,9 @@ class CreateArrayFromFragmentsTest(DiskTestCase):
 
         def write_fragments(target_path, dshape, num_frags):
             for i in range(1, num_frags + 1):
-                with tiledb.open(target_path, "w", timestamp=i) as A:
+                with tiledb.open(
+                    target_path, "w", timestamp=i if use_timestamps else None
+                ) as A:
                     A[[1, 2, 3]] = np.random.rand(dshape[1])
 
         src_path = self.path("test_create_array_from_fragments_src")
@@ -521,13 +556,22 @@ class CreateArrayFromFragmentsTest(DiskTestCase):
         write_fragments(src_path, dshape, num_frags)
         frags = tiledb.FragmentInfoList(src_path)
         assert len(frags) == 10
-        assert frags.timestamp_range == ts
+        if use_timestamps:
+            assert frags.timestamp_range == ts
 
-        tiledb.create_array_from_fragments(src_path, dst_path, (3, 6))
+        if use_timestamps:
+            tiledb.create_array_from_fragments(src_path, dst_path, (3, 6))
+        else:
+            tiledb.create_array_from_fragments(
+                src_path,
+                dst_path,
+                (frags.timestamp_range[2][0], frags.timestamp_range[5][1]),
+            )
 
         frags = tiledb.FragmentInfoList(dst_path)
         assert len(frags) == 4
-        assert frags.timestamp_range == ts[2:6]
+        if use_timestamps:
+            assert frags.timestamp_range == ts[2:6]
 
 
 class CopyFragmentsToExistingArrayTest(DiskTestCase):
@@ -631,7 +675,8 @@ class CopyFragmentsToExistingArrayTest(DiskTestCase):
 
 
 class DeleteFragmentsTest(DiskTestCase):
-    def test_delete_fragments(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_delete_fragments(self, use_timestamps):
         dshape = (1, 3)
         num_writes = 10
 
@@ -643,7 +688,9 @@ class DeleteFragmentsTest(DiskTestCase):
 
         def write_fragments(target_path, dshape, num_writes):
             for i in range(1, num_writes + 1):
-                with tiledb.open(target_path, "w", timestamp=i) as A:
+                with tiledb.open(
+                    target_path, "w", timestamp=i if use_timestamps else None
+                ) as A:
                     A[[1, 2, 3]] = np.random.rand(dshape[1])
 
         path = self.path("test_delete_fragments")
@@ -654,16 +701,24 @@ class DeleteFragmentsTest(DiskTestCase):
         write_fragments(path, dshape, num_writes)
         frags = tiledb.array_fragments(path)
         assert len(frags) == 10
-        assert frags.timestamp_range == ts
+        if use_timestamps:
+            assert frags.timestamp_range == ts
 
         with tiledb.open(path, "m") as A:
-            A.delete_fragments(3, 6)
+            if use_timestamps:
+                A.delete_fragments(3, 6)
+            else:
+                A.delete_fragments(
+                    frags.timestamp_range[2][0], frags.timestamp_range[5][1]
+                )
 
         frags = tiledb.array_fragments(path)
         assert len(frags) == 6
-        assert frags.timestamp_range == ts[:2] + ts[6:]
+        if use_timestamps:
+            assert frags.timestamp_range == ts[:2] + ts[6:]
 
-    def test_delete_fragments_with_schema_evolution(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_delete_fragments_with_schema_evolution(self, use_timestamps):
         path = self.path("test_delete_fragments_with_schema_evolution")
         dshape = (1, 3)
 
@@ -673,8 +728,12 @@ class DeleteFragmentsTest(DiskTestCase):
         tiledb.libtiledb.Array.create(path, schema)
 
         ts1_data = np.random.rand(3)
-        with tiledb.open(path, "w", timestamp=1) as A:
-            A[[1, 2, 3]] = ts1_data
+        if use_timestamps:
+            with tiledb.open(path, "w", timestamp=1) as A:
+                A[[1, 2, 3]] = ts1_data
+        else:
+            with tiledb.open(path, "w") as A:
+                A[[1, 2, 3]] = ts1_data
 
         ctx = tiledb.default_ctx()
         se = tiledb.ArraySchemaEvolution(ctx)
@@ -682,8 +741,12 @@ class DeleteFragmentsTest(DiskTestCase):
         se.array_evolve(path)
 
         ts2_data = np.random.rand(3)
-        with tiledb.open(path, "w", timestamp=2) as A:
-            A[[1, 2, 3]] = {"a1": ts2_data, "a2": ts2_data}
+        if use_timestamps:
+            with tiledb.open(path, "w", timestamp=2) as A:
+                A[[1, 2, 3]] = {"a1": ts2_data, "a2": ts2_data}
+        else:
+            with tiledb.open(path, "w") as A:
+                A[[1, 2, 3]] = {"a1": ts2_data, "a2": ts2_data}
 
         frags = tiledb.array_fragments(path)
         assert len(frags) == 2
@@ -693,7 +756,12 @@ class DeleteFragmentsTest(DiskTestCase):
             assert_array_equal(A[:]["a2"], ts2_data)
 
         with tiledb.open(path, "m") as A:
-            A.delete_fragments(2, 2)
+            if use_timestamps:
+                A.delete_fragments(2, 2)
+            else:
+                A.delete_fragments(
+                    frags.timestamp_range[1][0], frags.timestamp_range[1][1]
+                )
 
         frags = tiledb.array_fragments(path)
         assert len(frags) == 1

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -117,7 +117,10 @@ class GroupTest(GroupTestCase):
             ),
         ),
     )
-    def test_group_metadata(self, int_data, flt_data, str_data, str_type, capfd):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_group_metadata(
+        self, int_data, flt_data, str_data, str_type, capfd, use_timestamps
+    ):
         def values_equal(lhs, rhs):
             if isinstance(lhs, np.ndarray):
                 if not isinstance(rhs, np.ndarray):
@@ -133,13 +136,13 @@ class GroupTest(GroupTestCase):
         grp_path = self.path("test_group_metadata")
         tiledb.Group.create(grp_path)
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 1})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 1} if use_timestamps else {})
         with tiledb.Group(grp_path, "w", cfg) as grp:
             grp.meta["int"] = int_data
             grp.meta["flt"] = flt_data
             grp.meta["str"] = str_data
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 1})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 1} if use_timestamps else {})
         with tiledb.Group(grp_path, "r", cfg) as grp:
             assert len(grp.meta) == 3
             assert "int" in grp.meta
@@ -156,11 +159,11 @@ class GroupTest(GroupTestCase):
             assert "Type: DataType.INT" in metadata_dump
             assert f"Type: DataType.{str_type}" in metadata_dump
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 2})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 2} if use_timestamps else {})
         with tiledb.Group(grp_path, "w", cfg) as grp:
             del grp.meta["int"]
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 2})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 2} if use_timestamps else {})
         with tiledb.Group(grp_path, "r", cfg) as grp:
             assert len(grp.meta) == 2
             assert "int" not in grp.meta
@@ -356,7 +359,8 @@ class GroupMetadataTest(GroupTestCase):
             (np.array([1, 2, 3]), np.array([1.5, 2.5, 3.5]), np.array(["x"])),
         ),
     )
-    def test_group_metadata(self, int_data, flt_data, str_data):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_group_metadata(self, int_data, flt_data, str_data, use_timestamps):
         def values_equal(lhs, rhs):
             if isinstance(lhs, np.ndarray):
                 if not isinstance(rhs, np.ndarray):
@@ -372,13 +376,13 @@ class GroupMetadataTest(GroupTestCase):
         grp_path = self.path("test_group_metadata")
         tiledb.Group.create(grp_path)
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 1})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 1} if use_timestamps else {})
         with tiledb.Group(grp_path, "w", cfg) as grp:
             grp.meta["int"] = int_data
             grp.meta["flt"] = flt_data
             grp.meta["str"] = str_data
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 1})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 1} if use_timestamps else {})
         with tiledb.Group(grp_path, "r", cfg) as grp:
             assert grp.meta.keys() == {"int", "flt", "str"}
             assert len(grp.meta) == 3
@@ -389,11 +393,11 @@ class GroupMetadataTest(GroupTestCase):
             assert "str" in grp.meta
             assert values_equal(grp.meta["str"], str_data)
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 2})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 2} if use_timestamps else {})
         with tiledb.Group(grp_path, "w", cfg) as grp:
             del grp.meta["int"]
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 2})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 2} if use_timestamps else {})
         with tiledb.Group(grp_path, "r", cfg) as grp:
             assert len(grp.meta) == 2
             assert "int" not in grp.meta
@@ -570,20 +574,21 @@ class GroupMetadataTest(GroupTestCase):
         self.assert_metadata_roundtrip(grp.meta, test_vals)
         grp.close()
 
-    def test_consolidation_and_vac(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_consolidation_and_vac(self, use_timestamps):
         vfs = tiledb.VFS()
         path = self.path("test_consolidation_and_vac")
         tiledb.Group.create(path)
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 1})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 1} if use_timestamps else {})
         with tiledb.Group(path, "w", cfg) as grp:
             grp.meta["meta"] = 1
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 2})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 2} if use_timestamps else {})
         with tiledb.Group(path, "w", cfg) as grp:
             grp.meta["meta"] = 2
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 3})
+        cfg = tiledb.Config({"sm.group.timestamp_end": 3} if use_timestamps else {})
         with tiledb.Group(path, "w", cfg) as grp:
             grp.meta["meta"] = 3
 

--- a/tiledb/tests/test_metadata.py
+++ b/tiledb/tests/test_metadata.py
@@ -189,7 +189,8 @@ class MetadataTest(DiskTestCase):
 
     @given(st_metadata, st_ndarray)
     @settings(deadline=None)
-    def test_numpy(self, test_vals, ndarray):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_numpy(self, use_timestamps, test_vals, ndarray):
         test_vals["ndarray"] = ndarray
 
         path = self.path()
@@ -202,8 +203,9 @@ class MetadataTest(DiskTestCase):
         with tiledb.Array(path) as A:
             self.assert_metadata_roundtrip(A.meta, test_vals)
 
-        # test resetting a key with a ndarray value to a non-ndarray value
-        time.sleep(0.001)
+        if use_timestamps:
+            # test resetting a key with a ndarray value to a non-ndarray value
+            time.sleep(0.001)
         with tiledb.Array(path, "w") as A:
             A.meta["ndarray"] = 42
             test_vals["ndarray"] = 42
@@ -219,8 +221,9 @@ class MetadataTest(DiskTestCase):
         with tiledb.Array(path) as A:
             self.assert_metadata_roundtrip(A.meta, test_vals)
 
-        # test del ndarray key
-        time.sleep(0.001)
+        if use_timestamps:
+            # test del ndarray key
+            time.sleep(0.001)
         with tiledb.Array(path, "w") as A:
             del A.meta["ndarray"]
             del test_vals["ndarray"]
@@ -228,8 +231,9 @@ class MetadataTest(DiskTestCase):
         with tiledb.Array(path) as A:
             self.assert_metadata_roundtrip(A.meta, test_vals)
 
-        # test update
-        time.sleep(0.001)
+        if use_timestamps:
+            # test update
+            time.sleep(0.001)
         with tiledb.Array(path, mode="w") as A:
             test_vals.update(ndarray=np.stack([ndarray, ndarray]), transp=ndarray.T)
             A.meta.update(ndarray=np.stack([ndarray, ndarray]), transp=ndarray.T)
@@ -241,7 +245,8 @@ class MetadataTest(DiskTestCase):
     @tiledb.scope_ctx(
         {"sm.vacuum.mode": "array_meta", "sm.consolidation.mode": "array_meta"}
     )
-    def test_consecutive(self):
+    @pytest.mark.parametrize("use_timestamps", [True, False])
+    def test_consecutive(self, use_timestamps):
         vfs = tiledb.VFS()
         path = self.path("test_md_consecutive")
 
@@ -254,11 +259,17 @@ class MetadataTest(DiskTestCase):
         randutf8s = [rand_utf8(i) for i in np.random.randint(1, 30, size=write_count)]
 
         # write 100 times, then consolidate
-        for i in range(write_count):
-            with tiledb.Array(path, mode="w") as A:
-                A.meta["randint"] = int(randints[i])
-                A.meta["randutf8"] = randutf8s[i]
-                time.sleep(0.001)
+        if use_timestamps:
+            for i in range(write_count):
+                with tiledb.Array(path, mode="w") as A:
+                    A.meta["randint"] = int(randints[i])
+                    A.meta["randutf8"] = randutf8s[i]
+                    time.sleep(0.001)
+        else:
+            for i in range(write_count):
+                with tiledb.Array(path, mode="w") as A:
+                    A.meta["randint"] = int(randints[i])
+                    A.meta["randutf8"] = randutf8s[i]
 
         self.assertEqual(len(vfs.ls(os.path.join(path, "__meta"))), 100)
 
@@ -285,12 +296,23 @@ class MetadataTest(DiskTestCase):
             self.assertEqual(A.meta["randutf8"], randutf8s[-1])
 
         # use randutf8s as keys, then consolidate
-        for _ in range(2):
-            for i in range(write_count):
-                with tiledb.Array(path, mode="w") as A:
-                    A.meta[randutf8s[i] + "{}".format(randints[i])] = int(randints[i])
-                    A.meta[randutf8s[i]] = randutf8s[i]
-                    time.sleep(0.001)
+        if use_timestamps:
+            for _ in range(2):
+                for i in range(write_count):
+                    with tiledb.Array(path, mode="w") as A:
+                        A.meta[randutf8s[i] + "{}".format(randints[i])] = int(
+                            randints[i]
+                        )
+                        A.meta[randutf8s[i]] = randutf8s[i]
+                        time.sleep(0.001)
+        else:
+            for _ in range(2):
+                for i in range(write_count):
+                    with tiledb.Array(path, mode="w") as A:
+                        A.meta[randutf8s[i] + "{}".format(randints[i])] = int(
+                            randints[i]
+                        )
+                        A.meta[randutf8s[i]] = randutf8s[i]
 
         # test data
         with tiledb.Array(path) as A:

--- a/tiledb/tests/test_timestamp_overrides.py
+++ b/tiledb/tests/test_timestamp_overrides.py
@@ -8,8 +8,7 @@ import pytest
 
 import tiledb
 from tiledb.main import PyFragmentInfo
-
-from .common import DiskTestCase
+from tiledb.tests.common import DiskTestCase
 
 
 def has_libfaketime():
@@ -20,7 +19,7 @@ def has_libfaketime():
         return False
 
 
-class TimestampOverridesTest(DiskTestCase):
+class TestTimestampOverrides(DiskTestCase):
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="libfaketime is not supported on Windows",
@@ -35,9 +34,9 @@ class TimestampOverridesTest(DiskTestCase):
 
         python_exe = sys.executable
         cmd = (
-            f"from tiledb.tests.test_timestamp_overrides import TimestampOverridesTest; "
-            f"TimestampOverridesTest().helper_fragments('{uri_fragments}'); "
-            f"TimestampOverridesTest().helper_group_metadata('{uri_group_metadata}')"
+            f"from tiledb.tests.test_timestamp_overrides import TestTimestampOverrides; "
+            f"TestTimestampOverrides().helper_fragments('{uri_fragments}'); "
+            f"TestTimestampOverrides().helper_group_metadata('{uri_group_metadata}')"
         )
         test_path = os.path.dirname(os.path.abspath(__file__))
 

--- a/tiledb/tests/test_timestamp_overrides.py
+++ b/tiledb/tests/test_timestamp_overrides.py
@@ -25,13 +25,14 @@ class TimestampOverridesTest(DiskTestCase):
     #     reason="libfaketime not installed",
     # )
     def test_timestamp_overrides(self):
-        uri = self.path("time_test")
+        uri_fragments = self.path("time_test_fragments")
+        uri_group_metadata = self.path("time_test_group_metadata")
 
         python_exe = sys.executable
         cmd = (
             f"from tiledb.tests.test_timestamp_overrides import TimestampOverridesTest; "
-            f"TimestampOverridesTest().helper_fragments('{uri}'); "
-            f"TimestampOverridesTest().helper_group_metadata('{uri}')"
+            f"TimestampOverridesTest().helper_fragments('{uri_fragments}'); "
+            f"TimestampOverridesTest().helper_group_metadata('{uri_group_metadata}')"
         )
         test_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -99,8 +100,8 @@ class TimestampOverridesTest(DiskTestCase):
 
         self.assertEqual(len(uuids), fragments)
 
-        # Sort order for the fragment info matches the write order
-        self.assertEqual(final_uris, chronological_order)
+        # Ensure that write order is correct
+        self.assertEqual(chronological_order, sorted(final_uris))
 
     def helper_group_metadata(self, uri):
         vfs = tiledb.VFS()
@@ -108,7 +109,7 @@ class TimestampOverridesTest(DiskTestCase):
         start_datetime = datetime.datetime.now()
 
         tiledb.Group.create(uri)
-        loop_count = 30
+        loop_count = 10
         uris_seen = set()
         chronological_order = []
         meta_path = f"{uri}/__meta"
@@ -151,5 +152,5 @@ class TimestampOverridesTest(DiskTestCase):
 
         self.assertEqual(len(uuids), loop_count)
 
-        # Sort order for the fragment info matches the write order
-        self.assertEqual(final_uris, chronological_order)
+        # Ensure that write order is correct
+        self.assertEqual(chronological_order, sorted(final_uris))

--- a/tiledb/tests/test_timestamp_overrides.py
+++ b/tiledb/tests/test_timestamp_overrides.py
@@ -1,0 +1,77 @@
+import datetime
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+import tiledb
+from tiledb.main import PyFragmentInfo
+
+from .common import DiskTestCase
+
+# def has_libfaketime():
+#     find a way to check if libfaketime is installed
+
+
+class TimestampOverridesTest(DiskTestCase):
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="libfaketime is not supported on Windows",
+    )
+    # @pytest.mark.skipif(
+    #     not has_libfaketime(),
+    #     reason="libfaketime not installed",
+    # )
+    def test_timestamp_overrides(self):
+        uri = self.path("time_test")
+
+        python_exe = sys.executable
+        cmd = (
+            f"from tiledb.tests.test_timestamp_overrides import TimestampOverridesTest; "
+            f"TimestampOverridesTest().helper('{uri}')"
+        )
+        test_path = os.path.dirname(os.path.abspath(__file__))
+
+        try:
+            # "+x0" is the time multiplier, which makes the time freeze during the test
+            subprocess.run(
+                ["faketime", "-f", "+x0", python_exe, "-c", cmd], cwd=test_path
+            )
+        except subprocess.CalledProcessError as e:
+            raise e
+
+    def helper(self, uri):
+        start_datetime = datetime.datetime.now()
+
+        fragments = 25
+        A = np.zeros(fragments)
+
+        dom = tiledb.Domain(tiledb.Dim(domain=(0, 24), tile=fragments, dtype=np.int64))
+        att = tiledb.Attr(dtype=A.dtype)
+        schema = tiledb.ArraySchema(domain=dom, attrs=(att,))
+
+        tiledb.DenseArray.create(uri, schema)
+
+        uris_seen = set()
+        chronological_order = []
+
+        for fragment_idx in range(fragments):
+            with tiledb.DenseArray(uri, mode="w") as T:
+                T[fragment_idx : fragment_idx + 1] = fragment_idx
+
+            fragment_info = PyFragmentInfo(uri, schema, False, tiledb.default_ctx())
+            uris = fragment_info.get_uri()
+            new_uris = set(uris) - uris_seen
+            uris_seen.update(uris)
+            chronological_order.extend(new_uris)
+
+        end_datetime = datetime.datetime.now()
+        self.assertTrue(start_datetime == end_datetime)
+
+        # check if fragment_info.get_uri() returns the uris in chronological order
+        fragment_info = PyFragmentInfo(uri, schema, False, tiledb.default_ctx())
+        final_uris = fragment_info.get_uri()
+        for uri1, uri2 in zip(chronological_order, final_uris):
+            assert uri1 == uri2

--- a/tiledb/tests/test_timestamp_overrides.py
+++ b/tiledb/tests/test_timestamp_overrides.py
@@ -11,8 +11,13 @@ from tiledb.main import PyFragmentInfo
 
 from .common import DiskTestCase
 
-# def has_libfaketime():
-#     find a way to check if libfaketime is installed
+
+def has_libfaketime():
+    try:
+        subprocess.check_output(["which", "faketime"])
+        return True
+    except subprocess.CalledProcessError:
+        return False
 
 
 class TimestampOverridesTest(DiskTestCase):
@@ -20,10 +25,10 @@ class TimestampOverridesTest(DiskTestCase):
         sys.platform == "win32",
         reason="libfaketime is not supported on Windows",
     )
-    # @pytest.mark.skipif(
-    #     not has_libfaketime(),
-    #     reason="libfaketime not installed",
-    # )
+    @pytest.mark.skipif(
+        not has_libfaketime(),
+        reason="libfaketime not installed.",
+    )
     def test_timestamp_overrides(self):
         uri_fragments = self.path("time_test_fragments")
         uri_group_metadata = self.path("time_test_group_metadata")


### PR DESCRIPTION
Currently in TileDB-Py we have a number of tests which override the timestamp for writes in order to avoid test failures when writes happen within the same millisecond, e.g.:

https://github.com/TileDB-Inc/TileDB-Py/blob/ff2149738a5daeee2c11d7660b3c7631fe1a293e/tiledb/tests/cc/test_cc.py#L124
https://github.com/TileDB-Inc/TileDB-Py/blob/ff2149738a5daeee2c11d7660b3c7631fe1a293e/tiledb/tests/test_fragments.py#L100

In libtiledb [2.22.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.22.0) a sub-millisecond temporal disambiguation of random labels from a single-process is implemented (serialized ordering for writes).

To test this from Python, tests that use timestamp ordering overrides are modified. They now run both with and without overriding and they should succeed in both cases. This solution is temporary; in the future, code that uses ordering override will be removed, ensuring a robust solution.

Additionally, to _directly_ check that the new feature is working as expected, [libfaketime](https://github.com/wolfcw/libfaketime) is utilized. More specifically the [faketime wrapper](https://github.com/wolfcw/libfaketime/blob/master/README#L569-L589) comes in handy in our case to decrease the complexity and have a unified solution for both Linux and macOS.
By using faketime and setting the time multiplier to zero (`faketime -f '+x0' python time_test.py`), we are able to "freeze" time for the whole duration of the test which runs in a subprocess.
Installation of libfaketime means a new CI step. A new test file, `test_timestamp_overrides` is added to run write tests under faketime and check that the expected outcome holds.

Checking if libfaketime exists, means a system call to skip test.