### PR TITLE
Fix `numpy.ma.fix_invalid` issue in NumPy 2.1.0 by replacing with `numpy.ma.masked_invalid`

### DIFF
--- a/tiledb/libtiledb.pyx
+++ b/tiledb/libtiledb.pyx
@@ -2705,7 +2705,7 @@ cdef class DenseArrayImpl(Array):
                                         "typed attribute '{}'!".format(name))
                     
                     if attr.isnullable and name not in nullmaps:
-                        nullmaps[name] = ~np.ma.fix_invalid(val).mask
+                        nullmaps[name] = ~np.ma.masked_invalid(val).mask
                         val = np.nan_to_num(val)
                     val = np.ascontiguousarray(val, dtype=attr.dtype)
             except Exception as exc:


### PR DESCRIPTION
For an unknown reason, `numpy.ma.fix_invalid` behaves differently between NumPy 2.1.0 and NumPy 2.0.0. Specifically, when passing a pandas Series containing a `numpy.nan` value, `numpy.ma.fix_invalid` now makes changes in-place, even if the `copy` argument is set to its default value of `True`. This issue occurs only with pandas Series, not with NumPy arrays, for example.

Nevertheless, we don't actually need the `numpy.ma.fix_invalid` function since we handle `NaNs` later using `numpy.nan_to_num`. It would be wiser (and likely more performant) to use `numpy.ma.masked_invalid`, which simply creates a `MaskedArray` instance and allows us to obtain the mask from there.

cc: @jdblischak 
Closes https://github.com/TileDB-Inc/TileDB-Py/issues/2040

---

```
>>> import pandas as pd, numpy as np
>>> pd.__version__; np.__version__
'2.2.2'
'2.1.0'
>>> my_series = pd.Series([1.0, 2.0, np.nan, 0.0, 1.0])
>>> my_series
0    1.0
1    2.0
2    NaN
3    0.0
4    1.0
dtype: float64
>>> np.ma.fix_invalid(my_series)
masked_array(data=[1.0, 2.0, --, 0.0, 1.0],
             mask=[False, False,  True, False, False],
       fill_value=1e+20)
>>> my_series
0    1.000000e+00
1    2.000000e+00
2    1.000000e+20
3    0.000000e+00
4    1.000000e+00
dtype: float64
```

```
>>> import pandas as pd, numpy as np
>>> pd.__version__; np.__version__
'2.2.2'
'2.0.0'
>>> my_series = pd.Series([1.0, 2.0, np.nan, 0.0, 1.0])
>>> my_series
0    1.0
1    2.0
2    NaN
3    0.0
4    1.0
dtype: float64
>>> np.ma.fix_invalid(my_series)
masked_array(data=[1.0, 2.0, --, 0.0, 1.0],
             mask=[False, False,  True, False, False],
       fill_value=1e+20)
>>> my_series
0    1.0
1    2.0
2    NaN
3    0.0
4    1.0
dtype: float64
```