### PR TITLE
Compatibility fix: delete_fragments

### DIFF
--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -76,7 +76,6 @@ from .fragment import (
     FragmentsInfo,
     copy_fragments_to_existing_array,
     create_array_from_fragments,
-    delete_fragments,
 )
 from .group import Group
 from .highlevel import (

--- a/tiledb/fragment.py
+++ b/tiledb/fragment.py
@@ -341,28 +341,6 @@ def FragmentsInfo(array_uri, ctx=None):
     )
 
 
-def delete_fragments(
-    uri, timestamp_range, config=None, ctx=None, verbose=False, dry_run=False
-):
-    """
-    Delete fragments from an array located at uri that falls within a given
-    timestamp_range.
-
-    :param str uri: URI for the TileDB array (any supported TileDB URI)
-    :param (int, int) timestamp_range: (default None) If not None, vacuum the
-        array using the given range (inclusive)
-    :param config: Override the context configuration. Defaults to ctx.config()
-    :param ctx: (optional) TileDB Ctx
-    :param verbose: (optional) Print fragments being deleted (default: False)
-    :param dry_run: (optional) Preview fragments to be deleted without
-        running (default: False)
-    """
-    raise tiledb.TileDBError(
-        "tiledb.delete_fragments is deprecated; you must use Array.delete_fragments. "
-        "This message will be removed in 0.21.0."
-    )
-
-
 def create_array_from_fragments(
     src_uri,
     dst_uri,


### PR DESCRIPTION
In #1958 the static method delete_fragments replaced the instance method with the same name. This, instead of deprecation warning, caused errors for vector search tests: https://github.com/TileDB-Inc/TileDB-Vector-Search/actions/runs/9060651237/job/24890783433?pr=369

In this PR:
- Since both methods have the same name and number of required arguments, it's impossible to have two separate methods in Python even after using the `@staticmethod` decorator. We use just one function, checking the argument type.
Both `tiledb.Array.delete_fragments(path, 2, 2)` and 
```
>>> with tiledb.open(path, 'm') as A:
...     A.delete_fragments(2, 2)
```
are now valid.
- A higher level `delete_fragments()` function is deleted. Should have been removed since `0.21.0`.

---
[sc-47282]