### PR TITLE
Update HISTORY for 0.32.2 and 0.32.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ if (NOT TileDB_FOUND)
         message(STATUS "Downloading TileDB default version ...")
         # Download latest release
         fetch_prebuilt_tiledb(
-                VERSION 2.26.1
-                RELLIST_HASH SHA256=256216aa989015397f4efbbd319ebeccfead568baa73611aa0c1c0fcea35f8d5
+                VERSION 2.26.2
+                RELLIST_HASH SHA256=86c19d7c5246cb18e370a4272cead63ea84bd651789842e618de4d57d4510522
         )
     endif()
     find_package(TileDB REQUIRED)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
 ## Build system changes
 
-* Pass pretend version to container by @dudoslav in https://github.com/TileDB-Inc/TileDB-Py/pull/2077
+* Override tag version in manylinux container by @dudoslav in https://github.com/TileDB-Inc/TileDB-Py/pull/2077
 
 # Release 0.32.2
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+# Release 0.32.3
+
+* TileDB-Py 0.32.3 includes TileDB Embedded [2.26.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.26.2)
+
+## Build system changes
+
+* Pass pretend version to container by @dudoslav in https://github.com/TileDB-Inc/TileDB-Py/pull/2077
+
 # Release 0.32.2
 
 ## Improvements

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# Release 0.32.2
+
+## Improvements
+
+* Fix object_type return value by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/2073
+
 # Release 0.32.1
 
 * TileDB-Py 0.32.1 includes TileDB Embedded [2.26.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.26.1)


### PR DESCRIPTION
Release branches were needed for `0.32.2` and `0.32.3`. This led to two missing commits on the `dev` branch. These commits have been cherry-picked in this PR's branch.