### PR TITLE
Add version pins for pandas 3.0

### DIFF
--- a/examples/incomplete_iteration.py
+++ b/examples/incomplete_iteration.py
@@ -40,8 +40,8 @@ import tiledb
 
 
 def check_dataframe_deps():
-    pd_error = """Pandas version >= 1.0 required for dataframe functionality.
-                  Please `pip install pandas>=1.0` to proceed."""
+    pd_error = """Pandas version >= 1.0 and < 3.0 required for dataframe functionality.
+                  Please `pip install pandas>=1.0,<3.0` to proceed."""
 
     try:
         import pandas as pd
@@ -50,7 +50,9 @@ def check_dataframe_deps():
 
     from packaging.version import Version
 
-    if Version(pd.__version__) < Version("1.0"):
+    if Version(pd.__version__) < Version("1.0") or Version(pd.__version__) >= Version(
+        "3.0.0.dev0"
+    ):
         raise Exception(pd_error)
 
 

--- a/examples/parallel_csv_ingestion.py
+++ b/examples/parallel_csv_ingestion.py
@@ -49,8 +49,8 @@ in_test = "PYTEST_CURRENT_TEST" in os.environ
 
 
 def check_dataframe_deps():
-    pd_error = """Pandas version >= 1.0 required for dataframe functionality.
-                  Please `pip install pandas>=1.0` to proceed."""
+    pd_error = """Pandas version >= 1.0 and < 3.0 required for dataframe functionality.
+                  Please `pip install pandas>=1.0,<3.0` to proceed."""
 
     try:
         import pandas as pd
@@ -59,7 +59,9 @@ def check_dataframe_deps():
 
     from packaging.version import Version
 
-    if Version(pd.__version__) < Version("1.0"):
+    if Version(pd.__version__) < Version("1.0") or Version(pd.__version__) >= Version(
+        "3.0.0.dev0"
+    ):
         raise Exception(pd_error)
 
 

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -13,8 +13,8 @@ from .datatypes import DataType
 
 
 def check_dataframe_deps():
-    pd_error = """Pandas version >= 1.0 required for dataframe functionality.
-                  Please `pip install pandas>=1.0` to proceed."""
+    pd_error = """Pandas version >= 1.0 and < 3.0 required for dataframe functionality.
+                  Please `pip install pandas>=1.0,<3.0` to proceed."""
     pa_error = """PyArrow version >= 1.0 is suggested for dataframe functionality.
                   Please `pip install pyarrow>=1.0`."""
 
@@ -25,7 +25,9 @@ def check_dataframe_deps():
 
     from packaging.version import Version
 
-    if Version(pd.__version__) < Version("1.0"):
+    if Version(pd.__version__) < Version("1.0") or Version(pd.__version__) >= Version(
+        "3.0.0.dev0"
+    ):
         raise Exception(pd_error)
 
     try:

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -15,6 +15,7 @@ import uuid
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_array_equal, assert_equal
+from packaging.version import Version
 
 import tiledb
 
@@ -24,11 +25,29 @@ SUPPORTED_DATETIME64_DTYPES = tuple(
 
 
 def has_pandas():
-    return importlib.util.find_spec("pandas") is not None
+    try:
+        import pandas as pd
+    except ImportError:
+        return False
+
+    if Version(pd.__version__) < Version("1.0") or Version(pd.__version__) >= Version(
+        "3.0.0.dev0"
+    ):
+        return False
+
+    return True
 
 
 def has_pyarrow():
-    return importlib.util.find_spec("pyarrow") is not None
+    try:
+        import pyarrow as pa
+
+        if Version(pa.__version__) < Version("1.0"):
+            return False
+    except ImportError:
+        return False
+
+    return True
 
 
 def assert_tail_equal(a, *rest, **kwargs):

--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -108,7 +108,7 @@ class EnumerationTest(DiskTestCase):
 
     @pytest.mark.skipif(
         not has_pyarrow() or not has_pandas(),
-        reason="pyarrow and/or pandas not installed",
+        reason="pyarrow>=1.0 and/or pandas>=1.0,<3.0 not installed",
     )
     @pytest.mark.parametrize("sparse", [True, False])
     @pytest.mark.parametrize("pass_df", [True, False])
@@ -182,7 +182,7 @@ class EnumerationTest(DiskTestCase):
             assert enmr.dtype == enmr.values().dtype == dtype
             assert_array_equal(enmr.values(), values)
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     def test_from_pandas_dtype_mismatch(self):
         import pandas as pd
 

--- a/tiledb/tests/test_examples.py
+++ b/tiledb/tests/test_examples.py
@@ -38,7 +38,7 @@ class ExamplesTest:
             ]
         ]
         if not has_pandas() and path in requires_pd:
