### PR TITLE
Fix serialization test and add command line option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ TILEDB_PATH = {env="TILEDB_PATH"}
 TILEDB_VERSION = {env="TILEDB_VERSION"}
 TILEDB_HASH = {env="TILEDB_HASH"}
 TILEDB_REMOVE_DEPRECATIONS = "ON"
+TILEDB_SERIALIZATION = "OFF"
 
 [tool.pytest.ini_options]
 python_classes = "*Test*"

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ def main():
     parser.add_argument("--tiledb", type=str, required=False)
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--enable-deprecations", action="store_true", required=False)
+    parser.add_argument("--enable-serialization", action="store_true", required=False)
     parser.add_argument("-v", action="store_true")
     args = parser.parse_args()
 
@@ -32,6 +33,9 @@ def main():
 
     if args.enable_deprecations:
         cmd.append(f"-Cskbuild.cmake.define.TILEDB_REMOVE_DEPRECATIONS=OFF")
+
+    if args.enable_serialization:
+        cmd.append(f"-Cskbuild.cmake.define.TILEDB_SERIALIZATION=ON")
 
     if args.v:
         cmd.append("-v")

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -56,6 +56,14 @@ target_compile_features(
     cxx_std_20
 )
 
+if (TILEDB_SERIALIZATION)
+    target_compile_definitions(
+        main
+        PRIVATE
+        TILEDB_SERIALIZATION
+    )
+endif()
+
 install(TARGETS main libtiledb DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)

--- a/tiledb/cc/CMakeLists.txt
+++ b/tiledb/cc/CMakeLists.txt
@@ -42,6 +42,14 @@ if (TILEDB_REMOVE_DEPRECATIONS)
     )
 endif()
 
+if (TILEDB_SERIALIZATION)
+    target_compile_definitions(
+        cc
+        PRIVATE
+        TILEDB_SERIALIZATION
+    )
+endif()
+
 install(TARGETS cc DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)

--- a/tiledb/tests/test_serialization.py
+++ b/tiledb/tests/test_serialization.py
@@ -5,10 +5,10 @@ import tiledb
 
 from .common import DiskTestCase
 
-ser_test = pytest.importorskip(
-    "tiledb.main.test_serialization", reason="Serialization not enabled."
-)
-
+try:
+    from tiledb.main import test_serialization as ser_test
+except ImportError:
+    pytest.skip("Serialization not enabled.", allow_module_level=True)
 
 class SerializationTest(DiskTestCase):
     def test_query_deserialization(self):

--- a/tiledb/tests/test_serialization.py
+++ b/tiledb/tests/test_serialization.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     pytest.skip("Serialization not enabled.", allow_module_level=True)
 
+
 class SerializationTest(DiskTestCase):
     def test_query_deserialization(self):
         path = self.path("test_query_deserialization")


### PR DESCRIPTION
A problem identified even before `scikit-build-core` was introduced was that the serialization test was always skipped, even after setting it using the old/deprecated way: `python setup.py -DTILEDB_SERIALIZATION=ON`.

Additionally, elements like `tiledb.main.test_serialization.create_serialized_test_query` or `tiledb.main.TILEDB_CAPNP` were also undefined.

It turns out that the way the `test_serialization` import was handled was incorrect:

```
>>> import tiledb.main.test_serialization
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'tiledb.main.test_serialization'; 'tiledb.main' is not a package
```
but we were silently receiving only the `Serialization not enabled.` message

Here is the correct way:
```
>>> from tiledb.main import test_serialization
```

This PR:
- adds flag for serialization: `pip install . -Cskbuild.cmake.define.TILEDB_SERIALIZATION=ON` and `python setup.py install --enable-serialization` [**deprecated!**]

- fixes import error of `tiledb/tests/test_serialization.py`

---

[sc-49775]