### PR TITLE
Define `TILEDB_REMOVE_DEPRECATIONS` macro for cc and remove deprecated code

### DIFF
--- a/tiledb/cc/CMakeLists.txt
+++ b/tiledb/cc/CMakeLists.txt
@@ -33,11 +33,13 @@ target_compile_features(
     cxx_std_20
 )
 
-target_compile_definitions(
-    cc
-    PRIVATE
-    TILEDB_REMOVE_DEPRECATIONS
-)
+if (TILEDB_REMOVE_DEPRECATIONS)
+    target_compile_definitions(
+        cc
+        PRIVATE
+        TILEDB_REMOVE_DEPRECATIONS
+    )
+endif()
 
 install(TARGETS cc DESTINATION tiledb)
 

--- a/tiledb/cc/CMakeLists.txt
+++ b/tiledb/cc/CMakeLists.txt
@@ -33,6 +33,12 @@ target_compile_features(
     cxx_std_20
 )
 
+target_compile_definitions(
+    cc
+    PRIVATE
+    TILEDB_REMOVE_DEPRECATIONS
+)
+
 install(TARGETS cc DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)

--- a/tiledb/cc/array.cc
+++ b/tiledb/cc/array.cc
@@ -35,16 +35,6 @@ void init_array(py::module &m) {
       .def("schema", &Array::schema)
       //.def("ptr", [](Array& arr){ return py::capsule(arr.ptr()); } )
       .def("open", (void(Array::*)(tiledb_query_type_t)) & Array::open)
-      // open with encryption key
-      .def("open",
-           (void(Array::*)(tiledb_query_type_t, tiledb_encryption_type_t,
-                           const std::string &)) &
-               Array::open)
-      // open with encryption key and timestamp
-      .def("open",
-           (void(Array::*)(tiledb_query_type_t, tiledb_encryption_type_t,
-                           const std::string &, uint64_t)) &
-               Array::open)
       .def("reopen", &Array::reopen)
       .def("set_open_timestamp_start", &Array::set_open_timestamp_start)
       .def("set_open_timestamp_end", &Array::set_open_timestamp_end)
@@ -121,7 +111,6 @@ void init_array(py::module &m) {
            })
       .def("consolidate_metadata",
            py::overload_cast<const Context &, const std::string &,
-                             tiledb_encryption_type_t, const std::string &,
                              Config *const>(&Array::consolidate_metadata))
       .def("put_metadata",
            [](Array &self, std::string &key, tiledb_datatype_t tdb_type,

--- a/tiledb/cc/schema.cc
+++ b/tiledb/cc/schema.cc
@@ -165,10 +165,6 @@ void init_schema(py::module &m) {
 
       .def(py::init<Context &, std::string &>())
 
-      .def(py::init<Context &, std::string &, tiledb_encryption_type_t,
-                    std::string &>(),
-           py::keep_alive<1, 2>())
-
       .def(py::init<Context &, py::capsule>())
 
       .def("__capsule__",

--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -482,14 +482,6 @@ cdef extern from "tiledb/tiledb.h":
         const char* array_uri,
         tiledb_array_schema_t** array_schema) nogil
 
-    int tiledb_array_schema_load_with_key(
-        tiledb_ctx_t* ctx,
-        const char* array_uri,
-        tiledb_encryption_type_t key_type,
-        const void* key_ptr,
-        unsigned int key_len,
-        tiledb_array_schema_t** array_schema) nogil
-
     int tiledb_array_schema_get_array_type(
         tiledb_ctx_t* ctx,
         const tiledb_array_schema_t* array_schema,
@@ -643,14 +635,6 @@ cdef extern from "tiledb/tiledb.h":
     int tiledb_array_consolidate_metadata(
         tiledb_ctx_t* ctx,
         const char* array_uri,
-        tiledb_config_t* config) nogil
-
-    int tiledb_array_consolidate_metadata_with_key(
-        tiledb_ctx_t* ctx,
-        const char* array_uri,
-        tiledb_encryption_type_t encryption_type,
-        const void* encryption_key,
-        uint32_t key_length,
         tiledb_config_t* config) nogil
 
     int tiledb_array_delete(
@@ -808,23 +792,6 @@ cdef extern from "tiledb/tiledb.h":
         tiledb_ctx_t* ctx,
         tiledb_array_t* array,
         tiledb_query_type_t query_type) nogil
-
-    int tiledb_array_open_with_key(
-        tiledb_ctx_t* ctx,
-        tiledb_array_t* array,
-        tiledb_query_type_t query_type,
-        tiledb_encryption_type_t key_type,
-        const void* key,
-        unsigned int key_len) nogil
-
-    int tiledb_array_open_at_with_key(
-        tiledb_ctx_t* ctx,
-        tiledb_array_t* array,
-        tiledb_query_type_t query_type,
-        tiledb_encryption_type_t encryption_type,
-        const void * encryption_key,
-        int key_length,
-        uint64_t timestamp) nogil
 
     int tiledb_array_reopen(
         tiledb_ctx_t* ctx,

--- a/tiledb/tests/cc/test_cc.py
+++ b/tiledb/tests/cc/test_cc.py
@@ -94,9 +94,6 @@ def test_array():
     assert os.path.basename(arr.uri()) == os.path.basename(uri)
     assert arr.schema == arr.schema
 
-    # TODO test
-    # open(tiledb_query_type_t query_type, tiledb_encryption_type_t encryption_type, const std::string& encryption_key, uint64_t timestamp)
-
     arr.reopen()
     arr.set_open_timestamp_start(0)
     arr.set_open_timestamp_end(1)


### PR DESCRIPTION
This PR defines the `TILEDB_REMOVE_DEPRECATIONS` macro, resulting in an error when deprecated core code is used.
Also removes, deprecated code.

Related PRs:
- https://github.com/TileDB-Inc/TileDB-Py/pull/2021
- https://github.com/TileDB-Inc/TileDB-Py/pull/1958

Solves:
https://github.com/jdblischak/centralized-tiledb-nightlies/issues/14