### PR TITLE
Add packaging as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   "numpy>=1.19 ; python_version == '3.8' and platform_machine == 'aarch64'",
   "numpy>=1.21 ; python_version == '3.8' and platform_machine == 'arm64'",
   "numpy>=1.25 ; python_version >= '3.9'",
+  "packaging",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
This PR should fix issue: https://github.com/TileDB-Inc/TileDB-Py/issues/2031

I am not sure why the automated tests did not pick up on this missing dependency.