### PR TITLE
Make dump calls conditional to fix errors when building against <2.26

### DIFF
--- a/tiledb/cc/attribute.cc
+++ b/tiledb/cc/attribute.cc
@@ -108,9 +108,13 @@ void init_attribute(py::module &m) {
       .def("_set_enumeration_name", set_enumeration_name)
 
       .def("_dump", [](Attribute &attr) {
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 26
         std::stringstream ss;
         ss << attr;
         return ss.str();
+#else
+        attr.dump();
+#endif
       });
 }
 

--- a/tiledb/cc/domain.cc
+++ b/tiledb/cc/domain.cc
@@ -202,9 +202,13 @@ void init_domain(py::module &m) {
       .def("_add_dim", &Domain::add_dimension, py::keep_alive<1, 2>())
 
       .def("_dump", [](Domain &dom) {
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 26
         std::stringstream ss;
         ss << dom;
         return ss.str();
+#else
+        dom.dump();
+#endif
       });
 }
 

--- a/tiledb/cc/filter.cc
+++ b/tiledb/cc/filter.cc
@@ -104,11 +104,15 @@ void init_filter(py::module &m) {
                TPY_ERROR_LOC("Unrecognized filter option to _get_option");
              }
            })
-      .def("_dump", [](Filter &filter) {
-        std::stringstream ss;
-        ss << filter;
-        return ss.str();
-      });
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 26
+      .def("_dump",
+           [](Filter &filter) {
+             std::stringstream ss;
+             ss << filter;
+             return ss.str();
+           })
+#endif
+      ;
 
   py::class_<FilterList>(m, "FilterList")
       .def(py::init<FilterList>())

--- a/tiledb/cc/schema.cc
+++ b/tiledb/cc/schema.cc
@@ -174,9 +174,13 @@ void init_schema(py::module &m) {
 
       .def("_dump",
            [](ArraySchema &schema) {
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 26
              std::stringstream ss;
              ss << schema;
              return ss.str();
+#else
+             schema.dump();
+#endif
            })
 
       .def("_ctx", &ArraySchema::context)


### PR DESCRIPTION
After https://github.com/TileDB-Inc/TileDB-Py/commit/ce8310e60a493be0fc412c92a8fb937575385649 `operator<<` is used instead of `dump` functions. Since this is introduced in `2.26.0`, building against older libtiledb versions results in failing tests: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/10824513851

Daily tests workflow: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/10832807692

Fixes: https://github.com/TileDB-Inc/TileDB-Py/issues/2061