### PR TITLE
Add CI to test against the TileDB core library built from source with a custom version

### DIFF
--- a/.github/workflows/ci-tiledb-from-source.yml
+++ b/.github/workflows/ci-tiledb-from-source.yml
@@ -6,6 +6,8 @@ on:
       libtiledb_ref:
         default: dev
         type: string
+      libtiledb_version:
+        type: string
   pull_request:
 
 jobs:
@@ -37,7 +39,7 @@ jobs:
 
       - name: Build TileDB
         env:
-          TILEDB_PACKAGE_VERSION: ${{ github.head_ref || github.ref_name }}
+          TILEDB_PACKAGE_VERSION: ${{ inputs.libtiledb_version || '0.1' }}
         run: cmake --build build --config Release --target package
 
       - name: Upload TileDB Core Artifact

--- a/.github/workflows/ci-tiledb-from-source.yml
+++ b/.github/workflows/ci-tiledb-from-source.yml
@@ -8,7 +8,6 @@ on:
         type: string
       libtiledb_version:
         type: string
-  pull_request:
 
 jobs:
 

--- a/.github/workflows/ci-tiledb-from-source.yml
+++ b/.github/workflows/ci-tiledb-from-source.yml
@@ -13,11 +13,11 @@ jobs:
   build_libtiledb:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout TileDB Core ${{ inputs.libtiledb_ref || dev }}
+      - name: Checkout TileDB Core ${{ inputs.libtiledb_ref || 'dev' }}
         uses: actions/checkout@v4
         with:
           repository: TileDB-Inc/TileDB
-          ref: ${{ inputs.libtiledb_ref || dev }}
+          ref: ${{ inputs.libtiledb_ref || 'dev' }}
 
       - name: Configure TileDB
         run: |

--- a/.github/workflows/ci-tiledb-from-source.yml
+++ b/.github/workflows/ci-tiledb-from-source.yml
@@ -6,17 +6,18 @@ on:
       libtiledb_ref:
         default: dev
         type: string
+  pull_request:
 
 jobs:
 
   build_libtiledb:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout TileDB Core ${{ inputs.libtiledb_ref }}
+      - name: Checkout TileDB Core ${{ inputs.libtiledb_ref || dev }}
         uses: actions/checkout@v4
         with:
           repository: TileDB-Inc/TileDB
-          ref: ${{ inputs.libtiledb_ref }}
+          ref: ${{ inputs.libtiledb_ref || dev }}
 
       - name: Configure TileDB
         run: |

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -6,6 +6,9 @@ on:
       libtiledb_ref:
         default: dev
         type: string
+      libtiledb_version:
+        required: true
+        type: string
 
 jobs:
 
@@ -35,6 +38,8 @@ jobs:
             -DVCPKG_TARGET_TRIPLET=x64-linux-release
 
       - name: Build TileDB
