### PR TITLE
Fix syntax error in nightly build workflow

### DIFF
--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -34,7 +34,7 @@ jobs:
       TILEDB_VERSION: ${{ github.event.inputs.libtiledb_version }}
       # 11.7 necessary due to: https://github.com/actions/setup-python/issues/682#issuecomment-1604261330
       #MACOSX_DEPLOYMENT_TARGET: "10.15"
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-12' && matrix.python-version == '3.8' ? '11.7' : '11' }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-12' && matrix.python-version == '3.8' && '11.7' || '11' }}
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
     steps:
       - name: Checkout TileDB-Py `dev`

--- a/tiledb/tests/cc/test_cc.py
+++ b/tiledb/tests/cc/test_cc.py
@@ -275,8 +275,9 @@ def test_schema():
 
     with pytest.raises(lt.TileDBError):
         schema._tile_order = lt.LayoutType.HILBERT
-    with pytest.raises(lt.TileDBError):
-        schema._tile_order = lt.LayoutType.UNORDERED
+    if tiledb.libtiledb.version() >= (2, 24, 0):
+        with pytest.raises(lt.TileDBError):
+            schema._tile_order = lt.LayoutType.UNORDERED
     schema._tile_order = lt.LayoutType.ROW_MAJOR
     assert schema._tile_order == lt.LayoutType.ROW_MAJOR
 

--- a/tiledb/tests/cc/test_cc.py
+++ b/tiledb/tests/cc/test_cc.py
@@ -275,8 +275,10 @@ def test_schema():
 
     with pytest.raises(lt.TileDBError):
         schema._tile_order = lt.LayoutType.HILBERT
-    schema._tile_order = lt.LayoutType.UNORDERED
-    assert schema._tile_order == lt.LayoutType.UNORDERED
+    with pytest.raises(lt.TileDBError):
+        schema._tile_order = lt.LayoutType.UNORDERED
+    schema._tile_order = lt.LayoutType.ROW_MAJOR
+    assert schema._tile_order == lt.LayoutType.ROW_MAJOR
 
     # TODO schema._set_coords_filter_list(...)
     # TODO assert schema._coords_filter_list() == lt.FilterListType.NONE


### PR DESCRIPTION
Fix syntax error in nightly build workflow

```
Nested mappings are not allowed in compact mappings at line 37, column 33:

      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-12' && matrix.python-ve…
```