### PR TITLE
Fix Query constructor to return error for dense arrays with return_incomplete=True

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -1895,6 +1895,10 @@ cdef class Query(object):
             if not use_arrow:
                 raise TileDBError("Cannot initialize return_arrow with use_arrow=False")
         self.use_arrow = use_arrow
+
+        if return_incomplete and not array.schema.sparse:
+            raise TileDBError("Incomplete queries are only supported for sparse arrays at this time")
+
         self.return_incomplete = return_incomplete
 
         self.domain_index = DomainIndexer(array, query=self)

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -3598,6 +3598,22 @@ class IncompleteTest(DiskTestCase):
                 T2.multi_index[101:105][""], np.array([], dtype=np.dtype("<U"))
             )
 
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_query_return_incomplete_error(self, sparse):
+        path = self.path("test_query_return_incomplete_error")
+
+        dom = tiledb.Domain(tiledb.Dim(domain=(1, 3), tile=1))
+        attrs = [tiledb.Attr("ints", dtype=np.uint8)]
+        schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=sparse)
+        tiledb.Array.create(path, schema)
+
+        with tiledb.open(path, "r") as A:
+            if sparse:
+                A.query(return_incomplete=True)[:]
+            else:
+                with self.assertRaises(tiledb.TileDBError):
+                    A.query(return_incomplete=True)[:]
+
     @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     @pytest.mark.parametrize(
         "use_arrow, return_arrow, indexer",


### PR DESCRIPTION
Incomplete queries are only supported for sparse arrays in TileDB-Py at this time. Dense reads will internally reallocate buffers and resubmit the query until successful completion. Docs: https://docs.tiledb.com/main/how-to/arrays/reading-arrays/incomplete-queries

Additionally, create a test to verify the expected behavior for both sparse and dense arrays.