### PR TITLE
Handle removal of 'StorageManager' from stats dumps in 2.27 - Part 2

### DIFF
--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -3480,7 +3480,8 @@ class GetStatsTest(DiskTestCase):
             T[:] = np.random.randint(10, size=3)
 
         stats = ctx.get_stats(print_out=False)
-        assert "Context.StorageManager.write_store" in stats
+        # check that the stats are non-empty
+        assert stats
 
     def test_query(self):
         tiledb.stats_enable()


### PR DESCRIPTION
Forgot about this in https://github.com/TileDB-Inc/TileDB-Py/pull/2088.

Should fix the related error in https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/24
cc @jdblischak 