### PR TITLE
Fix CompressionFilter docstring example

### DIFF
--- a/tiledb/filter.py
+++ b/tiledb/filter.py
@@ -79,7 +79,7 @@ class CompressionFilter(Filter):
     >>> with tempfile.TemporaryDirectory() as tmp:
     ...     dom = tiledb.Domain(tiledb.Dim(domain=(0, 9), tile=2, dtype=np.uint64))
     ...     a1 = tiledb.Attr(name="a1", dtype=np.int64,
-    ...                      filters=tiledb.FilterList([tiledb.GzipFilter(level=10)]))
+    ...                      filters=tiledb.FilterList([tiledb.CompressionFilter(level=10)]))
     ...     schema = tiledb.ArraySchema(domain=dom, attrs=(a1,))
     ...     tiledb.DenseArray.create(tmp + "/array", schema)
 


### PR DESCRIPTION
The provided example in the `CompressionFilter` class docstring incorrectly used `GzipFilter` instead of `CompressionFilter`. This PR fixes the issue, ensuring that the example accurately reflects the intended use of the base class for compression filters, rather than a specific filter type.