### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -96,7 +96,7 @@ jobs:
           - macos-14
           - windows-2022
           - ubuntu-22.04
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           # libfaketime tests fail on macos arm. Disable tests for now.
           # - macos-14
           - windows-latest
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     env:
       MACOSX_DEPLOYMENT_TARGET: "11"

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, macos-14, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
           # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
           - python-version: "3.12"
@@ -39,8 +39,6 @@ jobs:
             numpy-version: "2.0.1"
           - python-version: "3.9"
             numpy-version: "1.25.2"
-          - python-version: "3.8"
-            numpy-version: "1.21.6"
       fail-fast: false
     env:
       TILEDB_VERSION: ${{ inputs.libtiledb_version }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.12"
 
 sphinx:
   configuration: doc/source/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,12 @@ requires = [
     "scikit-build-core",
     "pybind11",
     "Cython>=3",
-    "numpy==1.17.* ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'",
-    "numpy==1.19.* ; python_version == '3.8' and platform_machine == 'aarch64'",
-    "numpy==1.21.* ; python_version == '3.8' and platform_machine == 'arm64'",
-    "numpy>=2.0.1 ; python_version >= '3.9'"
+    "numpy>=2.0.1"
 ]
 build-backend = "scikit_build_core.build"
 
 [project]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 name = "tiledb"
 description = "Pythonic interface to the TileDB array storage manager"
 readme = "README.md"
@@ -34,17 +31,13 @@ classifiers=[
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-  "numpy>=1.17 ; python_version == '3.8' and platform_machine not in 'arm64|aarch64'",
-  "numpy>=1.19 ; python_version == '3.8' and platform_machine == 'aarch64'",
-  "numpy>=1.21 ; python_version == '3.8' and platform_machine == 'arm64'",
-  "numpy>=1.25 ; python_version >= '3.9'",
+  "numpy>=1.25",
   "packaging",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
This PR removes support for TileDB-Py on Python 3.8. Some reasons are:
- Python 3.8 reaches end-of-life in October 2024: https://devguide.python.org/versions/#supported-versions
- Continuing support for Python 3.8 has become untenable because NumPy [no longer supports it](https://pypi.org/project/numpy/1.26.4/#files)
- Reducing the number of wheels will decrease overall maintenance costs

---

[sc-48532]