### PR TITLE
Extend the `GroupMetadata` functionality to support NumPy arrays

### DIFF
--- a/tiledb/cc/group.cc
+++ b/tiledb/cc/group.cc
@@ -27,9 +27,9 @@ void put_metadata_numpy(Group &group, const std::string &key, py::array value) {
 
   py::size_t ncells = get_ncells(value.dtype());
   if (ncells != 1)
-    throw py::type_error(py::str(py::str("Unsupported dtype '") +
-                                 py::str(value.dtype()) +
-                                 py::str("' for metadata")));
+    throw py::type_error("Unsupported dtype '" +
+                         std::string(py::str(value.dtype())) +
+                         "' for metadata");
 
   auto value_num = is_tdb_str(value_type) ? value.nbytes() : value.size();
   group.put_metadata(key, value_type, value_num,
@@ -66,20 +66,12 @@ py::object unpack_metadata_val(tiledb_datatype_t value_type, uint32_t value_num,
     throw TileDBError("internal error: unexpected value_num==0");
 
   if (value_type == TILEDB_STRING_UTF8) {
-    if (value_ptr == nullptr)
-      return py::str();
-    else {
-      return py::str(value_ptr, value_num);
-    }
+    return value_ptr == nullptr ? py::str() : py::str(value_ptr, value_num);
   }
 
   if (value_type == TILEDB_BLOB || value_type == TILEDB_CHAR ||
       value_type == TILEDB_STRING_ASCII) {
-    if (value_ptr == nullptr)
-      return py::bytes();
-    else {
-      return py::bytes(value_ptr, value_num);
-    }
+    return value_ptr == nullptr ? py::bytes() : py::bytes(value_ptr, value_num);
   }
 
   if (value_ptr == nullptr)

--- a/tiledb/cc/group.cc
+++ b/tiledb/cc/group.cc
@@ -22,16 +22,14 @@ void put_metadata_numpy(Group &group, const std::string &key, py::array value) {
     throw py::type_error(e.what());
   }
 
-  if (is_tdb_str(value_type) && value.size() > 1)
-    throw py::type_error("array/list of strings not supported");
-
-  py::buffer_info value_buffer = value.request();
-  if (value_buffer.ndim != 1)
+  if (value.ndim() != 1)
     throw py::type_error("Only 1D Numpy arrays can be stored as metadata");
 
   py::size_t ncells = get_ncells(value.dtype());
   if (ncells != 1)
-    throw py::type_error("Unsupported dtype for metadata");
+    throw py::type_error(py::str(py::str("Unsupported dtype '") +
+                                 py::str(value.dtype()) +
+                                 py::str("' for metadata")));
 
   auto value_num = is_tdb_str(value_type) ? value.nbytes() : value.size();
   group.put_metadata(key, value_type, value_num,
@@ -40,8 +38,10 @@ void put_metadata_numpy(Group &group, const std::string &key, py::array value) {
 
 void put_metadata(Group &group, const std::string &key,
                   tiledb_datatype_t value_type, uint32_t value_num,
-                  const char *value) {
-  group.put_metadata(key, value_type, value_num, value);
+                  py::buffer &value) {
+
+  py::buffer_info info = value.request();
+  group.put_metadata(key, value_type, value_num, info.ptr);
 }
 
 bool has_metadata(Group &group, const std::string &key) {
@@ -60,28 +60,110 @@ std::string get_key_from_index(Group &group, uint64_t index) {
   return key;
 }
 
-py::tuple get_metadata(Group &group, const std::string &key) {
+py::object unpack_metadata_val(tiledb_datatype_t value_type, uint32_t value_num,
+                               const char *value_ptr) {
+  if (value_num == 0)
+    throw TileDBError("internal error: unexpected value_num==0");
+
+  if (value_type == TILEDB_STRING_UTF8) {
+    if (value_ptr == nullptr)
+      return py::str();
+    else {
+      return py::str(value_ptr, value_num);
+    }
+  }
+
+  if (value_type == TILEDB_BLOB || value_type == TILEDB_CHAR ||
+      value_type == TILEDB_STRING_ASCII) {
+    if (value_ptr == nullptr)
+      return py::bytes();
+    else {
+      return py::bytes(value_ptr, value_num);
+    }
+  }
+
+  if (value_ptr == nullptr)
+    return py::tuple();
+
+  py::tuple unpacked(value_num);
+  for (uint32_t i = 0; i < value_num; i++) {
+    switch (value_type) {
+    case TILEDB_INT64:
+      unpacked[i] = *((int64_t *)value_ptr);
+      break;
+    case TILEDB_FLOAT64:
+      unpacked[i] = *((double *)value_ptr);
+      break;
+    case TILEDB_FLOAT32:
+      unpacked[i] = *((float *)value_ptr);
+      break;
+    case TILEDB_INT32:
+      unpacked[i] = *((int32_t *)value_ptr);
+      break;
+    case TILEDB_UINT32:
+      unpacked[i] = *((uint32_t *)value_ptr);
+      break;
+    case TILEDB_UINT64:
+      unpacked[i] = *((uint64_t *)value_ptr);
+      break;
+    case TILEDB_INT8:
+      unpacked[i] = *((int8_t *)value_ptr);
+      break;
+    case TILEDB_UINT8:
+      unpacked[i] = *((uint8_t *)value_ptr);
+      break;
+    case TILEDB_INT16:
+      unpacked[i] = *((int16_t *)value_ptr);
+      break;
+    case TILEDB_UINT16:
+      unpacked[i] = *((uint16_t *)value_ptr);
+      break;
+    default:
+      throw TileDBError("TileDB datatype not supported");
+    }
+    value_ptr += tiledb_datatype_size(value_type);
+  }
+
+  if (value_num > 1)
+    return unpacked;
+
+  // for single values, return the value directly
+  return unpacked[0];
+}
+
+py::array unpack_metadata_ndarray(tiledb_datatype_t value_type,
+                                  uint32_t value_num, const char *value_ptr) {
+  py::dtype dtype = tdb_to_np_dtype(value_type, 1);
+
+  if (value_ptr == nullptr) {
+    auto np = py::module::import("numpy");
+    return np.attr("empty")(py::make_tuple(0), dtype);
+  }
+
+  // special case for TILEDB_STRING_UTF8: TileDB assumes size=1
+  if (value_type != TILEDB_STRING_UTF8) {
+    value_num *= tiledb_datatype_size(value_type);
+  }
+
+  auto buf = py::memoryview::from_memory(value_ptr, value_num);
+
+  auto np = py::module::import("numpy");
+  return np.attr("frombuffer")(buf, dtype);
+}
+
+py::tuple get_metadata(Group &group, const py::str &key, bool is_ndarray) {
   tiledb_datatype_t tdb_type;
   uint32_t value_num;
-  const void *value;
+  const char *value_ptr;
 
-  group.get_metadata(key, &tdb_type, &value_num, &value);
-
-  py::dtype value_type = tdb_to_np_dtype(tdb_type, 1);
-
-  py::array py_buf;
-  if (value == nullptr) {
-    py_buf = py::array(value_type, 0);
-    return py::make_tuple(py_buf, tdb_type);
+  group.get_metadata(key, &tdb_type, &value_num, (const void **)&value_ptr);
+  if (is_ndarray) {
+    auto arr = unpack_metadata_ndarray(tdb_type, value_num, value_ptr);
+    return py::make_tuple(arr, tdb_type);
+  } else {
+    auto arr = unpack_metadata_val(tdb_type, value_num, value_ptr);
+    return py::make_tuple(arr, tdb_type);
   }
-
-  if (tdb_type == TILEDB_STRING_UTF8) {
-    value_type = py::dtype("|S1");
-  }
-
-  py_buf = py::array(value_type, value_num, value);
-
-  return py::make_tuple(py_buf, tdb_type);
 }
 
 bool has_member(Group &group, std::string obj) {

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -237,7 +237,7 @@ class Group(CtxMixin, lt.Group):
                 # else: ignore the shape keys
 
         def __repr__(self):
-            return str(dict(self._iter(keys_only=False)))
+            return str(dict(self))
 
         def setdefault(self, key, default=None):
             raise NotImplementedError(

--- a/tiledb/group.py
+++ b/tiledb/group.py
@@ -116,6 +116,8 @@ class Group(CtxMixin, lt.Group):
                 flat_value = value.ravel()
                 put_metadata(f"{Group._NP_DATA_PREFIX}{key}", flat_value)
                 if value.shape != flat_value.shape:
+                    # If the value is not a 1D ndarray, store its associated shape.
+                    # The value's shape will be stored as separate metadata with the correct prefix.
                     self.__setitem__(f"{Group._NP_SHAPE_PREFIX}{key}", value.shape)
             else:
                 from .metadata import pack_metadata_val

--- a/tiledb/tests/cc/test_group.py
+++ b/tiledb/tests/cc/test_group.py
@@ -23,9 +23,9 @@ def test_group_metadata(tmp_path):
     grp._open(lt.QueryType.READ)
     assert grp._metadata_num() == 2
     assert grp._has_metadata("int")
-    assert_array_equal(grp._get_metadata("int")[0], int_data)
+    assert_array_equal(grp._get_metadata("int", False)[0], int_data)
     assert grp._has_metadata("flt")
-    assert_array_equal(grp._get_metadata("flt")[0], flt_data)
+    assert_array_equal(grp._get_metadata("flt", False)[0], flt_data)
     grp._close()
 
     time.sleep(0.001)

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -585,6 +585,59 @@ class GroupMetadataTest(GroupTestCase):
         self.assert_metadata_roundtrip(grp.meta, test_vals)
         grp.close()
 
+    @given(st_metadata, st_ndarray)
+    @settings(deadline=None)
+    def test_numpy(self, test_vals, ndarray):
+        test_vals["ndarray"] = ndarray
+
+        path = self.path()
+        tiledb.Group.create(path)
+
+        grp = tiledb.Group(path, "w")
+        grp.meta.update(test_vals)
+        grp.close()
+
+        grp = tiledb.Group(path, "r")
+        self.assert_metadata_roundtrip(grp.meta, test_vals)
+        grp.close()
+
+        grp = tiledb.Group(path, "w")
+        grp.meta["ndarray"] = 42
+        test_vals["ndarray"] = 42
+        grp.close()
+
+        grp = tiledb.Group(path, "r")
+        self.assert_metadata_roundtrip(grp.meta, test_vals)
+        grp.close()
+
+        # test resetting a key with a non-ndarray value to a ndarray value
+        grp = tiledb.Group(path, "w")
+        grp.meta["bytes"] = ndarray
+        test_vals["bytes"] = ndarray
+        grp.close()
+
+        grp = tiledb.Group(path, "r")
+        self.assert_metadata_roundtrip(grp.meta, test_vals)
+        grp.close()
+
+        grp = tiledb.Group(path, "w")
+        del grp.meta["ndarray"]
+        del test_vals["ndarray"]
+        grp.close()
+
+        grp = tiledb.Group(path, "r")
+        self.assert_metadata_roundtrip(grp.meta, test_vals)
+        grp.close()
+
+        grp = tiledb.Group(path, "w")
+        test_vals.update(ndarray=np.stack([ndarray, ndarray]), transp=ndarray.T)
+        grp.meta.update(ndarray=np.stack([ndarray, ndarray]), transp=ndarray.T)
+        grp.close()
+
+        grp = tiledb.Group(path, "r")
+        self.assert_metadata_roundtrip(grp.meta, test_vals)
+        grp.close()
+
     @pytest.mark.parametrize("use_timestamps", [True, False])
     def test_consolidation_and_vac(self, use_timestamps):
         vfs = tiledb.VFS()

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -726,12 +726,23 @@ class GroupMetadataTest(GroupTestCase):
         with pytest.raises(TypeError) as exc:
             grp.meta["abc"] = np.array(["foo", "12345"])
 
-        grp.meta["abc"] = np.array(["1", "2", "3", "f", "o", "o"])
+        grp.meta["abc"] = np.array(["1", "2", "3", "f", "o", "o"], dtype="U1")
         grp.close()
 
         grp = tiledb.Group(uri, "r")
         self.assert_metadata_roundtrip(
-            grp.meta, {"abc": np.array(["1", "2", "3", "f", "o", "o"])}
+            grp.meta, {"abc": np.array(["1", "2", "3", "f", "o", "o"], dtype="U1")}
+        )
+        grp.close()
+
+        grp = tiledb.Group(uri, "w")
+        grp.meta["abc"] = np.array(["T", "i", "l", "e", "D", "B", "!"], dtype="S1")
+        grp.close()
+
+        grp = tiledb.Group(uri, "r")
+        self.assert_metadata_roundtrip(
+            grp.meta,
+            {"abc": np.array([b"T", b"i", b"l", b"e", b"D", b"B", b"!"], dtype="S1")},
         )
         grp.close()
 

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -691,7 +691,7 @@ class GroupMetadataTest(GroupTestCase):
         assert len(vfs.ls(meta_path)) == 1
 
     def test_string_metadata(self, capfd):
-        # this tests ensures that string metadata is correctly stored and
+        # this test ensures that string metadata is correctly stored and
         # retrieved from the metadata store. It also tests that the metadata
         # dump method works correctly for string metadata.
         uri = self.path("test_ascii_metadata")
@@ -708,7 +708,7 @@ class GroupMetadataTest(GroupTestCase):
         grp.close()
 
     def test_array_or_list_of_strings_metadata_error(self):
-        # this tests ensures that an error is raised when trying to store
+        # this test ensures that an error is raised when trying to store
         # an array or list of strings as metadata in a group.
         # numpy arrays of single characters are supported since we don't need
         # any extra offset information to retrieve them.
@@ -736,7 +736,7 @@ class GroupMetadataTest(GroupTestCase):
         grp.close()
 
     def test_bytes_metadata(self, capfd):
-        # this tests ensures that bytes metadata is correctly stored and
+        # this test ensures that bytes metadata is correctly stored and
         # retrieved from the metadata store. It also tests that the metadata
         # dump method works correctly for bytes metadata.
         path = self.path()


### PR DESCRIPTION
Even though the `GroupMetadata` and `Metadata` (used by the `Array` class) classes  utilize the same underlying code (similar C++ APIs), it was found that `GroupMetadata` does not support NumPy arrays and also lacks tests for handling such data.

This PR extends the functionality of `GroupMetadata` to handle the same data as `Metadata` and includes tests for the changes.

The modifications were made so that `GroupMetadata` uses only pybind11 and Python, without any Cython. In a future follow-up PR, the Cython `Metadata` class will be removed, and `GroupMetadata` will be renamed to `Metadata`. Additionally, the pybind11 code will be moved to a separate `metadata.cc` file. The new class will be shared across Array and Group classes.

---

[sc-57551]