### PR TITLE
Set an upper bound for numpy to dodge 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ classifiers=[
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    numpy==1.17.*,<2.0 ; python_version == "3.8" and platform_machine != 'aarch64',
-    numpy==1.19.4,<2.0 ; python_version == "3.9" and platform_machine != 'aarch64',
-    numpy==1.20.*,<2.0 ; python_version < "3.10" and platform_machine == 'aarch64',
-    numpy==1.21.*,<2.0 ; python_version == "3.10",
-    numpy>=1.23.2,<2.0 ; python_version >= "3.11",
+    "numpy==1.17.*,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'",
+    "numpy==1.19.4,<2.0 ; python_version == '3.9' and platform_machine != 'aarch64'",
+    "numpy==1.20.*,<2.0 ; python_version < '3.10' and platform_machine == 'aarch64'",
+    "numpy==1.21.*,<2.0 ; python_version == '3.10'",
+    "numpy>=1.23.2,<2.0 ; python_version >= '3.11'",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,20 +26,23 @@ classifiers=[
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dynamic = ["version", "dependencies"]
+dependencies = [
+    numpy==1.17.*,<2.0 ; python_version == "3.8" and platform_machine != 'aarch64'
+    numpy==1.19.4,<2.0 ; python_version == "3.9" and platform_machine != 'aarch64'
+    numpy==1.20.*,<2.0 ; python_version < "3.10" and platform_machine == 'aarch64'
+    numpy==1.21.*,<2.0 ; python_version == "3.10"
+    numpy>=1.23.2,<2.0 ; python_version >= "3.11"
+]
+dynamic = ["version"]
 
 [tool.setuptools.packages.find]
 exclude = ["*.pyc", ".pytest_cache/*", ".hypothesis/*"]
-
-[tool.setuptools.dynamic]
-dependencies = {file = "requirements_wheel.txt"}
 
 [project.urls]
 homepage = "https://github.com/TileDB-Inc/TileDB-Py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ classifiers=[
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    numpy==1.17.*,<2.0 ; python_version == "3.8" and platform_machine != 'aarch64'
-    numpy==1.19.4,<2.0 ; python_version == "3.9" and platform_machine != 'aarch64'
-    numpy==1.20.*,<2.0 ; python_version < "3.10" and platform_machine == 'aarch64'
-    numpy==1.21.*,<2.0 ; python_version == "3.10"
-    numpy>=1.23.2,<2.0 ; python_version >= "3.11"
+    numpy==1.17.*,<2.0 ; python_version == "3.8" and platform_machine != 'aarch64',
+    numpy==1.19.4,<2.0 ; python_version == "3.9" and platform_machine != 'aarch64',
+    numpy==1.20.*,<2.0 ; python_version < "3.10" and platform_machine == 'aarch64',
+    numpy==1.21.*,<2.0 ; python_version == "3.10",
+    numpy>=1.23.2,<2.0 ; python_version >= "3.11",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Set an upper bound for numpy to dodge 2.0 and avoid incompatible upcoming release until we support it. x-ref sc-46950