### PR TITLE
Change wheels artifact names

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.buildplat[1] }}-${{ strategy.job-index }}
+          name: cibw-wheels-${{ matrix.buildplat[0] }}-${{ matrix.buildplat[1] }}-${{ matrix.python }}
           path: "./wheelhouse/*.whl"
 
   build_sdist:


### PR DESCRIPTION
Rename artifacts so that we can see what version of python/OS they are built for.


![1721742308_grim](https://github.com/user-attachments/assets/5d3be13c-1985-413f-861f-421b4471f780)


New naming: https://github.com/dudoslav/TileDB-Py/actions/runs/10059940542
