### PR TITLE
Remove deprecations

### DIFF
--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -65,7 +65,6 @@ from .filter import (
 from .fragment import (
     FragmentInfo,
     FragmentInfoList,
-    FragmentsInfo,
     copy_fragments_to_existing_array,
     create_array_from_fragments,
 )

--- a/tiledb/filestore.py
+++ b/tiledb/filestore.py
@@ -142,29 +142,6 @@ class Filestore:
 
         lt.Filestore._uri_export(ctx, filestore_array_uri, file_uri)
 
-    def uri_import(self, file_uri: str, mime_type: str = "AUTODETECT") -> None:
-        warnings.warn(
-            "Filestore.uri_import is deprecated; please use Filestore.copy_from",
-            DeprecationWarning,
-        )
-
-        if not isinstance(file_uri, str):
-            raise TypeError(
-                f"Unexpected file_uri type '{type(file_uri)}': expected str"
-            )
-
-        if not isinstance(mime_type, str):
-            raise TypeError(
-                f"Unexpected mime_type type '{type(mime_type)}': expected str"
-            )
-
-        lt.Filestore._uri_import(
-            self._ctx,
-            self._filestore_uri,
-            file_uri,
-            lt.Filestore._mime_type_from_str(mime_type),
-        )
-
     def __len__(self) -> int:
         """
         :rtype: int

--- a/tiledb/fragment.py
+++ b/tiledb/fragment.py
@@ -131,38 +131,6 @@ class FragmentInfoList:
         if libtiledb_version() >= (2, 5, 0):
             self.array_schema_name = fi.get_array_schema_name()
 
-    @property
-    def non_empty_domain(self):
-        raise tiledb.TileDBError(
-            "FragmentInfoList.non_empty_domain is deprecated; "
-            "you must use FragmentInfoList.nonempty_domain",
-            "This message will be removed in 0.21.0.",
-        )
-
-    @property
-    def to_vacuum_num(self):
-        raise tiledb.TileDBError(
-            "FragmentInfoList.to_vacuum_num is deprecated; "
-            "you must use len(FragmentInfoList.to_vacuum)",
-            "This message will be removed in 0.21.0.",
-        )
-
-    @property
-    def to_vacuum_uri(self):
-        raise tiledb.TileDBError(
-            "FragmentInfoList.to_vacuum_uri is deprecated; "
-            "you must use FragmentInfoList.to_vacuum",
-            "This message will be removed in 0.21.0.",
-        )
-
-    @property
-    def dense(self):
-        raise tiledb.TileDBError(
-            "FragmentInfoList.dense is deprecated; "
-            "you must use FragmentInfoList.sparse",
-            "This message will be removed in 0.21.0.",
-        )
-
     def __getattr__(self, name):
         if name == "mbrs":
             raise AttributeError(
@@ -296,50 +264,6 @@ class FragmentInfo:
                 "Use tiledb.array_fragments(include_mbrs=True) to enable)"
             )
         return self.__getattribute__(name)
-
-    @property
-    def non_empty_domain(self):
-        raise tiledb.TileDBError(
-            "FragmentInfo.non_empty_domain is deprecated; "
-            "you must use FragmentInfo.nonempty_domain. ",
-            "This message will be removed in 0.21.0.",
-        )
-
-    @property
-    def to_vacuum_num(self):
-        raise tiledb.TileDBError(
-            "FragmentInfo.to_vacuum_num is deprecated; "
-            "you must use len(FragmentInfoList.to_vacuum).",
-            "This message will be removed in 0.21.0.",
-        )
-
-    @property
-    def to_vacuum_uri(self):
-        raise tiledb.TileDBError(
-            "FragmentInfo.to_vacuum_uri is deprecated; "
-            "you must use FragmentInfoList.to_vacuum.",
-            "This message will be removed in 0.21.0.",
-        )
-
-    @property
-    def dense(self):
-        raise tiledb.TileDBError(
-            "FragmentInfo.dense is deprecated; you must use FragmentInfo.sparse",
-            "This message will be removed in 0.21.0.",
-        )
-
-
-def FragmentsInfo(array_uri, ctx=None):
-    """
-    Deprecated in 0.8.8.
-
-    Renamed to FragmentInfoList to make name more distinguishable from FragmentInfo.
-    """
-
-    raise tiledb.TileDBError(
-        "FragmentsInfo is deprecated; you must use FragmentInfoList. "
-        "This message will be removed in 0.21.0.",
-    )
 
 
 def create_array_from_fragments(

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -649,13 +649,6 @@ def _get_pyquery(
     if query and query.cond is not None:
         if isinstance(query.cond, str):
             pyquery.set_cond(QueryCondition(query.cond))
-        elif isinstance(query.cond, QueryCondition):
-            raise TileDBError(
-                "Passing `tiledb.QueryCondition` to `cond` is no longer supported "
-                "as of 0.19.0. Instead of `cond=tiledb.QueryCondition('expression')` "
-                "you must use `cond='expression'`. This message will be "
-                "removed in 0.21.0.",
-            )
         else:
             raise TypeError("`cond` expects type str.")
 

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -321,11 +321,6 @@ class QueryConditionTree(ast.NodeVisitor):
             variable = variable_node.id
         elif isinstance(variable_node, ast.Constant):
             variable = variable_node.value
-        elif isinstance(variable_node, ast.Constant) or isinstance(
-            variable_node, ast.Constant
-        ):
-            # deprecated in 3.8
-            variable = variable_node.s
         else:
             raise TileDBError(
                 f"Incorrect type for variable name: {ast.dump(variable_node)}"
@@ -492,19 +487,3 @@ class QueryConditionTree(ast.NodeVisitor):
                 )
 
             return node.operand
-
-    def visit_Num(self, node: ast.Constant) -> ast.Constant:
-        # deprecated in 3.8
-        return node
-
-    def visit_Str(self, node: ast.Constant) -> ast.Constant:
-        # deprecated in 3.8
-        return node
-
-    def visit_Bytes(self, node: ast.Constant) -> ast.Constant:
-        # deprecated in 3.8
-        return node
-
-    def visit_NameConstant(self, node: ast.Constant) -> ast.Constant:
-        # deprecated in 3.8
-        return node

--- a/tiledb/tests/test_filestore.py
+++ b/tiledb/tests/test_filestore.py
@@ -74,22 +74,6 @@ class FilestoreTest(DiskTestCase):
             assert data == fs.read(0, len(data))
             assert len(fs) == len(data)
 
-    def test_deprecated_uri(self, text_fname):
-        path = self.path("test_uri")
-        schema = tiledb.ArraySchema.from_file(text_fname)
-        tiledb.Array.create(path, schema)
-
-        fs = tiledb.Filestore(path)
-        with pytest.warns(
-            DeprecationWarning, match="Filestore.uri_import is deprecated"
-        ):
-            fs.uri_import(text_fname)
-
-        with open(text_fname, "rb") as text:
-            data = text.read()
-            assert data == fs.read(0, len(data))
-            assert len(fs) == len(data)
-
     def test_multiple_writes(self):
         path = self.path("test_buffer")
         schema = tiledb.ArraySchema.from_file()

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -392,10 +392,6 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         with tiledb.open(uri) as B:
             tm.assert_frame_equal(df, B.df[:])
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="requires Python 3.8 or higher. date_format argument is not supported in 3.7 and below",
-    )
     def test_dataframe_csv_rt1(self):
         def rand_dtype(dtype, size):
             nbytes = size * np.dtype(dtype).itemsize
@@ -703,10 +699,6 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         tmp_array2 = os.path.join(tmp_dir, "array2")
         tiledb.from_csv(tmp_array2, tmp_csv, sparse=False)
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="requires Python 3.8 or higher. date_format argument is not supported in 3.7 and below",
-    )
     def test_csv_col_to_sparse_dims(self):
         df = make_dataframe_basic3(20)
 
@@ -780,10 +772,6 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             cmp_df = df.set_index("int_vals").sort_values(by="time")
             tm.assert_frame_equal(res_df, cmp_df)
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="requires Python 3.8 or higher. date_format argument is not supported in 3.7 and below",
-    )
     def test_dataframe_csv_schema_only(self):
         col_size = 10
         df = make_dataframe_basic3(col_size)
@@ -893,10 +881,6 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             df_bk.sort_index(level="time", inplace=True)
             tm.assert_frame_equal(df_bk, df_combined)
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="requires Python 3.8 or higher. date_format argument is not supported in 3.7 and below",
-    )
     def test_dataframe_csv_chunked(self):
         col_size = 200
         df = make_dataframe_basic3(col_size)
@@ -979,10 +963,6 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             df_idx_res = A.query(coords=False).df[int(ned[0]) : int(ned[1])]
             tm.assert_frame_equal(df_idx_res, df.reset_index(drop=True))
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="requires Python 3.8 or higher. date_format argument is not supported in 3.7 and below",
-    )
     def test_csv_fillna(self):
         if pytest.tiledb_vfs == "s3":
             pytest.skip(

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -119,12 +119,7 @@ class QueryConditionTest(DiskTestCase):
 
     def test_unsigned_sparse(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
-            with pytest.raises(tiledb.TileDBError) as exc_info:
-                A.query(cond=tiledb.QueryCondition("U < 5"), attrs=["U"])[:]
-            assert (
-                "Passing `tiledb.QueryCondition` to `cond` is no longer supported"
-                in str(exc_info.value)
-            )
+            A.query(cond="U < 5", attrs=["U"])[:]
 
             result = A.query(cond="U < 5", attrs=["U"])[:]
             assert all(result["U"] < 5)
@@ -133,12 +128,7 @@ class QueryConditionTest(DiskTestCase):
         with tiledb.open(self.create_input_array_UIDSA(sparse=False)) as A:
             mask = A.attr("U").fill
 
-            with pytest.raises(tiledb.TileDBError) as exc_info:
-                A.query(cond=tiledb.QueryCondition("U < 5"), attrs=["U"])[:]
-            assert (
-                "Passing `tiledb.QueryCondition` to `cond` is no longer supported"
-                in str(exc_info.value)
-            )
+            A.query(cond="U < 5", attrs=["U"])[:]
 
             result = A.query(cond="U < 5", attrs=["U"])[:]
             assert all(self.filter_dense(result["U"], mask) < 5)
@@ -699,25 +689,9 @@ class QueryConditionTest(DiskTestCase):
         with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
             qc = "U < 3"
 
-            with pytest.raises(tiledb.TileDBError) as exc_info:
-                A.query(cond=qc, attr_cond=qc)
-            assert "Both `attr_cond` and `cond` were passed." in str(exc_info.value)
-
-            with pytest.raises(tiledb.TileDBError) as exc_info:
-                A.query(attr_cond=qc)
-            assert "`attr_cond` is no longer supported" in str(exc_info.value)
-
-            with pytest.raises(tiledb.TileDBError) as exc_info:
-                A.query(cond=qc).attr_cond
-            assert "`attr_cond` is no longer supported" in str(exc_info.value)
-
-            with pytest.raises(tiledb.TileDBError) as exc_info:
-                A.subarray(1, cond=qc, attr_cond=qc)
-            assert "Both `attr_cond` and `cond` were passed." in str(exc_info.value)
-
-            with pytest.raises(tiledb.TileDBError) as exc_info:
-                A.subarray(1, attr_cond=qc)
-            assert "`attr_cond` is no longer supported" in str(exc_info.value)
+            A.query(cond=qc)
+            A.query(cond=qc).cond
+            A.subarray(1, cond=qc)
 
     def test_on_dense_dimensions(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=False)) as A:

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -111,15 +111,7 @@ class VFS(lt.VFS):
         :rtype: :py:func:`bytes`
         :return: read bytes
         :raises: :py:exc:`tiledb.TileDBError`
-
         """
-        if isinstance(file, FileIO):
-            raise lt.TileDBError(
-                "`tiledb.VFS().open` now returns a FileIO object. Use "
-                "`FileIO.seek` and `FileIO.read`. This message will be removed "
-                "in 0.21.0."
-            )
-
         if nbytes == 0:
             return b""
 


### PR DESCRIPTION
This PR removes some easy-to-delete deprecations. They come from either the TileDB-Py version or the Python version.