+        env:
+          TILEDB_PACKAGE_VERSION: ${{ input.libtiledb_version }}
         run: cmake --build build --config Release --target package
 
       - name: Upload TileDB Core Artifact

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -72,15 +72,12 @@ jobs:
       - name: Unpack Release Archive
         run: tar xvf ${{ github.workspace }}/libtiledb/*.tar.gz --directory ${{ github.workspace }}/libtiledb
 
-      - name: "DBG: LIST"
-        run: ls -laR ${{ github.workspace }}/libtiledb
-
       - name: Build TileDB-Py Wheel
         env:
           TILEDB_PATH: ${{ github.workspace }}/libtiledb
         run: |
           python -m pip wheel -w dist --verbose .
-          python -m pip install tiledb-*.whl
+          python -m pip install dist/tiledb-*.whl[test]
 
       - name: Upload TileDB Core Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -60,6 +60,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Checkout TileDB-Py
+        uses: actions/checkout@v4
+
       - name: Download TileDB Core Artifact
         uses: actions/download-artifact@v4
         with:
@@ -68,9 +71,6 @@ jobs:
 
       - name: Unpack Release Archive
         run: tar xvf ${{ github.workspace }}/libtiledb/*.tar.gz --directory ${{ github.workspace }}/libtiledb
-
-      - name: Checkout TileDB-Py
-        uses: actions/checkout@v4
 
       - name: "DBG: LIST"
         run: ls -laR ${{ github.workspace }}/libtiledb

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -77,6 +77,6 @@ jobs:
 
       - name: Build TileDB-Py Wheel
         env:
-          TILEDB_PATH: ${{ github.workspace }}/libtiledb
+          TILEDB_PATH: ${{ github.workspace }}/libtiledb/lib
         run: python -m pip install --verbose .[test]
         # - name: Upload TileDB Py Wheel

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -67,7 +67,7 @@ jobs:
           path: ${{ github.workspace }}/libtiledb
 
       - name: Unpack Release Archive
-        run: tar xvf ${{ github.workspace }}/libtiledb/*.tar.gz --strip-components=1 --directory ${{ github.workspace }}/libtiledb
+        run: tar xvf ${{ github.workspace }}/libtiledb/*.tar.gz --directory ${{ github.workspace }}/libtiledb
 
       - name: "DBG: LIST"
         run: ls -la ${{ github.workspace }}/libtiledb

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -67,7 +67,7 @@ jobs:
           path: ${{ github.workspace }}/libtiledb
 
       - name: Unpack Release Archive
-        run: tar -xf --strip-components=1 ${{ github.workspace }}/libtiledb/*.tar.gz
+        run: tar xvf ${{ github.workspace }}/libtiledb/*.tar.gz --strip-components=1
 
       - name: "DBG: LIST"
         run: ls -la ${{ github.workspace }}/libtiledb

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -1,0 +1,74 @@
+name: TileDB Python CI Using TileDB Core Source Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      libtiledb_ref:
+        default: dev
+        type: string
+
+jobs:
+
+  build_libtiledb:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout TileDB Core ${{ inputs.libtiledb_ref }}
+        uses: actions/checkout@v4
+        with:
+          repository: TileDB/TileDB
+          ref: ${{ inputs.libtiledb_ref }}
+
+      - name: Configure TileDB
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DCMAKE_INSTALL_PREFIX=./dist \
+            -DTILEDB_INSTALL_LIBDIR=lib \
+            -DTILEDB_S3=ON \
+            -DTILEDB_AZURE=ON \
+            -DTILEDB_GCS=ON \
+            -DTILEDB_HDFS=ON \
+            -DTILEDB_SERIALIZATION=ON \
+            -DTILEDB_WEBP=ON \
+            -DTILEDB_TESTS=OFF \
+            -DVCPKG_TARGET_TRIPLET=x64-linux-release
+
+      - name: Build TileDB
+        run: cmake --build build --config Release --target package
+
+      - name: Upload TileDB Core Artifact
+        uses: actions/upload-artifacts@v4
+        with:
+          name: libtiledb
+          path: |
+            build/tiledb-*.tar.gz*
+            build/tiledb-*.zip*
+
+  build_tiledb_py:
+    needs:
+      - build_libtiledb
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download TileDB Core Artifact
+        uses: actions/download-artifacts@v4
+        with:
+          name: libtiledb
+          path: ${{ github.workspace }}/libtiledb
+
+      - name: "DBG: LIST"
+        run: ls -la ${{ github.workspace }}/libtiledb
+
+      - name: Checkout TileDB-Py
+        uses: actions/checkout@v4
+
+      - name: Build TileDB-Py Wheel
+        env:
+          TILEDB_PATH: ${{ github.workspace }}/libtiledb
+        run: python -m pip install --verbose .[test]
+        # - name: Upload TileDB Py Wheel

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -38,7 +38,7 @@ jobs:
         run: cmake --build build --config Release --target package
 
       - name: Upload TileDB Core Artifact
-        uses: actions/upload-artifacts@v4
+        uses: actions/upload-artifact@v4
         with:
           name: libtiledb
           path: |
@@ -56,7 +56,7 @@ jobs:
           python-version: "3.11"
 
       - name: Download TileDB Core Artifact
-        uses: actions/download-artifacts@v4
+        uses: actions/download-artifact@v4
         with:
           name: libtiledb
           path: ${{ github.workspace }}/libtiledb

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -70,7 +70,7 @@ jobs:
         run: tar xvf ${{ github.workspace }}/libtiledb/*.tar.gz --directory ${{ github.workspace }}/libtiledb
 
       - name: "DBG: LIST"
-        run: ls -la ${{ github.workspace }}/libtiledb
+        run: ls -laR ${{ github.workspace }}/libtiledb
 
       - name: Checkout TileDB-Py
         uses: actions/checkout@v4

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build TileDB
         env:
-          TILEDB_PACKAGE_VERSION: ${{ input.libtiledb_version }}
+          TILEDB_PACKAGE_VERSION: ${{ inputs.libtiledb_version }}
         run: cmake --build build --config Release --target package
 
       - name: Upload TileDB Core Artifact

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -77,7 +77,7 @@ jobs:
           TILEDB_PATH: ${{ github.workspace }}/libtiledb
         run: |
           python -m pip wheel -w dist --verbose .
-          python -m pip install dist/tiledb-*.whl[test]
+          python -m pip install dist/tiledb-*.whl
 
       - name: Upload TileDB Core Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -66,6 +66,9 @@ jobs:
           name: libtiledb
           path: ${{ github.workspace }}/libtiledb
 
+      - name: Unpack Release Archive
+        run: tar -xf --strip-components=1 ${{ github.workspace }}/libtiledb/*.tar.gz
+
       - name: "DBG: LIST"
         run: ls -la ${{ github.workspace }}/libtiledb
 

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -67,7 +67,7 @@ jobs:
           path: ${{ github.workspace }}/libtiledb
 
       - name: Unpack Release Archive
-        run: tar xvf ${{ github.workspace }}/libtiledb/*.tar.gz --strip-components=1
+        run: tar xvf ${{ github.workspace }}/libtiledb/*.tar.gz --strip-components=1 --directory ${{ github.workspace }}/libtiledb
 
       - name: "DBG: LIST"
         run: ls -la ${{ github.workspace }}/libtiledb

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -6,9 +6,6 @@ on:
       libtiledb_ref:
         default: dev
         type: string
-      libtiledb_version:
-        required: true
-        type: string
 
 jobs:
 
@@ -39,7 +36,7 @@ jobs:
 
       - name: Build TileDB
         env:
-          TILEDB_PACKAGE_VERSION: ${{ inputs.libtiledb_version }}
+          TILEDB_PACKAGE_VERSION: ${{ github.head_ref || github.ref_name }}
         run: cmake --build build --config Release --target package
 
       - name: Upload TileDB Core Artifact

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -77,7 +77,8 @@ jobs:
           TILEDB_PATH: ${{ github.workspace }}/libtiledb
         run: |
           python -m pip wheel -w dist --verbose .
-          python -m pip install dist/tiledb-*.whl
+          WHEEL=$(ls dist/tiledb-*.whl)
+          python -m pip install ${WHEEL}[test]
 
       - name: Upload TileDB Core Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -69,14 +69,14 @@ jobs:
       - name: Unpack Release Archive
         run: tar xvf ${{ github.workspace }}/libtiledb/*.tar.gz --directory ${{ github.workspace }}/libtiledb
 
-      - name: "DBG: LIST"
-        run: ls -laR ${{ github.workspace }}/libtiledb
-
       - name: Checkout TileDB-Py
         uses: actions/checkout@v4
 
+      - name: "DBG: LIST"
+        run: ls -laR ${{ github.workspace }}/libtiledb
+
       - name: Build TileDB-Py Wheel
         env:
-          TILEDB_PATH: ${{ github.workspace }}/libtiledb/lib
+          TILEDB_PATH: ${{ github.workspace }}/libtiledb
         run: python -m pip install --verbose .[test]
         # - name: Upload TileDB Py Wheel

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -78,5 +78,20 @@ jobs:
       - name: Build TileDB-Py Wheel
         env:
           TILEDB_PATH: ${{ github.workspace }}/libtiledb
-        run: python -m pip install --verbose .[test]
-        # - name: Upload TileDB Py Wheel
+        run: |
+          python -m pip wheel -w dist --verbose .
+          python -m pip install tiledb-*.whl
+
+      - name: Upload TileDB Core Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tiledb-py
+          path: |
+            dist/tiledb-*.whl
+
+      - name: Run tests
+        run: |
+          PROJECT_CWD=$PWD
+          rm tiledb/__init__.py
+          cd /tmp
+          pytest -vv --showlocals $PROJECT_CWD

--- a/.github/workflows/ci_tiledb_from_source.yml
+++ b/.github/workflows/ci_tiledb_from_source.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout TileDB Core ${{ inputs.libtiledb_ref }}
         uses: actions/checkout@v4
         with:
-          repository: TileDB/TileDB
+          repository: TileDB-Inc/TileDB
           ref: ${{ inputs.libtiledb_ref }}
 
       - name: Configure TileDB


### PR DESCRIPTION
There are several PRs that we need to test against a branch of libtiledb, most commonly the `dev` branch, as they implement features/fixes we want to test before the release of the libtiledb binaries.

This PR implements a workflow to test against the TileDB core library built from source using a custom version.

---

[sc-57260]