### PR TITLE
Pybin11 Config should honor prefix for iter

### DIFF
--- a/tiledb/cc/context.cc
+++ b/tiledb/cc/context.cc
@@ -75,7 +75,7 @@ void init_config(py::module &m) {
       .def(
           "_iter",
           [](Config &cfg, std::string prefix) {
-            return py::make_iterator(cfg.begin(), cfg.end());
+            return py::make_iterator(cfg.begin(prefix), cfg.end());
           },
           py::keep_alive<0, 1>(), py::arg("prefix") = "")
       .def("unset", &Config::unset);

--- a/tiledb/tests/test_context_and_config.py
+++ b/tiledb/tests/test_context_and_config.py
@@ -141,6 +141,8 @@ class TestConfig(DiskTestCase):
             k.append(p[0])
             v.append(p[1])
         self.assertTrue(len(k) > 0)
+        # Validate the prefix is not included
+        self.assertTrue("vfs.s3." not in k[0])
 
     def test_config_bad_param(self):
         config = tiledb.Config()


### PR DESCRIPTION
Iterating over the config takes a prefix to filter the config parameters on. This was accidently broken in the pybind11 migration. This restores the functionality.

Before:
```
>>> import tiledb
>>> cfg = tiledb.Config()
>>> list(cfg.keys("sm."))
['config.env_var_prefix', 'config.logging_format', 'config.logging_level', 'filestore.buffer_size', 'rest.capnp_traversal_limit', 'rest.curl.buffer_size', 'rest.curl.verbose', 'rest.http_compressor', 'rest.load_enumerations_on_array_open', 'rest.load_metadata_on_array_open', 'rest.load_non_empty_domain_on_array_open', 'rest.retry_count', 'rest.retry_delay_factor', 'rest.retry_http_codes', 'rest.retry_initial_delay_ms', 'rest.server_address', 'rest.server_serialization_format', 'rest.use_refactored_array_open', 'rest.use_refactored_array_open_and_query_submit', 'sm.allow_separate_attribute_writes', 'sm.allow_updates_experimental', 'sm.check_coord_dups', 'sm.check_coord_oob', 'sm.check_global_order', 'sm.compute_concurrency_level', 'sm.consolidation.amplification', 'sm.consolidation.buffer_size', 'sm.consolidation.max_fragment_size', 'sm.consolidation.mode', 'sm.consolidation.purge_deleted_cells', 'sm.consolidation.step_max_frags', 'sm.consolidation.step_min_frags', 'sm.consolidation.step_size_ratio', 'sm.consolidation.steps', 'sm.consolidation.timestamp_end', 'sm.consolidation.timestamp_start', 'sm.consolidation.total_buffer_size', 'sm.dedup_coords', 'sm.enable_signal_handlers', 'sm.encryption_key', 'sm.encryption_type', 'sm.enumerations_max_size', 'sm.enumerations_max_total_size', 'sm.fragment_info.preload_mbrs', 'sm.group.timestamp_end', 'sm.group.timestamp_start', 'sm.io_concurrency_level', 'sm.max_tile_overlap_size', 'sm.mem.malloc_trim', 'sm.mem.reader.sparse_global_order.ratio_array_data', 'sm.mem.reader.sparse_global_order.ratio_coords', 'sm.mem.reader.sparse_global_order.ratio_tile_ranges', 'sm.mem.reader.sparse_unordered_with_dups.ratio_array_data', 'sm.mem.reader.sparse_unordered_with_dups.ratio_coords', 'sm.mem.reader.sparse_unordered_with_dups.ratio_tile_ranges', 'sm.mem.tile_upper_memory_limit', 'sm.mem.total_budget', 'sm.memory_budget', 'sm.memory_budget_var', 'sm.merge_overlapping_ranges_experimental', 'sm.partial_tile_offsets_loading', 'sm.query.dense.qc_coords_mode', 'sm.query.dense.reader', 'sm.query.sparse_global_order.reader', 'sm.query.sparse_unordered_with_dups.reader', 'sm.read_range_oob', 'sm.skip_checksum_validation', 'sm.skip_est_size_partitioning', 'sm.skip_unary_partitioning_budget_check', 'sm.vacuum.mode', 'sm.var_offsets.bitsize', 'sm.var_offsets.extra_element', 'sm.var_offsets.mode', 'ssl.ca_file', 'ssl.ca_path', 'ssl.verify', 'vfs.azure.blob_endpoint', 'vfs.azure.block_list_block_size', 'vfs.azure.max_parallel_ops', 'vfs.azure.max_retries', 'vfs.azure.max_retry_delay_ms', 'vfs.azure.retry_delay_ms', 'vfs.azure.storage_account_key', 'vfs.azure.storage_account_name', 'vfs.azure.storage_sas_token', 'vfs.azure.use_block_list_upload', 'vfs.file.posix_directory_permissions', 'vfs.file.posix_file_permissions', 'vfs.gcs.endpoint', 'vfs.gcs.max_direct_upload_size', 'vfs.gcs.max_parallel_ops', 'vfs.gcs.multi_part_size', 'vfs.gcs.project_id', 'vfs.gcs.request_timeout_ms', 'vfs.gcs.use_multi_part_upload', 'vfs.hdfs.kerb_ticket_cache_path', 'vfs.hdfs.name_node_uri', 'vfs.hdfs.username', 'vfs.max_batch_size', 'vfs.min_batch_gap', 'vfs.min_batch_size', 'vfs.min_parallel_size', 'vfs.read_ahead_cache_size', 'vfs.read_ahead_size', 'vfs.read_logging_mode', 'vfs.s3.aws_access_key_id', 'vfs.s3.aws_external_id', 'vfs.s3.aws_load_frequency', 'vfs.s3.aws_role_arn', 'vfs.s3.aws_secret_access_key', 'vfs.s3.aws_session_name', 'vfs.s3.aws_session_token', 'vfs.s3.bucket_canned_acl', 'vfs.s3.ca_file', 'vfs.s3.ca_path', 'vfs.s3.config_source', 'vfs.s3.connect_max_tries', 'vfs.s3.connect_scale_factor', 'vfs.s3.connect_timeout_ms', 'vfs.s3.endpoint_override', 'vfs.s3.install_sigpipe_handler', 'vfs.s3.logging_level', 'vfs.s3.max_parallel_ops', 'vfs.s3.multipart_part_size', 'vfs.s3.no_sign_request', 'vfs.s3.object_canned_acl', 'vfs.s3.proxy_host', 'vfs.s3.proxy_password', 'vfs.s3.proxy_port', 'vfs.s3.proxy_scheme', 'vfs.s3.proxy_username', 'vfs.s3.region', 'vfs.s3.request_timeout_ms', 'vfs.s3.requester_pays', 'vfs.s3.scheme', 'vfs.s3.skip_init', 'vfs.s3.sse', 'vfs.s3.sse_kms_key_id', 'vfs.s3.use_multipart_upload', 'vfs.s3.use_virtual_addressing', 'vfs.s3.verify_ssl']
```

After:
```
>>> import tiledb
>>> cfg = tiledb.Config()
>>> list(cfg.keys(prefix="sm."))
['allow_separate_attribute_writes', 'allow_updates_experimental', 'check_coord_dups', 'check_coord_oob', 'check_global_order', 'compute_concurrency_level', 'consolidation.amplification', 'consolidation.buffer_size', 'consolidation.max_fragment_size', 'consolidation.mode', 'consolidation.purge_deleted_cells', 'consolidation.step_max_frags', 'consolidation.step_min_frags', 'consolidation.step_size_ratio', 'consolidation.steps', 'consolidation.timestamp_end', 'consolidation.timestamp_start', 'consolidation.total_buffer_size', 'dedup_coords', 'enable_signal_handlers', 'encryption_key', 'encryption_type', 'enumerations_max_size', 'enumerations_max_total_size', 'fragment_info.preload_mbrs', 'group.timestamp_end', 'group.timestamp_start', 'io_concurrency_level', 'max_tile_overlap_size', 'mem.malloc_trim', 'mem.reader.sparse_global_order.ratio_array_data', 'mem.reader.sparse_global_order.ratio_coords', 'mem.reader.sparse_global_order.ratio_tile_ranges', 'mem.reader.sparse_unordered_with_dups.ratio_array_data', 'mem.reader.sparse_unordered_with_dups.ratio_coords', 'mem.reader.sparse_unordered_with_dups.ratio_tile_ranges', 'mem.tile_upper_memory_limit', 'mem.total_budget', 'memory_budget', 'memory_budget_var', 'merge_overlapping_ranges_experimental', 'partial_tile_offsets_loading', 'query.dense.qc_coords_mode', 'query.dense.reader', 'query.sparse_global_order.reader', 'query.sparse_unordered_with_dups.reader', 'read_range_oob', 'skip_checksum_validation', 'skip_est_size_partitioning', 'skip_unary_partitioning_budget_check', 'vacuum.mode', 'var_offsets.bitsize', 'var_offsets.extra_element', 'var_offsets.mode']
```