### PR TITLE
Enable Python 3.13

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -46,7 +46,7 @@ jobs:
           brew install automake pkg-config ninja llvm
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.1
+        uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB S3_BUCKET TILEDB_TOKEN TILEDB_NAMESPACE

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           - [macos-13, macosx_x86_64]
           - [macos-14, macosx_arm64]
           - [windows-2022, win_amd64]
-        python: ["cp39", "cp310", "cp311", "cp312"]
+        python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
           - macos-14
           - windows-2022
           - ubuntu-22.04
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           # libfaketime tests fail on macos arm. Disable tests for now.
           # - macos-14
           - windows-latest
-        python-version: [ "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
       fail-fast: false
     env:
       MACOSX_DEPLOYMENT_TARGET: "11"

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -22,9 +22,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, macos-14, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
+          - python-version: "3.13"
+            numpy-version: "2.1.0"
           - python-version: "3.12"
             numpy-version: "1.26.4"
           - python-version: "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers=[
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
   "numpy>=1.25",


### PR DESCRIPTION
Since October 2024, Python 3.13 has been in "bugfix" mode (also known as "maintenance" or "stable" mode): https://devguide.python.org/versions/#supported-versions.

To add support for TileDB-Py, an upgrade to the latest version of `cibuildwheel` was required, as it supports Python 3.13 and CPython 3.13. (More info: https://github.com/pypa/cibuildwheel/releases)

Testing:
- Wheels workflow: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/11796573304
- Tested locally (manylinux_x86_64) on a fresh conda env with Python 3.13 and works fine!

---

[sc-57688]