### PR TITLE
Migrate away from deprecated TileDB C++ APIs

### DIFF
--- a/tiledb/libmetadata.pyx
+++ b/tiledb/libmetadata.pyx
@@ -400,11 +400,12 @@ cdef class Metadata:
                 ctx.__capsule__(), "ctx")
             tiledb_config_t* config_ptr = NULL
             tiledb_encryption_type_t key_type = TILEDB_NO_ENCRYPTION
-            void* key_ptr = NULL
+            const char* key_ptr = NULL
             uint32_t key_len = 0
             bytes bkey
             bytes buri = unicode_path(self.array.uri)
             str key = (<Array?>self.array).key
+            tiledb_error_t* err_ptr = NULL
 
         if config:
             config_ptr = <tiledb_config_t*>PyCapsule_GetPointer(
@@ -416,19 +417,28 @@ cdef class Metadata:
             else:
                 bkey = bytes(self.array.key)
             key_type = TILEDB_AES_256_GCM
-            key_ptr = <void *> PyBytes_AS_STRING(bkey)
+            key_ptr = <const char *> PyBytes_AS_STRING(bkey)
             #TODO: unsafe cast here ssize_t -> uint64_t
             key_len = <uint32_t> PyBytes_GET_SIZE(bkey)
+
+            rc = tiledb_config_alloc(&config_ptr, &err_ptr)
+            if rc != TILEDB_OK:
+                _raise_ctx_err(ctx_ptr, rc)
+
+            rc = tiledb_config_set(config_ptr, "sm.encryption_type", "AES_256_GCM", &err_ptr)
+            if rc != TILEDB_OK:
+                _raise_ctx_err(ctx_ptr, rc)
+
+            rc = tiledb_config_set(config_ptr, "sm.encryption_key", key_ptr, &err_ptr)
+            if rc != TILEDB_OK:
+                _raise_ctx_err(ctx_ptr, rc)
 
         cdef const char* buri_ptr = <const char*>buri
 
         with nogil:
-            rc = tiledb_array_consolidate_with_key(
+            rc = tiledb_array_consolidate(
                     ctx_ptr,
                     buri_ptr,
-                    key_type,
-                    key_ptr,
-                    key_len,
                     config_ptr)
         if rc != TILEDB_OK:
             _raise_ctx_err(ctx_ptr, rc)

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -845,14 +845,6 @@ cdef extern from "tiledb/tiledb.h":
         const char* uri,
         const tiledb_array_schema_t* array_schema) nogil
 
-    int tiledb_array_create_with_key(
-        tiledb_ctx_t* ctx,
-        const char* uri,
-        const tiledb_array_schema_t* array_schema,
-        tiledb_encryption_type_t key_type,
-        const void* key,
-        unsigned int key_len) nogil
-
     int tiledb_array_is_open(
         tiledb_ctx_t* ctx,
         tiledb_array_t* array,

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -651,9 +651,8 @@ cdef extern from "tiledb/tiledb.h":
         uint32_t key_length,
         tiledb_config_t* config) nogil
 
-    int tiledb_array_delete_array(
+    int tiledb_array_delete(
         tiledb_ctx_t* ctx,
-        tiledb_array_t* array,
         const char* uri) nogil
 
     # Query
@@ -875,6 +874,12 @@ cdef extern from "tiledb/tiledb.h":
     int tiledb_array_delete_fragments(
         tiledb_ctx_t* ctx,
         tiledb_array_t* array,
+        const char* uri,
+        uint64_t timestamp_start,
+        uint64_t timestamp_end)
+
+    int tiledb_array_delete_fragments_v2(
+        tiledb_ctx_t* ctx,
         const char* uri,
         uint64_t timestamp_start,
         uint64_t timestamp_end)

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -855,14 +855,6 @@ cdef extern from "tiledb/tiledb.h":
         const char* array_path,
         tiledb_config_t* config) nogil
 
-    int tiledb_array_consolidate_with_key(
-        tiledb_ctx_t* ctx,
-        const char* uri,
-        tiledb_encryption_type_t key_type,
-        const void* key_ptr,
-        unsigned int key_len,
-        tiledb_config_t* config) nogil
-
     int tiledb_array_delete_fragments(
         tiledb_ctx_t* ctx,
         tiledb_array_t* array,

--- a/tiledb/tests/test_fragments.py
+++ b/tiledb/tests/test_fragments.py
@@ -704,13 +704,12 @@ class DeleteFragmentsTest(DiskTestCase):
         if use_timestamps:
             assert frags.timestamp_range == ts
 
-        with tiledb.open(path, "m") as A:
-            if use_timestamps:
-                A.delete_fragments(3, 6)
-            else:
-                A.delete_fragments(
-                    frags.timestamp_range[2][0], frags.timestamp_range[5][1]
-                )
+        if use_timestamps:
+            tiledb.Array.delete_fragments(path, 3, 6)
+        else:
+            tiledb.Array.delete_fragments(
+                path, frags.timestamp_range[2][0], frags.timestamp_range[5][1]
+            )
 
         frags = tiledb.array_fragments(path)
         assert len(frags) == 6
@@ -755,13 +754,12 @@ class DeleteFragmentsTest(DiskTestCase):
             assert_array_equal(A[:]["a1"], ts2_data)
             assert_array_equal(A[:]["a2"], ts2_data)
 
-        with tiledb.open(path, "m") as A:
-            if use_timestamps:
-                A.delete_fragments(2, 2)
-            else:
-                A.delete_fragments(
-                    frags.timestamp_range[1][0], frags.timestamp_range[1][1]
-                )
+        if use_timestamps:
+            tiledb.Array.delete_fragments(path, 2, 2)
+        else:
+            tiledb.Array.delete_fragments(
+                path, frags.timestamp_range[1][0], frags.timestamp_range[1][1]
+            )
 
         frags = tiledb.array_fragments(path)
         assert len(frags) == 1

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -367,12 +367,10 @@ class ArrayTest(DiskTestCase):
             assert frags.timestamp_range == ts
 
         if use_timestamps:
-            with tiledb.open(path, "m") as arr:
-                arr.delete_fragments(3, 6)
+            tiledb.Array.delete_fragments(path, 3, 6)
         else:
             timestamps = [t[0] for t in tiledb.array_fragments(path).timestamp_range]
-            with tiledb.open(path, "m") as arr:
-                arr.delete_fragments(timestamps[2], timestamps[5])
+            tiledb.Array.delete_fragments(path, timestamps[2], timestamps[5])
 
         frags = tiledb.array_fragments(path)
         assert len(frags) == 6


### PR DESCRIPTION
Python was using the following deprecated APIs:

- `tiledb_array_consolidate_with_key`
- `tiledb_array_create_with_key`
- `tiledb_array_delete_array`
- `tiledb_array_delete_fragments`

---

[sc-45876]