### PR TITLE
Change default value of `TILEDB_REMOVE_DEPRECATIONS` to `OFF`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ sdist.include = ["tiledb/_generated_version.py"]
 TILEDB_PATH = {env="TILEDB_PATH"}
 TILEDB_VERSION = {env="TILEDB_VERSION"}
 TILEDB_HASH = {env="TILEDB_HASH"}
-TILEDB_REMOVE_DEPRECATIONS = "ON"
+TILEDB_REMOVE_DEPRECATIONS = "OFF"
 TILEDB_SERIALIZATION = "OFF"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Following https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/152, it was decided that nightlies should be the place where we check for deprecations. The goal is to eliminate the use of deprecations over time. To enhance the user experience, TileDB-Py will make use of deprecated functions when necessary until their usage is replaced.