### PR TITLE
Expose `setup.py` flag to enable deprecations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ def main():
     if args.debug:
         cmd.append(f"-Cskbuild.cmake.build-type=Debug")
 
+    if args.enable_deprecations:
+        cmd.append(f"-Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS=OFF")
+
     if args.v:
         cmd.append("-v")
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ def main():
     parser.add_argument("command", choices=["install", "develop"])
     parser.add_argument("--tiledb", type=str, required=False)
     parser.add_argument("--debug", action="store_true")
+    parser.add_argument("--enable-deprecations", action="store_true", required=False)
     parser.add_argument("-v", action="store_true")
     args = parser.parse_args()
 


### PR DESCRIPTION
In https://github.com/TileDB-Inc/TileDB-Py/pull/2023, `TILEDB_REMOVE_DEPRECATIONS` macro was defined.
It would be good to also have this functionality in `setup.py`.

Right now, the default behavior is to remove deprecations when build TileDB-Py. In core, the default is to enable them.
Should we keep the logic, or follow the core's?