### PR TITLE
Fix skipif condition for `test_save_and_open_array_from_cloud`

### DIFF
--- a/tiledb/tests/test_cloud.py
+++ b/tiledb/tests/test_cloud.py
@@ -15,7 +15,10 @@ s3_bucket = os.getenv("S3_BUCKET")
 
 
 @pytest.mark.skipif(
-    not os.getenv("CI") and tiledb_token is None,
+    os.getenv("CI") == None
+    or tiledb_token == None
+    or tiledb_namespace == None
+    or s3_bucket == None,
     reason="No token was provided in a non-CI environment. Please set the TILEDB_TOKEN environment variable to run this test.",
 )
 class CloudTest(DiskTestCase):


### PR DESCRIPTION
This PR makes the skip-if condition for `test_save_and_open_array_from_cloud` stricter by requiring both a CI environment and each environment variable that it utilizes.

Should fix the related error in https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/24
cc @jdblischak 