### PR TITLE
Fix deprecation and test

### DIFF
--- a/tiledb/cc/array.cc
+++ b/tiledb/cc/array.cc
@@ -96,10 +96,6 @@ void init_array(py::module &m) {
            })
       .def("vacuum", &Array::vacuum)
       .def("create",
-           py::overload_cast<const std::string &, const ArraySchema &,
-                             tiledb_encryption_type_t, const std::string &>(
-               &Array::create))
-      .def("create",
            py::overload_cast<const std::string &, const ArraySchema &>(
                &Array::create))
       .def("load_schema",

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -28,6 +28,9 @@ from .datatypes import RaggedDtype
 
 if not has_pandas():
     pytest.skip("pandas>=1.0,<3.0 not installed", allow_module_level=True)
+else:
+    pd = pytest.importorskip("pandas")
+    tm = pd._testing
 
 
 def make_dataframe_basic1(col_size=10):


### PR DESCRIPTION
This PR fixes:
- API deprecation found in https://github.com/jdblischak/centralized-tiledb-nightlies/issues/14 and not fixed in https://github.com/TileDB-Inc/TileDB-Py/pull/1958
- code mistakenly deleted in https://github.com/TileDB-Inc/TileDB-Py/pull/2016
