### PR TITLE
Fix TypeError: 'FragmentsInfoIterator' object is not iterable

### DIFF
--- a/tiledb/fragment.py
+++ b/tiledb/fragment.py
@@ -188,6 +188,9 @@ class FragmentsInfoIterator:
         self._fragments = fragments
         self._index = 0
 
+    def __iter__(self):
+        return self
+
     def __next__(self):
         if self._index < len(self._fragments):
             fi = FragmentInfo(self._fragments, self._index)


### PR DESCRIPTION
Closes https://github.com/TileDB-Inc/TileDB-Py/issues/2113