### PR TITLE
Fix ModuleNotFoundError: No module named 'numpy' on build

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 
 ## Build system changes
 
+* Fix ModuleNotFoundError: No module named 'numpy' on build by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1979
 * Add support for numpy2 by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1969
 * Fix syntax error in nightly build workflow by @ihnorton in https://github.com/TileDB-Inc/TileDB-Py/pull/1970
 * Set an upper bound for numpy to dodge 2.0 by @sgillies in https://github.com/TileDB-Inc/TileDB-Py/pull/1963

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,11 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "pybind11", "Cython",
-    "numpy==1.17.*,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'",
-    "numpy>=1.25 ; python_version >= '3.9"
+requires = [
+    "setuptools>=64",
+    "wheel",
+    "pybind11",
+    "Cython",
+    "numpy== 1.17.*,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'",
+    "numpy>=1.25 ; python_version >= '3.9'",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "numpy", "pybind11", "Cython"]
+requires = ["setuptools>=64", "wheel", "pybind11", "Cython",
+    "numpy==1.17.*,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'",
+    "numpy>=1.25 ; python_version >= '3.9"
+]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "pybind11", "Cython"]
+requires = ["setuptools>=64", "wheel", "numpy", "pybind11", "Cython"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The following error occurs when trying to build. Fixed by adding `numpy` in build dependencies.

```
Traceback (most recent call last):
  File "/home/vsts/.local/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in <module>
    main()
  File "/home/vsts/.local/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 357, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
  File "/home/vsts/.local/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 308, in get_requires_for_build_sdist
    return hook(config_settings)
  File "/tmp/build-env-dg88woc1/lib/python3.10/site-packages/setuptools/build_meta.py", line 328, in get_requires_for_build_sdist
    return self._get_build_requires(config_settings, requirements=[])
  File "/tmp/build-env-dg88woc1/lib/python3.10/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
    self.run_setup()
  File "/tmp/build-env-dg88woc1/lib/python3.10/site-packages/setuptools/build_meta.py", line 311, in run_setup
    exec(code, locals())
  File "<string>", line 9, in <module>
ModuleNotFoundError: No module named 'numpy'
```

Also update `HISTORY`.