### PR TITLE
Raise error when `sparse=True` is passed to `tiledb.from_numpy`

### DIFF
--- a/tiledb/highlevel.py
+++ b/tiledb/highlevel.py
@@ -114,6 +114,10 @@ def from_numpy(uri, array, config=None, ctx=None, **kwargs):
     ctx = _get_ctx(ctx, config)
     mode = kwargs.pop("mode", "ingest")
     timestamp = kwargs.pop("timestamp", None)
+    sparse = kwargs.pop("sparse", False)
+
+    if sparse:
+        raise tiledb.TileDBError("from_numpy only supports dense arrays")
 
     if mode not in ("ingest", "schema_only", "append"):
         raise tiledb.TileDBError(f"Invalid mode specified ('{mode}')")

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -282,6 +282,14 @@ class FixesTest(DiskTestCase):
         a = tiledb.Group("mem://tmp1")
         repr(a.meta)
 
+    def test_sc56611(self):
+        # test from_numpy with sparse argument set to True
+        uri = self.path("test_sc56611")
+        data = np.random.rand(10, 10)
+        with pytest.raises(tiledb.cc.TileDBError) as exc_info:
+            tiledb.from_numpy(uri, data, sparse=True)
+        assert str(exc_info.value) == "from_numpy only supports dense arrays"
+
 
 class SOMA919Test(DiskTestCase):
     """


### PR DESCRIPTION
`tiledb.from_numpy` is supposed to only return a `DenseArray` and docs are explicit about it. We should check that especially before the `tiledb.Array.create` call because it will create a `SparseArray` but then not be able to write to it. The current error obscures what the actual problem is.

current error message with `sparse=True`: `AttributeError: 'tiledb.libtiledb.SparseArrayImpl' object has no attribute 'write_direct'`
error message after this PR with `sparse=True`: `tiledb.cc.TileDBError: from_numpy only supports dense arrays`

---

[sc-56611]