### PR TITLE
Remove workaround from `CurrentDomain`/`NDRectangle`

### DIFF
--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -396,11 +396,9 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
 
             :rtype: tiledb.CurrentDomain
             """
-            curr_dom = CurrentDomain.from_pybind11(
+            return CurrentDomain.from_pybind11(
                 self._ctx, self._current_domain(self._ctx)
             )
-            curr_dom._set_domain(self.domain)
-            return curr_dom
 
         def set_current_domain(self, current_domain):
             """Set the current domain

--- a/tiledb/cc/current_domain.cc
+++ b/tiledb/cc/current_domain.cc
@@ -118,87 +118,86 @@ void init_current_domain(py::module &m) {
           py::arg("dim_name"), py::arg("start"), py::arg("end"))
 
       .def("_range",
-           [](NDRectangle &ndrect, const std::string &dim_name,
-              const py::dtype &n_type) -> py::tuple {
-             if (n_type.is(py::dtype::of<uint64_t>())) {
+           [](NDRectangle &ndrect, const std::string &dim_name) -> py::tuple {
+             const tiledb_datatype_t n_type = ndrect.range_dtype(dim_name);
+             if (n_type == TILEDB_UINT64) {
                auto range = ndrect.range<uint64_t>(dim_name);
                return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<int64_t>())) {
+             } else if (n_type == TILEDB_INT64) {
                auto range = ndrect.range<int64_t>(dim_name);
                return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<uint32_t>())) {
+             } else if (n_type == TILEDB_UINT32) {
                auto range = ndrect.range<uint32_t>(dim_name);
                return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<int32_t>())) {
+             } else if (n_type == TILEDB_INT32) {
                auto range = ndrect.range<int32_t>(dim_name);
                return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<uint16_t>())) {
+             } else if (n_type == TILEDB_UINT16) {
                auto range = ndrect.range<uint16_t>(dim_name);
                return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<int16_t>())) {
+             } else if (n_type == TILEDB_INT16) {
                auto range = ndrect.range<int16_t>(dim_name);
                return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<uint8_t>())) {
+             } else if (n_type == TILEDB_UINT8) {
                auto range = ndrect.range<uint8_t>(dim_name);
                return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<int8_t>())) {
+             } else if (n_type == TILEDB_INT8) {
                auto range = ndrect.range<int8_t>(dim_name);
                return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<double>())) {
+             } else if (n_type == TILEDB_FLOAT64) {
                auto range = ndrect.range<double>(dim_name);
                return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<float>())) {
+             } else if (n_type == TILEDB_FLOAT32) {
                auto range = ndrect.range<float>(dim_name);
                return py::make_tuple(range[0], range[1]);
-             } else if (py::getattr(n_type, "kind").is(py::str("S")) ||
-                        py::getattr(n_type, "kind").is(py::str("U"))) {
+             } else if (n_type == TILEDB_STRING_ASCII ||
+                        n_type == TILEDB_STRING_UTF8) {
                auto range = ndrect.range<std::string>(dim_name);
                return py::make_tuple(range[0], range[1]);
              } else {
                TPY_ERROR_LOC("Unsupported type for NDRectangle's range");
              }
            })
