### PR TITLE
Change minimum libtiledb version for `CurrentDomain` to fix daily tests

### DIFF
--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -21,7 +21,7 @@ else:
 
 from tiledb.libtiledb import version as libtiledb_version
 
-if libtiledb_version()[0] == 2 and libtiledb_version()[1] >= 25:
+if libtiledb_version()[0] == 2 and libtiledb_version()[1] >= 26:
     from .current_domain import CurrentDomain
     from .ndrectangle import NDRectangle
 

--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -14,7 +14,7 @@ from .dimension_label import DimLabel
 from .domain import Domain
 from .filter import Filter, FilterList
 
-if libtiledb_version()[0] == 2 and libtiledb_version()[1] >= 25:
+if libtiledb_version()[0] == 2 and libtiledb_version()[1] >= 26:
     from .current_domain import CurrentDomain
 
 _tiledb_order_to_string = {
@@ -388,7 +388,7 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
         """
         return self._has_dim_label(self._ctx, name)
 
-    if libtiledb_version()[0] == 2 and libtiledb_version()[1] >= 25:
+    if libtiledb_version()[0] == 2 and libtiledb_version()[1] >= 26:
 
         @property
         def current_domain(self) -> CurrentDomain:

--- a/tiledb/cc/current_domain.cc
+++ b/tiledb/cc/current_domain.cc
@@ -16,7 +16,7 @@ using namespace tiledbpy::common;
 namespace py = pybind11;
 
 void init_current_domain(py::module &m) {
-#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 25
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 26
   py::class_<NDRectangle>(m, "NDRectangle")
       .def(py::init<NDRectangle>())
 

--- a/tiledb/cc/enum.cc
+++ b/tiledb/cc/enum.cc
@@ -175,7 +175,7 @@ void init_enums(py::module &m) {
       .value("TIFF", TILEDB_MIME_TIFF)
       .value("PDF", TILEDB_MIME_PDF);
 
-#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 25
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 26
   py::enum_<tiledb_current_domain_type_t>(m, "CurrentDomainType")
       .value("NDRECTANGLE", TILEDB_NDRECTANGLE);
 #endif

--- a/tiledb/cc/schema.cc
+++ b/tiledb/cc/schema.cc
@@ -278,7 +278,7 @@ void init_schema(py::module &m) {
              ArraySchemaExperimental::add_enumeration(ctx, schema, enmr);
            })
 
-#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 25
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 26
       .def("_current_domain",
            [](const ArraySchema &schema, const Context &ctx) {
              return ArraySchemaExperimental::current_domain(ctx, schema);

--- a/tiledb/schema_evolution.cc
+++ b/tiledb/schema_evolution.cc
@@ -100,7 +100,7 @@ void init_schema_evolution(py::module &m) {
              }
            })
 
-#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 25
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 26
       .def("expand_current_domain",
            [](ArraySchemaEvolution &inst, py::object current_domain_py) {
              tiledb_current_domain_t *current_domain_c =

--- a/tiledb/schema_evolution.py
+++ b/tiledb/schema_evolution.py
@@ -52,7 +52,7 @@ class ArraySchemaEvolution:
 
         self.ase.extend_enumeration(enmr)
 
-    if libtiledb_version()[0] == 2 and libtiledb_version()[1] >= 25:
+    if libtiledb_version()[0] == 2 and libtiledb_version()[1] >= 26:
         from .current_domain import CurrentDomain
 
         def expand_current_domain(self, current_domain: CurrentDomain):

--- a/tiledb/tests/test_current_domain.py
+++ b/tiledb/tests/test_current_domain.py
@@ -7,9 +7,9 @@ import pytest
 import tiledb
 import tiledb.cc as lt
 
-if not (tiledb.libtiledb.version()[0] == 2 and tiledb.libtiledb.version()[1] >= 25):
+if not (tiledb.libtiledb.version()[0] == 2 and tiledb.libtiledb.version()[1] >= 26):
     pytest.skip(
-        "CurrentDomain is only available in TileDB 2.25 and later",
+        "CurrentDomain is only available in TileDB 2.26 and later",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
The changes in https://github.com/TileDB-Inc/TileDB-Py/pull/2111 caused the daily tests to fail. The error indicates that the latest code is not compatible with the libtiledb 2.25.X binaries, since I make use of `range_dtype` function which was introduced in 2.26.0.

> `error: no member named 'range_dtype' in 'tiledb::NDRectangle'`  
> [Workflow Run](https://github.com/TileDB-Inc/TileDB-Py/actions/runs/12113046765/job/33767415747)

To address this, I suggest updating the required version for the current domain. Manually triggering the workflow for this branch appears to resolve the issue: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/12122419572. Our wheels built against 2.25.X should remain unaffected.

Other possible solutions include:
- Reverting the mentioned PR, which would keep the workaround in our code.  
- Branching out both codebases, though this could lead to a more chaotic structure.

To make something out of this, I would also suggest adding a backward compatibility job to our regular CI, derived from the daily tests, to help prevent similar issues in the future.