### PR TITLE
Remove pin to MSVC toolset version in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,11 @@ jobs:
       - name: Checkout TileDB-Py `dev`
         uses: actions/checkout@v3
 
-      # By default Visual Studio chooses the earliest installed toolset version
-      # for the main build and vcpkg chooses the latest. Force it to use the
-      # latest (14.39 currently).
       - name: Setup MSVC toolset (VS 2022)
         uses: TheMrMilchmann/setup-msvc-dev@v3
         if: matrix.os == 'windows-latest'
         with:
           arch: x64
-          toolset: 14.39
 
       - name: Install Ninja (VS 2022)
         uses: seanmiddleditch/gha-setup-ninja@v4

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -46,15 +46,11 @@ jobs:
       - name: Checkout TileDB-Py `dev`
         uses: actions/checkout@v3
 
-      # By default Visual Studio chooses the earliest installed toolset version
-      # for the main build and vcpkg chooses the latest. Force it to use the
-      # latest (14.39 currently).
       - name: Setup MSVC toolset (VS 2022)
         uses: TheMrMilchmann/setup-msvc-dev@v3
         if: matrix.os == 'windows-latest'
         with:
           arch: x64
-          toolset: 14.39
 
       - name: Install Ninja (VS 2022)
         uses: seanmiddleditch/gha-setup-ninja@v4

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -43,15 +43,11 @@ jobs:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
-      # By default Visual Studio chooses the earliest installed toolset version
-      # for the main build and vcpkg chooses the latest. Force it to use the
-      # latest (14.39 currently).
       - name: Setup MSVC toolset (VS 2022)
         uses: TheMrMilchmann/setup-msvc-dev@v3
         if: matrix.os == 'windows-latest'
         with:
           arch: x64
-          toolset: 14.39
 
       - name: Enable vcpkg binary caching
         uses: actions/github-script@v6


### PR DESCRIPTION
[SC-48973](https://app.shortcut.com/tiledb-inc/story/48973/revert-pins-to-msvc-toolset-14-39)

GitHub Actions is starting to update the MSVC toolset version in CI, causing [occasional failures](https://github.com/TileDB-Inc/TileDB-Py/actions/runs/9398673865/job/25888740034). This PR removes the pin to version 14.39 added in #1906.