-      .def("_range",
-           [](NDRectangle &ndrect, unsigned dim_idx,
-              const py::dtype &n_type) -> py::tuple {
-             if (n_type.is(py::dtype::of<uint64_t>())) {
-               auto range = ndrect.range<uint64_t>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<int64_t>())) {
-               auto range = ndrect.range<int64_t>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<uint32_t>())) {
-               auto range = ndrect.range<uint32_t>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<int32_t>())) {
-               auto range = ndrect.range<int32_t>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<uint16_t>())) {
-               auto range = ndrect.range<uint16_t>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<int16_t>())) {
-               auto range = ndrect.range<int16_t>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<uint8_t>())) {
-               auto range = ndrect.range<uint8_t>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<int8_t>())) {
-               auto range = ndrect.range<int8_t>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<double>())) {
-               auto range = ndrect.range<double>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else if (n_type.is(py::dtype::of<float>())) {
-               auto range = ndrect.range<float>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else if (py::getattr(n_type, "kind").is(py::str("S")) ||
-                        py::getattr(n_type, "kind").is(py::str("U"))) {
-               auto range = ndrect.range<std::string>(dim_idx);
-               return py::make_tuple(range[0], range[1]);
-             } else {
-               TPY_ERROR_LOC("Unsupported type for NDRectangle's range");
-             }
-           });
+      .def("_range", [](NDRectangle &ndrect, unsigned dim_idx) -> py::tuple {
+        const tiledb_datatype_t n_type = ndrect.range_dtype(dim_idx);
+        if (n_type == TILEDB_UINT64) {
+          auto range = ndrect.range<uint64_t>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else if (n_type == TILEDB_INT64) {
+          auto range = ndrect.range<int64_t>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else if (n_type == TILEDB_UINT32) {
+          auto range = ndrect.range<uint32_t>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else if (n_type == TILEDB_INT32) {
+          auto range = ndrect.range<int32_t>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else if (n_type == TILEDB_UINT16) {
+          auto range = ndrect.range<uint16_t>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else if (n_type == TILEDB_INT16) {
+          auto range = ndrect.range<int16_t>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else if (n_type == TILEDB_UINT8) {
+          auto range = ndrect.range<uint8_t>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else if (n_type == TILEDB_INT8) {
+          auto range = ndrect.range<int8_t>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else if (n_type == TILEDB_FLOAT64) {
+          auto range = ndrect.range<double>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else if (n_type == TILEDB_FLOAT32) {
+          auto range = ndrect.range<float>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else if (n_type == TILEDB_STRING_ASCII ||
+                   n_type == TILEDB_STRING_UTF8) {
+          auto range = ndrect.range<std::string>(dim_idx);
+          return py::make_tuple(range[0], range[1]);
+        } else {
+          TPY_ERROR_LOC("Unsupported type for NDRectangle's range");
+        }
+      });
 
   py::class_<CurrentDomain>(m, "CurrentDomain")
       .def(py::init<CurrentDomain>())
@@ -210,14 +209,14 @@ void init_current_domain(py::module &m) {
              return py::capsule(curr_dom.ptr().get(), "curr_dom");
            })
 
+      .def_property_readonly("_is_empty", &CurrentDomain::is_empty)
+
       .def_property_readonly("_type", &CurrentDomain::type)
 
       .def("_set_ndrectangle", &CurrentDomain::set_ndrectangle,
            py::arg("ndrect"))
 
-      .def("_ndrectangle", &CurrentDomain::ndrectangle)
-
-      .def("_is_empty", &CurrentDomain::is_empty);
+      .def("_ndrectangle", &CurrentDomain::ndrectangle);
 #endif
 }
 

--- a/tiledb/current_domain.py
+++ b/tiledb/current_domain.py
@@ -18,9 +18,6 @@ class CurrentDomain(CtxMixin, lt.CurrentDomain):
         """
         super().__init__(ctx)
 
-    def _set_domain(self, domain: Domain):
-        self._domain = domain
-
     @property
     def type(self):
         """The type of the current domain.
@@ -35,7 +32,7 @@ class CurrentDomain(CtxMixin, lt.CurrentDomain):
 
         :rtype: bool
         """
-        return self._is_empty()
+        return self._is_empty
 
     def set_ndrectangle(self, ndrect: NDRectangle):
         """Sets an N-dimensional rectangle representation on a current domain.
@@ -44,7 +41,6 @@ class CurrentDomain(CtxMixin, lt.CurrentDomain):
         :raises tiledb.TileDBError:
         """
         self._set_ndrectangle(ndrect)
-        self._domain = ndrect._get_domain()
 
     @property
     def ndrectangle(self):
@@ -53,6 +49,4 @@ class CurrentDomain(CtxMixin, lt.CurrentDomain):
         :rtype: NDRectangle
         :raises tiledb.TileDBError:
         """
-        ndrect = NDRectangle.from_pybind11(self._ctx, self._ndrectangle())
-        ndrect._set_domain(self._domain)
-        return ndrect
+        return NDRectangle.from_pybind11(self._ctx, self._ndrectangle())

--- a/tiledb/ndrectangle.py
+++ b/tiledb/ndrectangle.py
@@ -19,7 +19,6 @@ class NDRectangle(CtxMixin, lt.NDRectangle):
         :raises tiledb.TileDBError:
         """
         super().__init__(ctx, domain)
-        self._set_domain(domain)
 
     def __str__(self) -> str:
         dimensions_str = ", ".join(
@@ -27,12 +26,6 @@ class NDRectangle(CtxMixin, lt.NDRectangle):
             for i in range(self._domain.ndim)
         )
         return f"NDRectangle({dimensions_str})"
-
-    def _set_domain(self, domain: Domain):
-        self._domain = domain
-
-    def _get_domain(self) -> Domain:
-        return self._domain
 
     def set_range(
         self,
@@ -58,4 +51,4 @@ class NDRectangle(CtxMixin, lt.NDRectangle):
         :return: Range as a tuple (start, end)
         :raises tiledb.TileDBError:
         """
-        return self._range(dim, self._domain.dim(dim).dtype)
+        return self._range(dim)


### PR DESCRIPTION
In https://github.com/TileDB-Inc/TileDB-Py/pull/2015, `CurrentDomain` and `NDRectangle` were wrapped using pybind11. In that PR, a workaround was introduced that involved storing a reference to the underlying `Domain` object to determine the dtype of the dimension of interest (commit of interest: https://github.com/TileDB-Inc/TileDB-Py/pull/2015/commits/63fb4baeb8d36603ce24602f7ba82d416d0e239d).

This PR takes advantage of https://github.com/TileDB-Inc/TileDB/pull/5229 to remove the workaround, thus making the code cleaner at both the Python and pybind11 levels, and reducing the complexity of the Python API.