### PR TITLE
Update enumerations exception message.

### DIFF
--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -92,16 +92,10 @@ class EnumerationTest(DiskTestCase):
 
             with self.assertRaises(tiledb.TileDBError) as excinfo:
                 assert A.enum("enmr3") == []
-            if tiledb.libtiledb.version() >= (2, 27):
-                assert (
-                    "Array: Unable to get enumeration; Enumeration 'enmr3' does not exist."
-                    == str(excinfo.value)
-                )
-            else:
-                assert (
-                    "ArraySchema: Unable to check if unknown enumeration is loaded. No enumeration named 'enmr3'."
-                    == str(excinfo.value)
-                )
+            assert (
+                "ArraySchema: Unable to check if unknown enumeration is loaded. No enumeration named 'enmr3'."
+                == str(excinfo.value)
+            )
             assert attr3.enum_label is None
             assert A.attr("attr3").enum_label is None
 


### PR DESCRIPTION
Unless I missed some testing done on earlier core versions I think we can just remove the version check here since TileDB `dev` has corrected the error message and it will not be present in 2.27.

For context, I had changed this message in [TileDB-Inc/TileDB#5291](https://github.com/TileDB-Inc/TileDB/pull/5291/files#diff-74ce8c89d5884c4961474244d6263b78237ca72ec9e61c9a8268b4fab73b0b53R814-R816) by adding a check earlier in the code with a different message. We essentially decided to revert those changes to fix a performance regression in [TileDB-Inc/TileDB#5349](https://github.com/TileDB-Inc/TileDB/pull/5349/files#diff-74ce8c89d5884c4961474244d6263b78237ca72ec9e61c9a8268b4fab73b0b53L812-L818) so the exception message returned to the previous format.