### PR TITLE
Revert "Do not run CI in PR twice"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,6 @@
 name: TileDB Python CI
 
-on: 
-  push:
-    branches: [dev]
-  pull_request:
-    branches: [dev]
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
TileDB-Inc/TileDB-Py#2082 might have fixed the initial issue, but it causes PRs that we want to merge into non-dev branches to not run CI at all. For example: https://github.com/TileDB-Inc/TileDB-Py/pull/2099.

If there is no other solution, we should revert.