### PR TITLE
Draft: Initial setup.py compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core",
+#    "setuptools",
     "pybind11",
     "Cython",
     "numpy==1.17.* ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'",
@@ -8,6 +9,7 @@ requires = [
     "numpy==1.21.* ; python_version == '3.8' and platform_machine == 'arm64'",
     "numpy>=2.0.0rc2 ; python_version >= '3.9'"
 ]
+#build-backend = "scikit_build_core.setuptools.build_meta"
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -65,11 +67,15 @@ test = [
 [project.urls]
 homepage = "https://github.com/TileDB-Inc/TileDB-Py"
 
+[tool.setuptools]
+py-modules = ["tiledb"]
+
 [tool.setuptools_scm]
 version_file = "tiledb/_generated_version.py"
 
 [tool.scikit-build]
-wheel.expand-macos-universal-tags = true
+# AssertionError: wheel.expand_macos_universal_tags is not supported in setuptools mode
+# wheel.expand-macos-universal-tags = true
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 wheel.packages = ["tiledb", "examples", "external"]
 wheel.license-files = ["LICENSE", "external/LICENSE-*.txt"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+"""
+Deprecated, please use `pip install .` instead
+"""
+
+from scikit_build_core.setuptools.wrapper import setup
+
+setup(
+    cmake_source_dir=".",
+    cmake_args=[],
+)


### PR DESCRIPTION
This PR adds `setup.py` for backwards compatibility.


For now this does not work because the extensions `*.so` files can not be found, since they are installed in a different path:
```
-- Install configuration: "Release"
-- Installing: /home/dudoslav/Projects/TileDB-Py/build/lib.linux-x86_64-cpython-310/tiledb/main.cpython-310-x86_64-linux-gnu.so
-- Set non-toolchain portion of runtime path of "build/lib.linux-x86_64-cpython-310/tiledb/main.cpython-310-x86_64-linux-gnu.so" to "$ORIGIN"
-- Installing: /home/dudoslav/Projects/TileDB-Py/build/lib.linux-x86_64-cpython-310/tiledb/libtiledb.cpython-310-x86_64-linux-gnu.so
-- Set non-toolchain portion of runtime path of "build/lib.linux-x86_64-cpython-310/tiledb/libtiledb.cpython-310-x86_64-linux-gnu.so" to "$ORIGIN"
-- Installing: /home/dudoslav/Projects/TileDB-Py/build/lib.linux-x86_64-cpython-310/tiledb/libtiledb.so.2.24
-- Installing: /home/dudoslav/Projects/TileDB-Py/build/lib.linux-x86_64-cpython-310/tiledb/cc.cpython-310-x86_64-linux-gnu.so
-- Set non-toolchain portion of runtime path of "build/lib.linux-x86_64-cpython-310/tiledb/cc.cpython-310-x86_64-linux-gnu.so" to "$ORIGIN"
```

^^ `lib.linux-x86_64-cpython-310` ...