### PR TITLE
Make error message for non-existing `Enumeration` in test conditional

### DIFF
--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -93,7 +93,7 @@ class EnumerationTest(DiskTestCase):
             with self.assertRaises(tiledb.TileDBError) as excinfo:
                 assert A.enum("enmr3") == []
             assert (
-                "ArraySchema: Unable to check if unknown enumeration is loaded. No enumeration named 'enmr3'."
+                "Array: Unable to get enumeration; Enumeration 'enmr3' does not exist."
                 == str(excinfo.value)
             )
             assert attr3.enum_label is None

--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -92,10 +92,16 @@ class EnumerationTest(DiskTestCase):
 
             with self.assertRaises(tiledb.TileDBError) as excinfo:
                 assert A.enum("enmr3") == []
-            assert (
-                "Array: Unable to get enumeration; Enumeration 'enmr3' does not exist."
-                == str(excinfo.value)
-            )
+            if tiledb.libtiledb.version() >= (2, 27):
+                assert (
+                    "Array: Unable to get enumeration; Enumeration 'enmr3' does not exist."
+                    == str(excinfo.value)
+                )
+            else:
+                assert (
+                    "ArraySchema: Unable to check if unknown enumeration is loaded. No enumeration named 'enmr3'."
+                    == str(excinfo.value)
+                )
             assert attr3.enum_label is None
             assert A.attr("attr3").enum_label is None
 


### PR DESCRIPTION
Should fix the related error in https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/24
cc @jdblischak 