### PR TITLE
Do not run CI in PR twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: TileDB Python CI
 
-on: [push, pull_request, workflow_dispatch]
+on: 
+  push:
+    branches: [dev]
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
This PR should disable double CI run in all TileDB-Py PRs.
![1728041088_grim](https://github.com/user-attachments/assets/9a629343-4aad-4ab6-885c-4bee37b225dd)
