### PR TITLE
Update numpy versions everywhere to fix "Some build dependencies conflict with the backend dependencies"

### DIFF
--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -1,12 +1,8 @@
-# numpy pinning for ABI forward-compatibility
-numpy==1.16.5 ; python_version < "3.8" and platform_machine !='aarch64'
-numpy==1.17.* ; python_version == "3.8" and platform_machine !='aarch64'
-numpy==1.19.4 ; python_version == "3.9" and platform_machine !='aarch64'
-
-# NOTE: oldest-supported-numpy (1.19.2) had forward ABI compat problems
-numpy==1.20.* ; python_version < "3.10" and platform_machine=='aarch64'
-numpy==1.21.* ; python_version == "3.10"
-numpy>=1.23.2 ; python_version >= "3.11"
+numpy>=1.17,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'
+numpy>=1.19.4,<2.0 ; python_version == '3.9' and platform_machine != 'aarch64'
+numpy>=1.20,<2.0 ; python_version < '3.10' and platform_machine == 'aarch64'
+numpy>=1.21,<2.0 ; python_version == '3.10'
+numpy>=1.23.2,<2.0 ; python_version >= '3.11'
 
 #-------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,11 @@ requires = [
     "wheel",
     "pybind11",
     "Cython",
-    "numpy== 1.17.*,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'",
-    "numpy>=1.25 ; python_version >= '3.9'",
+    "numpy>=1.17,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'",
+    "numpy>=1.19.4,<2.0 ; python_version == '3.9' and platform_machine != 'aarch64'",
+    "numpy>=1.20,<2.0 ; python_version < '3.10' and platform_machine == 'aarch64'",
+    "numpy>=1.21,<2.0 ; python_version == '3.10'",
+    "numpy>=1.23.2,<2.0 ; python_version >= '3.11'",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -40,10 +43,10 @@ classifiers=[
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "numpy==1.17.*,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'",
-    "numpy==1.19.4,<2.0 ; python_version == '3.9' and platform_machine != 'aarch64'",
-    "numpy==1.20.*,<2.0 ; python_version < '3.10' and platform_machine == 'aarch64'",
-    "numpy==1.21.*,<2.0 ; python_version == '3.10'",
+    "numpy>=1.17,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'",
+    "numpy>=1.19.4,<2.0 ; python_version == '3.9' and platform_machine != 'aarch64'",
+    "numpy>=1.20,<2.0 ; python_version < '3.10' and platform_machine == 'aarch64'",
+    "numpy>=1.21,<2.0 ; python_version == '3.10'",
     "numpy>=1.23.2,<2.0 ; python_version >= '3.11'",
 ]
 dynamic = ["version"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-numpy>=1.16.5 ; python_version < "3.10" and platform_machine != 'aarch64'
-numpy>=1.19.2 ; python_version < "3.10" and platform_machine == 'aarch64'
-numpy>=1.21.0 ; python_version == "3.10"
-numpy>=1.23.2 ; python_version >= "3.11"
+numpy>=1.17,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'
+numpy>=1.19.4,<2.0 ; python_version == '3.9' and platform_machine != 'aarch64'
+numpy>=1.20,<2.0 ; python_version < '3.10' and platform_machine == 'aarch64'
+numpy>=1.21,<2.0 ; python_version == '3.10'
+numpy>=1.23.2,<2.0 ; python_version >= '3.11'
 packaging
 
 contextvars ;python_version<"3.7"


### PR DESCRIPTION
The problem we were getting with Azure pipeline when trying to create wheels: https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=39688&view=results

All artifacts are built after this change: https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=39692&view=results



