### PR TITLE
Improve Query Condition error messages to align with TileDB-SOMA-Py

### DIFF
--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -118,7 +118,7 @@ class QueryCondition:
         if not isinstance(self.c_obj, qc.PyQueryCondition):
             raise TileDBError(
                 "Malformed query condition statement. A query condition must "
-                "be made up of one or more Boolean expressions."
+                "be made up of one or more boolean expressions."
             )
 
 
@@ -163,6 +163,12 @@ class QueryConditionTree(ast.NodeVisitor):
 
     def visit_NotIn(self, node):
         return node
+
+    def visit_Is(self, node):
+        raise TileDBError("the `is` operator is not supported")
+
+    def visit_IsNot(self, node):
+        raise TileDBError("the `is not` operator is not supported")
 
     def visit_List(self, node):
         return list(node.elts)
@@ -225,6 +231,9 @@ class QueryConditionTree(ast.NodeVisitor):
             dtype = "string" if dt.kind in "SUa" else dt.name
             op = qc.TILEDB_IN if isinstance(operator, ast.In) else qc.TILEDB_NOT_IN
             result = self.create_pyqc(dtype)(self.ctx, node.left.id, values, op)
+
+        else:
+            raise TileDBError(f"unrecognized operator in <<{ast.dump(node)}>>")
 
         return result
 

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -167,6 +167,13 @@ class QueryConditionTree(ast.NodeVisitor):
     def visit_List(self, node):
         return list(node.elts)
 
+    def visit_Attribute(self, node) -> qc.PyQueryCondition:
+        raise TileDBError(
+            f"Unhandled dot operator in {ast.dump(node)} -- if your attribute name "
+            'has a dot in it, e.g. `orig.ident`, please wrap it with `attr("...")`, '
+            'e.g. `attr("orig.ident")`'
+        )
+
     def visit_Compare(self, node: Type[ast.Compare]) -> qc.PyQueryCondition:
         operator = self.visit(node.ops[0])
 

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -608,6 +608,24 @@ class QueryConditionTest(DiskTestCase):
                 exc_info.value
             )
 
+    @pytest.mark.parametrize(
+        "expression_and_message",
+        [
+            ["foo is True", "the `is` operator is not supported"],
+            ["foo is not True", "the `is not` operator is not supported"],
+            [
+                "foo &&& bar",
+                "Could not parse the given QueryCondition statement: foo &&& bar",
+            ],
+        ],
+    )
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_not_supported_operators(self, expression_and_message, sparse):
+        with tiledb.open(self.create_input_array_UIDSA(sparse=sparse)) as A:
+            expression, message = expression_and_message
+            with self.assertRaisesRegex(tiledb.TileDBError, message):
+                A.query(cond=expression)[:]
+
     @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
     def test_dense_datetime(self):
         import pandas as pd

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -208,6 +208,13 @@ class QueryConditionTest(DiskTestCase):
 
     def test_string_sparse(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
+            with self.assertRaises(tiledb.TileDBError) as exc_info:
+                A.query(cond="S == c", attrs=["S"])[:]
+            assert (
+                "right-hand sides must be constant expressions, not variables -- did you mean to quote the right-hand side as a string?"
+                in str(exc_info.value)
+            )
+
             result = A.query(cond="S == 'c'", attrs=["S"])[:]
             assert len(result["S"]) == 1
             assert result["S"][0] == b"c"
@@ -224,6 +231,13 @@ class QueryConditionTest(DiskTestCase):
 
     def test_string_dense(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=False)) as A:
+            with self.assertRaises(tiledb.TileDBError) as exc_info:
+                A.query(cond="S == ccc", attrs=["S"])[:]
+            assert (
+                "right-hand sides must be constant expressions, not variables -- did you mean to quote the right-hand side as a string?"
+                in str(exc_info.value)
+            )
+
             result = A.query(cond="S == 'ccc'", attrs=["S"])[:]
             assert all(self.filter_dense(result["S"], A.attr("S").fill) == b"c")
 


### PR DESCRIPTION
Following https://github.com/single-cell-data/TileDB-SOMA/pull/2830, https://github.com/single-cell-data/TileDB-SOMA/pull/2831, and https://github.com/single-cell-data/TileDB-SOMA/pull/2864 this PR improves some `QueryCondition` error messages.
In short, it improves error messages:
- when targeted attribute contains `.`
- on non-constant query-condition RHS
- for invalid operators in query-condition parser

---

[sc-52811]
[sc-52812]
[sc-52813]