### PR TITLE
[Backport release-0.29.1] Add numpy upper bound to dodge 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,11 @@ jobs:
       - name: Checkout TileDB-Py `dev`
         uses: actions/checkout@v3
 
-      # By default Visual Studio chooses the earliest installed toolset version
-      # for the main build and vcpkg chooses the latest. Force it to use the
-      # latest (14.39 currently).
       - name: Setup MSVC toolset (VS 2022)
         uses: TheMrMilchmann/setup-msvc-dev@v3
         if: matrix.os == 'windows-latest'
         with:
           arch: x64
-          toolset: 14.39
 
       - name: Install Ninja (VS 2022)
         uses: seanmiddleditch/gha-setup-ninja@v4

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -40,15 +40,11 @@ jobs:
       - name: Checkout TileDB-Py `dev`
         uses: actions/checkout@v3
 
-      # By default Visual Studio chooses the earliest installed toolset version
-      # for the main build and vcpkg chooses the latest. Force it to use the
-      # latest (14.39 currently).
       - name: Setup MSVC toolset (VS 2022)
         uses: TheMrMilchmann/setup-msvc-dev@v3
         if: matrix.os == 'windows-latest'
         with:
           arch: x64
-          toolset: 14.39
 
       - name: Install Ninja (VS 2022)
         uses: seanmiddleditch/gha-setup-ninja@v4

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -43,15 +43,11 @@ jobs:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
 
     steps:
-      # By default Visual Studio chooses the earliest installed toolset version
-      # for the main build and vcpkg chooses the latest. Force it to use the
-      # latest (14.39 currently).
       - name: Setup MSVC toolset (VS 2022)
         uses: TheMrMilchmann/setup-msvc-dev@v3
         if: matrix.os == 'windows-latest'
         with:
           arch: x64
-          toolset: 14.39
 
       - name: Enable vcpkg binary caching
         uses: actions/github-script@v6

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Release 0.29.1
+
+* Solves downloading numpy 2.0.0 after the stable version was made available by setting an upper bound.
+
 # Release 0.29.0
 
 * TileDB-Py 0.29.0 includes TileDB Embedded [2.23.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.23.0)

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,7 +6,7 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.29.0
+        TILEDBPY_VERSION: 0.29.1
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA
         LIBTILEDB_VERSION: "2.23.0"
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA

--- a/misc/requirements_wheel.txt
+++ b/misc/requirements_wheel.txt
@@ -1,12 +1,7 @@
-# numpy pinning for ABI forward-compatibility
-numpy==1.16.5 ; python_version < "3.8" and platform_machine !='aarch64'
-numpy==1.17.* ; python_version == "3.8" and platform_machine !='aarch64'
-numpy==1.19.4 ; python_version == "3.9" and platform_machine !='aarch64'
-
-# NOTE: oldest-supported-numpy (1.19.2) had forward ABI compat problems
-numpy==1.20.* ; python_version < "3.10" and platform_machine=='aarch64'
-numpy==1.21.* ; python_version == "3.10"
-numpy>=1.23.2 ; python_version >= "3.11"
+numpy==1.17.*,<2.0 ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'
+numpy==1.19.*,<2.0 ; python_version == '3.8' and platform_machine == 'aarch64'
+numpy==1.21.*,<2.0 ; python_version == '3.8' and platform_machine == 'arm64'
+numpy>=1.25,<2.0 ; python_version >= '3.9'
 
 #-------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,14 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "pybind11", "Cython"]
+requires = [
+    "setuptools>=64",
+    "wheel",
+    "pybind11",
+    "Cython",
+    "numpy==1.17.*,<2.0 ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'",
+    "numpy==1.19.*,<2.0 ; python_version == '3.8' and platform_machine == 'aarch64'",
+    "numpy==1.21.*,<2.0 ; python_version == '3.8' and platform_machine == 'arm64'",
+    "numpy>=1.25,<2.0 ; python_version >= '3.9'",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -33,7 +42,13 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dynamic = ["version", "dependencies"]
+dependencies = [
+  "numpy>=1.17,<2.0 ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'",
+  "numpy>=1.19,<2.0 ; python_version == '3.8' and platform_machine == 'aarch64'",
+  "numpy>=1.21,<2.0 ; python_version == '3.8' and platform_machine == 'arm64'",
+  "numpy>=1.25,<2.0 ; python_version >= '3.9'",
+]
+dynamic = ["version"]
 
 [tool.setuptools.packages.find]
 exclude = ["*.pyc", ".pytest_cache/*", ".hypothesis/*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy>=1.16.5 ; python_version < "3.10" and platform_machine != 'aarch64'
-numpy>=1.19.2 ; python_version < "3.10" and platform_machine == 'aarch64'
-numpy>=1.21.0 ; python_version == "3.10"
-numpy>=1.23.2 ; python_version >= "3.11"
+numpy>=1.17,<2.0 ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'
+numpy>=1.19,<2.0 ; python_version == '3.8' and platform_machine == 'aarch64'
+numpy>=1.21,<2.0 ; python_version == '3.8' and platform_machine == 'arm64'
+numpy>=1.25,<2.0 ; python_version >= '3.9'
 packaging
 
 contextvars ;python_version<"3.7"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,7 @@
-numpy >= 1.16.5
+numpy>=1.17,<2.0 ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'
+numpy>=1.19,<2.0 ; python_version == '3.8' and platform_machine == 'aarch64'
+numpy>=1.21,<2.0 ; python_version == '3.8' and platform_machine == 'arm64'
+numpy>=1.25,<2.0 ; python_version >= '3.9'
 
 # ------------------------------------------------
 # ** MUST sync with misc/requirements_wheel.txt **


### PR DESCRIPTION
Cherry picks f580dc71d601575d5b61086f622a870884049206 and backports #1989 + adding upper bounds.
Solves downloading numpy 2.0.0 after the stable version was made available. numpy2 is supported for `TileDB-Py >= 0.30`.