### PR TITLE
Fix the `object_type` return value for the `None` case

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1781,14 +1781,14 @@ void init_core(py::module &m) {
   m.def("datatype_size", &tiledb_datatype_size);
   m.def("as_built_dump", &as_built_dump);
   m.def("object_type",
-        [](const std::string &uri, const Context &ctx) -> py::str {
+        [](const std::string &uri, const Context &ctx) -> py::object {
           tiledb_object_t res;
           ctx.handle_error(
               tiledb_object_type(ctx.ptr().get(), uri.c_str(), &res));
           if (res == TILEDB_ARRAY) {
-            return std::string("array");
+            return py::str("array");
           } else if (res == TILEDB_GROUP) {
-            return std::string("group");
+            return py::str("group");
           }
           return py::none();
         });

--- a/tiledb/tests/test_util.py
+++ b/tiledb/tests/test_util.py
@@ -165,3 +165,18 @@ class UtilTest(DiskTestCase):
         with self.assertRaises(tiledb.TileDBError) as excinfo:
             tiledb.ls(dense_arrays_uri, lambda x, y: 1 / 0)
         assert "ZeroDivisionError: division by zero" in str(excinfo.value)
+
+    def test_object_type(self):
+        uri = self.path("test_object_type")
+
+        # None case
+        self.assertIsNone(tiledb.object_type(uri))
+
+        # Array case
+        with tiledb.from_numpy(uri, np.arange(0, 5)) as T:
+            self.assertEqual(tiledb.object_type(uri), "array")
+        tiledb.Array.delete_array(uri)
+
+        # Group case
+        tiledb.group_create(uri)
+        self.assertEqual(tiledb.object_type(uri), "group")


### PR DESCRIPTION
Following the changes in https://github.com/TileDB-Inc/TileDB-Py/pull/2049, `object_type` now returns the string `'None'` instead of the `<class 'NoneType'>` object. This PR fixes the issue and adds a new test for this case.

The output of the new test with the old `object_type` method:

```
=========================================================================== test session starts ============================================================================
platform darwin -- Python 3.11.9, pytest-8.3.1, pluggy-1.5.0
rootdir: /Users/agis/TileDB_workspace/TileDB-Py
configfile: pyproject.toml
plugins: hypothesis-6.108.4
collected 6 items / 5 deselected / 1 selected                                                                                                                              

tiledb/tests/test_util.py::UtilTest::test_object_type FAILED                                                                                                         [100%]

================================================================================= FAILURES =================================================================================
________________________________________________________________________ UtilTest.test_object_type _________________________________________________________________________

self = <tiledb.tests.test_util.UtilTest object at 0x106c8c650>

    def test_object_type(self):
        uri = self.path("test_object_type")
    
        # None case
>       self.assertIsNone(tiledb.object_type(uri))

tiledb/tests/test_util.py:173: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../anaconda3/envs/py11tiledb/lib/python3.11/contextlib.py:301: in helper
    return _GeneratorContextManager(func, args, kwds)
../../anaconda3/envs/py11tiledb/lib/python3.11/contextlib.py:105: in __init__
    self.gen = func(*args, **kwds)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tiledb.tests.test_util.UtilTest object at 0x106c8c650>, a1 = 'None'

    @contextlib.contextmanager
    def assertIsNone(self, a1):
>       assert a1 is None
E       AssertionError

tiledb/tests/common.py:183: AssertionError
========================================================================= short test summary info ==========================================================================
FAILED tiledb/tests/test_util.py::UtilTest::test_object_type - AssertionError
===================================================================== 1 failed, 5 deselected in 0.17s ======================================================================
```

---

[sc-55930]