### PR TITLE
Update HISTORY for 0.30.1 against TileDB 2.24.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,13 @@
-# Release 0.30
+# Release 0.30.1
+
+* TileDB-Py 0.30.1 includes TileDB Embedded [2.24.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.1)
+
+## Improvements
+
+* Document Azure, GCS and local support for VFS.ls_recursive by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1980
+* Skip Dask failing test on Windows by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1995
+
+# Release 0.30.0
 
 * TileDB-Py 0.30.0 includes TileDB Embedded [2.24.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.24.0)
 
@@ -21,6 +30,12 @@
 * Add support for numpy2 by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1969
 * Fix syntax error in nightly build workflow by @ihnorton in https://github.com/TileDB-Inc/TileDB-Py/pull/1970
 * Set an upper bound for numpy to dodge 2.0 by @sgillies in https://github.com/TileDB-Inc/TileDB-Py/pull/1963
+
+# Release 0.29.1
+
+## Build system changes
+
+* Add numpy upper bound to dodge 2.0 by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/1993
 
 # Release 0.29.0
 

--- a/misc/azure-release.yml
+++ b/misc/azure-release.yml
@@ -6,11 +6,11 @@ stages:
         LIBTILEDB_VERSION: dev
         LIBTILEDB_SHA: dev
       ${{ else }}:
-        TILEDBPY_VERSION: 0.30.0
+        TILEDBPY_VERSION: 0.30.1
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA
-        LIBTILEDB_VERSION: "2.24.0"
+        LIBTILEDB_VERSION: "2.24.1"
         # NOTE: *must* update both LIBTILEDB_VERSION and LIBTILEDB_SHA
-        LIBTILEDB_SHA: ff3879bbab2eb2ee8891271dad2d4bcab83dc0f9
+        LIBTILEDB_SHA: db03540e685296f0188819869eec92bece164db2
       LIBTILEDB_REPO: https://github.com/TileDB-Inc/TileDB
       TILEDB_SRC: "$(Build.Repository.Localpath)/tiledb_src"
       TILEDB_BUILD: "$(Build.Repository.Localpath)/tiledb_build"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import Extension, find_packages, setup
 # - this is for builds-from-source
 # - release builds are controlled by `misc/azure-release.yml`
 # - this should be set to the current core release, not `dev`
-TILEDB_VERSION = "2.24.0"
+TILEDB_VERSION = "2.24.1"
 
 # allow overriding w/ environment variable
 TILEDB_VERSION = (


### PR DESCRIPTION
Updates HISTORY for 0.30.1 against TileDB 2.24.1
Also updates HISTORY for backport 0.29.1 TileDB 2.23.0