### PR TITLE
Temporarily disable upload to PyPI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -141,6 +141,6 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
 
-      - name: Upload to pypi
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@release/v1
+      # - name: Upload to pypi
+      #   if: startsWith(github.ref, 'refs/tags/')
+      #   uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Disable automatic upload until we release the first wheels with scikit-build-core