### PR TITLE
Deprecate support for `[]` indexing with floats

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2335,7 +2335,8 @@ cdef class DenseArrayImpl(Array):
         idx = replace_ellipsis(self.schema.domain.ndim, selection)
         if check_for_floats(selection):
             warnings.warn(
-                "Floats will be soon not supported in selection. ",
+                "The use of floats in selection is deprecated. "
+                "It is slated for removal in 0.31.0.",
                 DeprecationWarning,
             )
         idx, drop_axes = replace_scalars_slice(self.schema.domain, idx)
@@ -3471,7 +3472,8 @@ cdef class SparseArrayImpl(Array):
         idx = replace_ellipsis(dom.ndim, idx)
         if check_for_floats(selection):
             warnings.warn(
-                "Floats will be soon not supported in selection. ",
+                "The use of floats in selection is deprecated. "
+                "It is slated for removal in 0.31.0.",
                 DeprecationWarning,
             )
         idx, drop_axes = replace_scalars_slice(dom, idx)

--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -580,6 +580,26 @@ def replace_scalars_slice(dom, idx: tuple):
     return tuple(new_idx), tuple(drop_axes)
 
 
+def check_for_floats(selection):
+    """
+    Check if a selection object contains floating point values
+
+    :param selection: selection object
+    :return: True if selection contains floating point values
+    :rtype: bool
+    """
+    if isinstance(selection, float):
+        return True
+    if isinstance(selection, slice):
+        if isinstance(selection.start, float) or isinstance(selection.stop, float):
+            return True
+    elif isinstance(selection, tuple):
+        for s in selection:
+            if check_for_floats(s):
+                return True
+    return False
+
+
 def index_domain_subarray(array: Array, dom, idx: tuple):
     """
     Return a numpy array representation of the tiledb subarray buffer
@@ -2284,11 +2304,6 @@ cdef class DenseArrayImpl(Array):
                     "Only use `cond`."
                 )
 
-            raise TileDBError(
-                "`attr_cond` is no longer supported. You must use `cond`. "
-                "This message will be removed in 0.21.0."
-            )
-
         cdef tiledb_layout_t layout = TILEDB_UNORDERED
         if order is None or order == 'C':
             layout = TILEDB_ROW_MAJOR
@@ -2318,6 +2333,11 @@ cdef class DenseArrayImpl(Array):
 
         selection = index_as_tuple(selection)
         idx = replace_ellipsis(self.schema.domain.ndim, selection)
+        if check_for_floats(selection):
+            warnings.warn(
+                "Floats will be soon not supported in selection. ",
+                DeprecationWarning,
+            )
         idx, drop_axes = replace_scalars_slice(self.schema.domain, idx)
         dim_ranges  = index_domain_subarray(self, self.schema.domain, idx)
         subarray = Subarray(self, self.ctx)
@@ -3449,6 +3469,11 @@ cdef class SparseArrayImpl(Array):
         dom = self.schema.domain
         idx = index_as_tuple(selection)
         idx = replace_ellipsis(dom.ndim, idx)
+        if check_for_floats(selection):
+            warnings.warn(
+                "Floats will be soon not supported in selection. ",
+                DeprecationWarning,
+            )
         idx, drop_axes = replace_scalars_slice(dom, idx)
         dim_ranges = index_domain_subarray(self, dom, idx)
         subarray = Subarray(self, self.ctx)

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -31,7 +31,11 @@ class FixesTest(DiskTestCase):
 
             with tiledb.open(uri, mode="r") as T:
                 assert T[:][""] == b"hello"
-                assert T[50.4][""] == b"hello"
+                with pytest.warns(
+                    DeprecationWarning,
+                    match="Floats will be soon not supported in selection",
+                ):
+                    assert T[50.4][""] == b"hello"
 
     def test_ch8292(self):
         # test fix for ch8292

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -33,7 +33,8 @@ class FixesTest(DiskTestCase):
                 assert T[:][""] == b"hello"
                 with pytest.warns(
                     DeprecationWarning,
-                    match="Floats will be soon not supported in selection",
+                    match="The use of floats in selection is deprecated. "
+                    "It is slated for removal in 0.31.0.",
                 ):
                     assert T[50.4][""] == b"hello"
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2463,7 +2463,9 @@ class TestDenseIndexing(DiskTestCase):
         # slice(-1, 0, -1),
     ]
 
-    bad_index_1d = [2.3, "foo", b"xxx", None, (0, 0), (slice(None), slice(None))]
+    bad_index_1d = ["foo", b"xxx", None, (0, 0), (slice(None), slice(None))]
+
+    warn_and_bad_index_1d = [2.3, -4.5]
 
     def test_index_1d(self):
         A = np.arange(1050, dtype=int)
@@ -2483,6 +2485,14 @@ class TestDenseIndexing(DiskTestCase):
             for idx in self.bad_index_1d:
                 with self.assertRaises(IndexError):
                     T[idx]
+
+            for idx in self.warn_and_bad_index_1d:
+                with pytest.warns(
+                    DeprecationWarning,
+                    match="Floats will be soon not supported in selection",
+                ):
+                    with self.assertRaises(IndexError):
+                        T[idx]
 
     good_index_2d = [
         # single row
@@ -2524,13 +2534,16 @@ class TestDenseIndexing(DiskTestCase):
     ]
 
     bad_index_2d = [
-        2.3,
         "foo",
         b"xxx",
         None,
-        (2.3, slice(None)),
         (0, 0, 0),
         (slice(None), slice(None), slice(None)),
+    ]
+
+    warn_and_bad_index_2d = [
+        2.3,
+        (2.3, slice(None)),
     ]
 
     def test_index_2d(self):
@@ -2553,6 +2566,14 @@ class TestDenseIndexing(DiskTestCase):
             for idx in self.bad_index_2d:
                 with self.assertRaises(IndexError):
                     T[idx]
+
+            for idx in self.warn_and_bad_index_2d:
+                with pytest.warns(
+                    DeprecationWarning,
+                    match="Floats will be soon not supported in selection",
+                ):
+                    with self.assertRaises(IndexError):
+                        T[idx]
 
 
 class TestDatetimeSlicing(DiskTestCase):

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2489,7 +2489,8 @@ class TestDenseIndexing(DiskTestCase):
             for idx in self.warn_and_bad_index_1d:
                 with pytest.warns(
                     DeprecationWarning,
-                    match="Floats will be soon not supported in selection",
+                    match="The use of floats in selection is deprecated. "
+                    "It is slated for removal in 0.31.0.",
                 ):
                     with self.assertRaises(IndexError):
                         T[idx]
@@ -2570,7 +2571,8 @@ class TestDenseIndexing(DiskTestCase):
             for idx in self.warn_and_bad_index_2d:
                 with pytest.warns(
                     DeprecationWarning,
-                    match="Floats will be soon not supported in selection",
+                    match="The use of floats in selection is deprecated. "
+                    "It is slated for removal in 0.31.0.",
                 ):
                     with self.assertRaises(IndexError):
                         T[idx]


### PR DESCRIPTION
Deprecate support for [] indexing with floats. NumPy no longer allows this (as of [1.12](https://numpy.org/devdocs/release/1.12.0-notes.html#deprecationwarning-to-error)), and it can cause confusion because of the wrap-around semantics.