### PR TITLE
[2.24] Document Azure, GCS and local support for `VFS.ls_recursive`

### DIFF
--- a/tiledb/tests/test_vfs.py
+++ b/tiledb/tests/test_vfs.py
@@ -292,8 +292,8 @@ class TestVFS(DiskTestCase):
         )
 
     @pytest.mark.skipif(
-        pytest.tiledb_vfs not in ["file", "s3", "azure"],
-        reason="Only test on local, S3 and Azure",
+        pytest.tiledb_vfs not in ["file", "s3", "azure, gcs"],
+        reason="Only test on local, S3, Azure, and GCS",
     )
     def test_ls_recursive(self):
         # Create a nested directory structure to test recursive listing

--- a/tiledb/tests/test_vfs.py
+++ b/tiledb/tests/test_vfs.py
@@ -292,7 +292,8 @@ class TestVFS(DiskTestCase):
         )
 
     @pytest.mark.skipif(
-        pytest.tiledb_vfs not in ["s3", "file"], reason="Only test on S3 and local"
+        pytest.tiledb_vfs not in ["file", "s3", "azure"],
+        reason="Only test on local, S3 and Azure",
     )
     def test_ls_recursive(self):
         # Create a nested directory structure to test recursive listing

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -312,7 +312,7 @@ class VFS(lt.VFS):
         If False, the walk will stop. If an error is thrown, the walk will stop and
         the error will be propagated to the caller using std::throw_with_nested.
 
-        Currently only S3 is supported, and the `path` must be a valid S3 URI.
+        Currently only local, S3 and Azure are supported.
 
         :param str uri: Input URI of the directory
         :param callback: Callback function to invoke on each entry

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -312,7 +312,7 @@ class VFS(lt.VFS):
         If False, the walk will stop. If an error is thrown, the walk will stop and
         the error will be propagated to the caller using std::throw_with_nested.
 
-        Currently only local, S3 and Azure are supported.
+        Currently only local, S3, Azure and GCS are supported.
 
         :param str uri: Input URI of the directory
         :param callback: Callback function to invoke on each entry


### PR DESCRIPTION
Following https://github.com/TileDB-Inc/TileDB/pull/4981 and https://github.com/TileDB-Inc/TileDB/pull/4997, this PR updates the docstring of `ls_recursive` and the skip condition for its test.