### PR TITLE
Update Cython minimum version to 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "scikit-build-core",
     "pybind11",
-    "Cython",
+    "Cython>=3",
     "numpy==1.17.* ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'",
     "numpy==1.19.* ; python_version == '3.8' and platform_machine == 'aarch64'",
     "numpy==1.21.* ; python_version == '3.8' and platform_machine == 'arm64'",


### PR DESCRIPTION
- Numpy2 docs: _"Cython users should use Cython 3."_ - https://numpy.org/devdocs/release/2.0.0-notes.html#c-api-changes
- Cython 3 is [available for python 3.8](https://pypi.org/project/Cython/#files)