### PR TITLE
Fix pinning wrong numpy version

### DIFF
--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -1,12 +1,7 @@
-# numpy pinning for ABI forward-compatibility
-numpy==1.16.5 ; python_version < "3.8" and platform_machine !='aarch64'
-numpy==1.17.* ; python_version == "3.8" and platform_machine !='aarch64'
-numpy==1.19.4 ; python_version == "3.9" and platform_machine !='aarch64'
-
-# NOTE: oldest-supported-numpy (1.19.2) had forward ABI compat problems
-numpy==1.20.* ; python_version < "3.10" and platform_machine=='aarch64'
-numpy==1.21.* ; python_version == "3.10"
-numpy>=1.23.2 ; python_version >= "3.11"
+numpy==1.17.* ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'
+numpy==1.19.* ; python_version == '3.8' and platform_machine == 'aarch64'
+numpy==1.21.* ; python_version == '3.8' and platform_machine == 'arm64'
+numpy>=2.0.0rc2 ; python_version >= '3.9'
 
 #-------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,10 @@ requires = [
     "wheel",
     "pybind11",
     "Cython",
-    "numpy== 1.17.*,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'",
-    "numpy>=1.25 ; python_version >= '3.9'",
+    "numpy==1.17.* ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'",
+    "numpy==1.19.* ; python_version == '3.8' and platform_machine == 'aarch64'",
+    "numpy==1.21.* ; python_version == '3.8' and platform_machine == 'arm64'",
+    "numpy>=2.0.0rc2 ; python_version >= '3.9'",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -40,11 +42,10 @@ classifiers=[
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "numpy==1.17.*,<2.0 ; python_version == '3.8' and platform_machine != 'aarch64'",
-    "numpy==1.19.4,<2.0 ; python_version == '3.9' and platform_machine != 'aarch64'",
-    "numpy==1.20.*,<2.0 ; python_version < '3.10' and platform_machine == 'aarch64'",
-    "numpy==1.21.*,<2.0 ; python_version == '3.10'",
-    "numpy>=1.23.2,<2.0 ; python_version >= '3.11'",
+  "numpy>=1.17 ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'",
+  "numpy>=1.19 ; python_version == '3.8' and platform_machine == 'aarch64'",
+  "numpy>=1.21 ; python_version == '3.8' and platform_machine == 'arm64'",
+  "numpy>=1.25 ; python_version >= '3.9'",
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy>=1.16.5 ; python_version < "3.10" and platform_machine != 'aarch64'
-numpy>=1.19.2 ; python_version < "3.10" and platform_machine == 'aarch64'
-numpy>=1.21.0 ; python_version == "3.10"
-numpy>=1.23.2 ; python_version >= "3.11"
+numpy>=1.17 ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'
+numpy>=1.19 ; python_version == '3.8' and platform_machine == 'aarch64'
+numpy>=1.21 ; python_version == '3.8' and platform_machine == 'arm64'
+numpy>=1.25 ; python_version >= '3.9'
 packaging
 
 contextvars ;python_version<"3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,7 @@
-numpy >= 1.16.5
+numpy>=1.17 ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'
+numpy>=1.19 ; python_version == '3.8' and platform_machine == 'aarch64'
+numpy>=1.21 ; python_version == '3.8' and platform_machine == 'arm64'
+numpy>=1.25 ; python_version >= '3.9'
 
 # ------------------------------------------------
 # ** MUST sync with misc/requirements_wheel.txt **


### PR DESCRIPTION
Right now, there is no single source of truth for dependencies. Until this is done, let's fix the required versions of numpy found in multiple project files. There are basically 5 different places where numpy version requirements should be specified:

1. `requirements.txt`
2. `requirements_dev.txt`
3. `requirements_wheel.txt`
4. `pyproject.toml -> build-system -> requires`
5. `pyproject.toml -> project -> dependencies`

They can be merged into 3 categories:
- **build dependencies**: `pyproject.toml -> build-system -> requires` and `requirements_wheel.txt` are the requirements when building wheels (https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#build-system-requirement). For python 3.8 wheels have to be built against numpy `1.17` because we want support for `>=1.17`. NumPy's ABI is forward but not backward compatible before `1.25`. This means; binaries compiled against a given version of NumPy will still run correctly with newer NumPy versions, but not with older versions (https://numpy.org/devdocs/dev/depending_on_numpy.html). For `aarch64` and `arm64` architectures the first version of numpy with available wheels is `1.19` and `1.21`, and thus we set this. For python 3.9+ wheels can be built against latest numpy (like other big projects are doing: https://github.com/pandas-dev/pandas/blob/58461fef2315d228d08f65f8a9430e9294d65b31/pyproject.toml#L11)
- **runtime dependencies**: `pyproject.toml -> project dependencies` and `requirements.txt` are the requirements used to run the package (https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#declaring-required-dependency). For python 3.8 whatever greater than numpy `1.17` (build version) is fine (for `aarch64` this is `1.19` and for `arm64` this is `1.21`) and for python 3.9+ we want something greater than numpy `1.25` since NumPy C-API is exposed in a backwards compatible way by default.
- **development dependencies**: `requirements_dev.txt`. This shouldn't be much of concern since it's what we are installing to build and run locally. If we use the runtime dependencies it should be safe.

---

**Testing**. 

**Python 3.8 (macos arm64)**
Build: numpy-1.21.6
Installed with wheel: numpy-1.24.4

**Python 3.8 (ubuntu)**
Build: numpy-1.17.5
Installed with wheel: numpy-1.24.4

**Python 3.9 (macos arm64)**
Build: numpy-2.0.0rc2
Installed with wheel: numpy-1.26.4

*Wheels were installed in a fresh conda environment using `pip install --no-cache-dir`.

---
[sc-48530]