### PR TITLE
Add wrapping for ls recursive

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## Improvements
 
+* Add wrapping for ls_recursive by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1933
 * Migrate away from deprecated TileDB C++ APIs by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1958
 * Pybind11 Config should honor prefix for iter by @Shelnutt2 in https://github.com/TileDB-Inc/TileDB-Py/pull/1962
 * Fix test skipping by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1957

--- a/tiledb/cc/vfs.cc
+++ b/tiledb/cc/vfs.cc
@@ -1,5 +1,7 @@
 #include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>
 
+#include <pybind11/functional.h>
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
@@ -41,6 +43,34 @@ void init_vfs(py::module &m) {
       .def("_copy_file", &VFS::copy_file)
 
       .def("_ls", &VFS::ls)
+      .def(
+          "_ls_recursive",
+          // 1. the user provides a callback, the user callback is passed to the
+          // C++ function. Return an empty vector.
+          // 2. no callback is passed and a default callback is used. The
+          // default callback just appends each path gathered. Return the paths.
+          [](VFS &vfs, std::string uri, py::object callback) {
+            tiledb::Context ctx;
+            if (callback.is_none()) {
+              std::vector<std::string> paths;
+              tiledb::VFSExperimental::ls_recursive(
+                  ctx, vfs, uri,
+                  [&](const std::string_view path,
+                      uint64_t object_size) -> bool {
+                    paths.push_back(std::string(path));
+                    return true;
+                  });
+              return paths;
+            } else {
+              tiledb::VFSExperimental::ls_recursive(
+                  ctx, vfs, uri,
+                  [&](const std::string_view path,
+                      uint64_t object_size) -> bool {
+                    return callback(path, object_size).cast<bool>();
+                  });
+              return std::vector<std::string>();
+            }
+          })
       .def("_touch", &VFS::touch);
 }
 

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -1053,8 +1053,7 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_ctx_t * ctx,
         tiledb_vfs_t * vfs,
         const char * path,
-        int (*callback)(const char *, void *) noexcept,
-        void * data)
+        void * data) nogil
 
     int tiledb_vfs_move_file(
         tiledb_ctx_t* ctx,


### PR DESCRIPTION
In https://github.com/TileDB-Inc/TileDB-Py/pull/1933, `ls_recursive` from `VFSExperimental` was added. Trying to -manually- build the Windows wheels, caused the problem described in the PR that reverted the changes: https://github.com/TileDB-Inc/TileDB-Py/pull/1964.

After discussing/debugging with @dudoslav, the problem wasn't related to the changes but the way that we are producing the wheels. We are now able to produce them without issues. Given the https://github.com/TileDB-Inc/TileDB-Py/pull/1933, we are ok to merge.

---
[sc-43316]