### PR TITLE
Fix OverflowError: Python int too large to convert to C long

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -627,11 +627,7 @@ def index_domain_subarray(array: Array, dom, idx: tuple):
         if not isinstance(dim_slice, slice):
             raise IndexError("invalid index type: {!r}".format(type(dim_slice)))
 
-        # numpy2 doesn't allow addition beween int and np.int64 - NEP 50
         start, stop, step = dim_slice.start, dim_slice.stop, dim_slice.step
-        start = np.int64(start) if isinstance(start, int) else start
-        stop = np.int64(stop) if isinstance(stop, int) else stop
-        step = np.int64(step) if isinstance(step, int) else step
 
         if np.issubdtype(dim_dtype, np.str_) or np.issubdtype(dim_dtype, np.bytes_):
             if start is None or stop is None:
@@ -686,7 +682,7 @@ def index_domain_subarray(array: Array, dom, idx: tuple):
                 elif not isinstance(start, _inttypes):
                     raise IndexError("cannot index integral domain dimension with non-integral slice (dtype: {})".format(type(start)))
             if not is_datetime and stop < 0:
-                stop += dim_ub
+                stop = np.int64(stop) + dim_ub
             if stop > dim_ub:
                 # numpy allows stop value > than the array dimension shape,
                 # clamp to upper bound of dimension domain


### PR DESCRIPTION
The problem is related to https://numpy.org/neps/nep-0050-scalar-promotion.html#nep50.
Especially the fact that in numpy2 this behavior is not valid anymore:
```
>>> np.uint64(5) + -1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: Python integer -1 out of bounds for uint64
```
And we have to do this:
```
>>> np.uint64(5) + np.int64(-1)
np.float64(4.0)
```

I had made a fix when support for `numpy2` was added, converting `start`,`stop`,`step` to `np.int64`, but this caused this overflow.