-            pytest.mark.skip("pandas not installed")
+            pytest.mark.skip("pandas>=1.0,<3.0 not installed")
         else:
             with tempfile.TemporaryDirectory() as tmpdir:
                 try:
@@ -73,7 +73,11 @@ class ExamplesTest:
         )
         if failures:
             stderr = capsys.readouterr().out
-            if "No module named 'pandas'" in stderr and not has_pandas():
-                pytest.skip("pandas not installed")
+            if (
+                "Pandas version >= 1.0 and < 3.0 required for dataframe functionality"
+                in stderr
+                and not has_pandas()
+            ):
+                pytest.skip("pandas>=1.0,<3.0 not installed")
             else:
                 pytest.fail(stderr)

--- a/tiledb/tests/test_examples.py
+++ b/tiledb/tests/test_examples.py
@@ -73,7 +73,7 @@ class ExamplesTest:
         )
         if failures:
             stderr = capsys.readouterr().out
-            if (
+            if "No module named 'pandas'" in stderr or (
                 "Pandas version >= 1.0 and < 3.0 required for dataframe functionality"
                 in stderr
                 and not has_pandas()

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -95,7 +95,7 @@ class FixesTest(DiskTestCase):
                 buffers = list(*q._get_buffers().values())
                 assert buffers[0].nbytes == max_val
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     def test_ch10282_concurrent_multi_index(self):
         """Test concurrent access to a single tiledb.Array using
         Array.multi_index and Array.df. We pass an array and slice
@@ -173,7 +173,8 @@ class FixesTest(DiskTestCase):
             tiledb.stats_disable()
 
     @pytest.mark.skipif(
-        not has_pandas() and has_pyarrow(), reason="pandas or pyarrow not installed"
+        not has_pandas() and has_pyarrow(),
+        reason="pandas>=1.0,<3.0 or pyarrow>=1.0 not installed",
     )
     def test_py1078_df_all_empty_strings(self):
         uri = self.path()
@@ -217,6 +218,7 @@ class FixesTest(DiskTestCase):
         assert get_config_with_env({"AWS_DEFAULT_REGION": ""}, "vfs.s3.region") == ""
         assert get_config_with_env({"AWS_REGION": ""}, "vfs.s3.region") == ""
 
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     @pytest.mark.parametrize("is_sparse", [True, False])
     def test_sc1430_nonexisting_timestamp(self, is_sparse):
         path = self.path("nonexisting_timestamp")

--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -7,10 +7,13 @@ import pytest
 
 import tiledb
 
+from .common import has_pandas
+
 pd = pytest.importorskip("pandas")
 tm = pd._testing
 
 
+@pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
 @pytest.mark.parametrize("mode", ["np", "df"])
 @hp.settings(deadline=None, verbosity=hp.Verbosity.verbose)
 @hp.given(st.binary())

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -403,7 +403,7 @@ class ArrayTest(DiskTestCase):
 
     @pytest.mark.skipif(
         not has_pyarrow() or not has_pandas(),
-        reason="pyarrow and/or pandas not installed",
+        reason="pyarrow>=1.0 and/or pandas>=1.0,<3.0 not installed",
     )
     @pytest.mark.parametrize("sparse", [True, False])
     @pytest.mark.parametrize("pass_df", [True, False])
@@ -1748,7 +1748,7 @@ class TestSparseArray(DiskTestCase):
                 "coords" not in T.query(coords=False).multi_index[-10.0:5.0]
             )
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     @pytest.mark.parametrize("dtype", ["u1", "u2", "u4", "u8", "i1", "i2", "i4", "i8"])
     def test_sparse_index_dtypes(self, dtype):
         path = self.path()
@@ -1769,7 +1769,7 @@ class TestSparseArray(DiskTestCase):
             assert B[data[1]]["attr"] == data[1]
             assert B.multi_index[data[0]]["attr"] == data[0]
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     @pytest.mark.skipif(
         tiledb.libtiledb.version() < (2, 10),
         reason="TILEDB_BOOL introduced in libtiledb 2.10",
@@ -3644,7 +3644,7 @@ class IncompleteTest(DiskTestCase):
                 with self.assertRaises(tiledb.TileDBError):
                     A.query(return_incomplete=True)[:]
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     @pytest.mark.parametrize(
         "use_arrow, return_arrow, indexer",
         [

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -141,7 +141,7 @@ class TestMultiRangeAuxiliary(DiskTestCase):
 class TestMultiRange(DiskTestCase):
     @pytest.mark.skipif(
         not has_pyarrow() or not has_pandas(),
-        reason="pyarrow and/or pandas not installed",
+        reason="pyarrow>=1.0 and/or pandas>=1.0,<3.0 not installed",
     )
     def test_return_arrow_indexers(self):
         uri = self.path("multirange_behavior_sparse")
@@ -183,7 +183,7 @@ class TestMultiRange(DiskTestCase):
 
     @pytest.mark.skipif(
         not has_pyarrow() or not has_pandas(),
-        reason="pyarrow and/or pandas not installed",
+        reason="pyarrow>=1.0 and/or pandas>=1.0,<3.0 not installed",
     )
     @pytest.mark.parametrize("sparse", [True, False])
     def test_return_large_arrow_table(self, sparse):
@@ -729,7 +729,7 @@ class TestMultiRange(DiskTestCase):
                 np.array([], dtype=np.uint64),
             )
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     def test_fixed_multi_attr_df(self):
         uri = self.path("test_fixed_multi_attr_df")
         dom = tiledb.Domain(
@@ -763,7 +763,7 @@ class TestMultiRange(DiskTestCase):
             result = A.query(attrs=["111"], use_arrow=False)
             assert_array_equal(result.df[0]["111"], data_111)
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     def test_var_multi_attr_df(self):
         uri = self.path("test_var_multi_attr_df")
         dom = tiledb.Domain(
@@ -845,7 +845,7 @@ class TestMultiRange(DiskTestCase):
             assert A.nonempty_domain() is None
             assert_array_equal(A.multi_index[:][""], A[:][""])
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     def test_multi_index_query_args(self):
         uri = self.path("test_multi_index_query_args")
         schema = tiledb.ArraySchema(
@@ -871,7 +871,7 @@ class TestMultiRange(DiskTestCase):
             assert_array_equal(q.multi_index[:]["a"], q.df[:]["a"])
             assert all(q[:]["a"] >= 5)
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     def test_multi_index_timing(self):
         path = self.path("test_multi_index_timing")
         attr_name = "a"
@@ -886,7 +886,7 @@ class TestMultiRange(DiskTestCase):
             assert "py.getitem_time.pandas_index_update_time :" in internal_stats
         tiledb.stats_disable()
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     def test_fixed_width_char(self):
         uri = self.path("test_fixed_width_char")
         schema = tiledb.ArraySchema(

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -18,6 +18,7 @@ from .common import (
     DiskTestCase,
     dtype_max,
     dtype_min,
+    has_pandas,
     rand_ascii,
     rand_ascii_bytes,
     rand_datetime64_array,
@@ -25,8 +26,8 @@ from .common import (
 )
 from .datatypes import RaggedDtype
 
-pd = pytest.importorskip("pandas")
-tm = pd._testing
+if not has_pandas():
+    pytest.skip("pandas>=1.0,<3.0 not installed", allow_module_level=True)
 
 
 def make_dataframe_basic1(col_size=10):

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -594,7 +594,7 @@ class QueryConditionTest(DiskTestCase):
                 exc_info.value
             )
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     def test_dense_datetime(self):
         import pandas as pd
 
@@ -753,7 +753,7 @@ class QueryConditionTest(DiskTestCase):
             # ensures that ' a' does not match 'a'
             assert len(result["A"]) == 0
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     def test_do_not_return_attrs(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
             cond = None


### PR DESCRIPTION
Pandas 3.0 is expected to release soon: https://pandas.pydata.org/docs/dev/whatsnew/v3.0.0.html
Since there are errors and deprecations when running tests with `pandas-3.0.0.dev0` (https://gist.github.com/kounelisagis/bb0b3896da4867882182b30c5224db5d) it would be wise to pin `pandas 2.x` until we add support for the new version.
Tests that require pandas, are skipped if `pandas 2.x` is not found, after this PR.

---
[sc-49618]