### PR TITLE
Add `tiledb_current_domain_t` as type

### DIFF
--- a/tiledb/libtiledb.pxd
+++ b/tiledb/libtiledb.pxd
@@ -142,6 +142,8 @@ cdef extern from "tiledb/tiledb.h":
         pass
     ctypedef struct tiledb_array_schema_t:
         pass
+    ctypedef struct tiledb_current_domain_t:
+        pass
     ctypedef struct tiledb_dimension_t:
         pass
     ctypedef struct tiledb_domain_t:


### PR DESCRIPTION
Fix for failing daily tests: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/10242931834
`
/home/runner/work/TileDB-Py/TileDB-Py/tiledb/schema_evolution.cc:104:14: error: ‘tiledb_current_domain_t’ was not declared in this scope; did you mean ‘tiledb_domain_t’?
`


`tiledb_current_domain_t` is needed after `CurrentDomain` wrapping: https://github.com/TileDB-Inc/TileDB-Py/pull/2015

Closes https://github.com/TileDB-Inc/TileDB-Py/issues/1986