### PR TITLE
Convert config values to strings in VFS init

### DIFF
--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -5,6 +5,7 @@ from typing import Callable, List, Optional, Type, Union
 
 import numpy as np
 
+import tiledb
 import tiledb.cc as lt
 
 from .ctx import Config, Ctx, default_ctx
@@ -40,7 +41,7 @@ class VFS(lt.VFS):
             # Convert all values to strings
             config = {k: str(v) for k, v in config.items()}
 
-            ccfg = lt.Config(config)
+            ccfg = tiledb.Config(config)
             super().__init__(ctx, ccfg)
         else:
             super().__init__(ctx)

--- a/tiledb/vfs.py
+++ b/tiledb/vfs.py
@@ -37,6 +37,9 @@ class VFS(lt.VFS):
                 except Exception:
                     raise ValueError("`config` argument must be of type Config or dict")
 
+            # Convert all values to strings
+            config = {k: str(v) for k, v in config.items()}
+
             ccfg = lt.Config(config)
             super().__init__(ctx, ccfg)
         else:


### PR DESCRIPTION
Enable passing config values with non-string types, for example:

```python
config = {"vfs.s3.no_sign_request": True}

vfs = tiledb.VFS(config=config)
```

which currently generates this error:
```
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. tiledb.cc.Config(arg0: tiledb.cc.Config)
    2. tiledb.cc.Config()
    3. tiledb.cc.Config(arg0: dict[str, str])
    4. tiledb.cc.Config(arg0: str)

Invoked with: {'vfs.s3.no_sign_request': True}
```
