### PR TITLE
Skip Dask test on Windows

### DIFF
--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -168,6 +168,7 @@ class TestDaskSupport(DiskTestCase):
         np.testing.assert_array_equal(D2 + 1, D3)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @pytest.mark.skipif(
     sys.version_info[:2] == (3, 8),
     reason="Fails on Python 3.8 due to dask worker restarts",


### PR DESCRIPTION
`test_sc33742_dask_array_object_dtype_conversion` is causing an error on windows CI. Let's skip it for windows as done with the other Dask test. We will investigate further the reason for failing in a later story.

---
[sc-49880]