### PR TITLE
Set version in workflow dispatch

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -7,6 +7,11 @@ on:
         description: Version to use are release version
         required: true
         type: string
+      test_pypi:
+        description: Upload packages to test.pypi.org
+        required: false
+        type: boolean
+        default: false
   push:
     tags:
       - "*"
@@ -139,11 +144,12 @@ jobs:
           echo "package_version=$(ls dist/ | head -n 1 | cut -d - -f 2)" >> "$GITHUB_OUTPUT"
 
       - name: Upload to test-pypi
+        if: inputs.test_pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Upload to pypi
         # If we tagged a version release it on PyPI
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && inputs.version == ''
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -2,15 +2,17 @@ name: Build and test wheels
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: Version to use are release version
+        required: true
+        type: string
   push:
-    branches:
-      - release-*
-      - "*wheel*" # must quote since "*" is a YAML reserved character; we want a string
     tags:
       - "*"
-  pull_request:
-    branches:
-      - "*wheel*" # must quote since "*" is a YAML reserved character; we want a string
+
+env:
+  SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB: ${{ inputs.version }}
 
 jobs:
   build_wheels:
@@ -142,5 +144,6 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Upload to pypi
+        # If we tagged a version release it on PyPI
         if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This way we can produce wheels with any version number:

From `workflow-dispatch` with input argument `123.1.7`:
https://github.com/dudoslav/TileDB-Py/actions/runs/10060209953/job/27807250342#step:3:24

From release triggered by creating tag `700.11.3`:
https://github.com/dudoslav/TileDB-Py/actions/runs/10060350710/job/27807753665#step:3:26