### PR TITLE
Fix `array.query()` incorrectly handling nullables

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2170,14 +2170,14 @@ cdef class DenseArrayImpl(Array):
                 if attr.isnullable:
                     data = np.array([values[idx] for idx in result[attr.name].data])
                     result[attr.name] = np.ma.array(
-                        data, mask=~result[attr.name].mask)
+                        data, mask=result[attr.name].mask)
                 else:
                     result[attr.name] = np.array(
                         [values[idx] for idx in result[attr.name]])
             else:
                 if attr.isnullable:
                     result[attr.name] = np.ma.array(result[attr.name].data, 
-                        mask=~result[attr.name].mask)
+                        mask=result[attr.name].mask)
 
         return result
 
@@ -2429,7 +2429,7 @@ cdef class DenseArrayImpl(Array):
                 out[name] = arr
             
             if self.schema.has_attr(name) and self.attr(name).isnullable:
-                out[name] = np.ma.array(out[name], mask=results[name][2].astype(bool))
+                out[name] = np.ma.array(out[name], mask=~results[name][2].astype(bool))
                 
         return out
 
@@ -3251,14 +3251,14 @@ cdef class SparseArrayImpl(Array):
                 if attr.isnullable:
                     data = np.array([values[idx] for idx in result[attr.name].data])
                     result[attr.name] = np.ma.array(
-                        data, mask=~result[attr.name].mask)
+                        data, mask=result[attr.name].mask)
                 else:
                     result[attr.name] = np.array(
                         [values[idx] for idx in result[attr.name]])
             else:
                 if attr.isnullable:
                     result[attr.name] = np.ma.array(result[attr.name].data, 
-                        mask=~result[attr.name].mask)
+                        mask=result[attr.name].mask)
 
         return result
 
@@ -3559,7 +3559,7 @@ cdef class SparseArrayImpl(Array):
                     out[final_name] = arr
             
             if self.schema.has_attr(final_name) and self.attr(final_name).isnullable:
-                out[final_name] = np.ma.array(out[final_name], mask=results[name][2])
+                out[final_name] = np.ma.array(out[final_name], mask=~results[name][2].astype(bool))
 
         return out
 

--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -140,6 +140,7 @@ class EnumerationTest(DiskTestCase):
             expected_validity = [False, False, True, False, False]
             assert_array_equal(A[:]["a"].mask, expected_validity)
             assert_array_equal(A.df[:]["a"].isna(), expected_validity)
+            assert_array_equal(A.query(attrs=["a"])[:]["a"].mask, expected_validity)
 
     @pytest.mark.parametrize(
         "dtype, values",

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -429,10 +429,12 @@ class ArrayTest(DiskTestCase):
             expected_validity1 = [False, False, True, False, False]
             assert_array_equal(A[:]["a1"].mask, expected_validity1)
             assert_array_equal(A.df[:]["a1"].isna(), expected_validity1)
+            assert_array_equal(A.query(attrs=["a1"])[:]["a1"].mask, expected_validity1)
 
             expected_validity2 = [False, False, True, True, False]
             assert_array_equal(A[:]["a2"].mask, expected_validity2)
             assert_array_equal(A.df[:]["a2"].isna(), expected_validity2)
+            assert_array_equal(A.query(attrs=["a2"])[:]["a2"].mask, expected_validity2)
 
         with tiledb.open(uri, "w") as A:
             dims = pa.array([1, 2, 3, 4, 5])
@@ -452,10 +454,12 @@ class ArrayTest(DiskTestCase):
             expected_validity1 = [True, True, True, True, True]
             assert_array_equal(A[:]["a1"].mask, expected_validity1)
             assert_array_equal(A.df[:]["a1"].isna(), expected_validity1)
+            assert_array_equal(A.query(attrs=["a1"])[:]["a1"].mask, expected_validity1)
 
             expected_validity2 = [True, True, True, True, True]
             assert_array_equal(A[:]["a2"].mask, expected_validity2)
             assert_array_equal(A.df[:]["a2"].isna(), expected_validity2)
+            assert_array_equal(A.query(attrs=["a2"])[:]["a2"].mask, expected_validity2)
 
 
 class DenseArrayTest(DiskTestCase):


### PR DESCRIPTION
This PR fixes `array.query()` incorrectly handling nullables. It was a logic issue.

When masking an array using `np.ma.array` with a mask derived from a subarray selection, as seen here: https://github.com/TileDB-Inc/TileDB-Py/blob/8c92a30bd3d2a5340c4498f48713f75d5813549d/tiledb/libtiledb.pyx#L3383, the mask should not be inverted because it's already a mask. Invertion is only needed when the array used originates from PyArrow::results, as shown here: https://github.com/TileDB-Inc/TileDB-Py/blob/8c92a30bd3d2a5340c4498f48713f75d5813549d/tiledb/core.cc#L1367. In that case it's the inverse of a mask.

---


A minimal reproducible example:
```
import tiledb
import numpy as np
import pyarrow as pa
import tempfile

uri = tempfile.mkdtemp()

schema = tiledb.ArraySchema(
    domain=tiledb.Domain(tiledb.Dim(domain=[0, 3], dtype=np.int64, tile=4)),
    attrs=[tiledb.Attr(name="a", dtype=np.float64, nullable=True)],
)
tiledb.Array.create(uri, schema)

with tiledb.open(uri, mode="w") as array:
    array[:] = pa.array([1.0, None, 1.2, None])

with tiledb.open(uri) as array:                                                                                                                                                                  
   A = array[:]
   B = array.query()[:]
```


Returns the following:

A:

```
OrderedDict([('a1',
              masked_array(data=[1.0, --, 1.2, --],
                           mask=[False,  True, False,  True],
                     fill_value=1e+20))])
```

B:

```
OrderedDict([('a1',
              masked_array(data=[--, 0.0, --, 0.0],
                           mask=[ True, False,  True, False],
                     fill_value=1e+20))])
```

A and B should be identical.