### PR TITLE
Eliminate hacky use of timestamps and `time.sleep` in tests

### DIFF
--- a/tiledb/tests/cc/test_group.py
+++ b/tiledb/tests/cc/test_group.py
@@ -28,7 +28,6 @@ def test_group_metadata(tmp_path):
     assert_array_equal(grp._get_metadata("flt", False)[0], flt_data)
     grp._close()
 
-    time.sleep(0.001)
     grp._open(lt.QueryType.WRITE)
     grp._delete_metadata("int")
     grp._close()

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -364,7 +364,7 @@ class SOMA919Test(DiskTestCase):
     We've distilled @atolopko-czi's gist example using the TileDB-Py API directly.
     """
 
-    def run_test(self, use_timestamps):
+    def run_test(self):
         import tempfile
 
         import numpy as np
@@ -372,18 +372,8 @@ class SOMA919Test(DiskTestCase):
         import tiledb
 
         root_uri = tempfile.mkdtemp()
-
-        if use_timestamps:
-            group_ctx100 = tiledb.Ctx(
-                {
-                    "sm.group.timestamp_start": 100,
-                    "sm.group.timestamp_end": 100,
-                }
-            )
-            timestamp = 100
-        else:
-            group_ctx100 = tiledb.Ctx()
-            timestamp = None
+        group_ctx100 = tiledb.Ctx()
+        timestamp = None
 
         # create the group and add a dummy subgroup "causes_bug"
         tiledb.Group.create(root_uri, ctx=group_ctx100)
@@ -411,13 +401,12 @@ class SOMA919Test(DiskTestCase):
         tiledb.libtiledb.version() < (2, 15, 0),
         reason="SOMA919 fix implemented in libtiledb 2.15",
     )
-    @pytest.mark.parametrize("use_timestamps", [True, False])
-    def test_soma919(self, use_timestamps):
+    def test_soma919(self):
         N = 100
         fails = 0
         for i in range(N):
             try:
-                self.run_test(use_timestamps)
+                self.run_test()
             except AssertionError:
                 fails += 1
         if fails > 0:

--- a/tiledb/tests/test_group.py
+++ b/tiledb/tests/test_group.py
@@ -120,10 +120,7 @@ class GroupTest(GroupTestCase):
             ),
         ),
     )
-    @pytest.mark.parametrize("use_timestamps", [True, False])
-    def test_group_metadata(
-        self, int_data, flt_data, str_data, str_type, capfd, use_timestamps
-    ):
+    def test_group_metadata(self, int_data, flt_data, str_data, str_type, capfd):
         def values_equal(lhs, rhs):
             if isinstance(lhs, np.ndarray):
                 if not isinstance(rhs, np.ndarray):
@@ -139,13 +136,13 @@ class GroupTest(GroupTestCase):
         grp_path = self.path("test_group_metadata")
         tiledb.Group.create(grp_path)
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 1} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(grp_path, "w", cfg) as grp:
             grp.meta["int"] = int_data
             grp.meta["flt"] = flt_data
             grp.meta["str"] = str_data
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 1} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(grp_path, "r", cfg) as grp:
             assert len(grp.meta) == 3
             assert "int" in grp.meta
@@ -162,11 +159,11 @@ class GroupTest(GroupTestCase):
             assert "Type: DataType.INT" in metadata_dump
             assert f"Type: DataType.{str_type}" in metadata_dump
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 2} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(grp_path, "w", cfg) as grp:
             del grp.meta["int"]
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 2} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(grp_path, "r", cfg) as grp:
             assert len(grp.meta) == 2
             assert "int" not in grp.meta
@@ -373,8 +370,7 @@ class GroupMetadataTest(GroupTestCase):
             (np.array([1, 2, 3]), np.array([1.5, 2.5, 3.5]), np.array(["x"])),
         ),
     )
-    @pytest.mark.parametrize("use_timestamps", [True, False])
-    def test_group_metadata(self, int_data, flt_data, str_data, use_timestamps):
+    def test_group_metadata(self, int_data, flt_data, str_data):
         def values_equal(lhs, rhs):
             if isinstance(lhs, np.ndarray):
                 if not isinstance(rhs, np.ndarray):
@@ -390,13 +386,13 @@ class GroupMetadataTest(GroupTestCase):
         grp_path = self.path("test_group_metadata")
         tiledb.Group.create(grp_path)
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 1} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(grp_path, "w", cfg) as grp:
             grp.meta["int"] = int_data
             grp.meta["flt"] = flt_data
             grp.meta["str"] = str_data
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 1} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(grp_path, "r", cfg) as grp:
             assert grp.meta.keys() == {"int", "flt", "str"}
             assert len(grp.meta) == 3
@@ -407,11 +403,11 @@ class GroupMetadataTest(GroupTestCase):
             assert "str" in grp.meta
             assert values_equal(grp.meta["str"], str_data)
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 2} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(grp_path, "w", cfg) as grp:
             del grp.meta["int"]
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 2} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(grp_path, "r", cfg) as grp:
             assert len(grp.meta) == 2
             assert "int" not in grp.meta
@@ -641,21 +637,20 @@ class GroupMetadataTest(GroupTestCase):
         self.assert_metadata_roundtrip(grp.meta, test_vals)
         grp.close()
 
-    @pytest.mark.parametrize("use_timestamps", [True, False])
-    def test_consolidation_and_vac(self, use_timestamps):
+    def test_consolidation_and_vac(self):
         vfs = tiledb.VFS()
         path = self.path("test_consolidation_and_vac")
         tiledb.Group.create(path)
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 1} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(path, "w", cfg) as grp:
             grp.meta["meta"] = 1
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 2} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(path, "w", cfg) as grp:
             grp.meta["meta"] = 2
 
-        cfg = tiledb.Config({"sm.group.timestamp_end": 3} if use_timestamps else {})
+        cfg = tiledb.Config()
         with tiledb.Group(path, "w", cfg) as grp:
             grp.meta["meta"] = 3
 

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -823,8 +823,7 @@ class DenseArrayTest(DiskTestCase):
                 assert_array_equal(T, R)
                 assert_array_equal(T, R.multi_index[0:2][""])
 
-    @pytest.mark.parametrize("use_timestamps", [True, False])
-    def test_open_with_timestamp(self, use_timestamps):
+    def test_open_with_timestamp(self):
         A = np.zeros(3)
 
         dom = tiledb.Domain(tiledb.Dim(domain=(0, 2), tile=3, dtype=np.int64))
@@ -841,15 +840,9 @@ class DenseArrayTest(DiskTestCase):
             self.assertEqual(T[1], 0)
             self.assertEqual(T[2], 0)
 
-        if use_timestamps:
-            # sleep 200ms and write
-            time.sleep(0.2)
         with tiledb.DenseArray(self.path("foo"), mode="w") as T:
             T[0:1] = 1
 
-        if use_timestamps:
-            # sleep 200ms and write
-            time.sleep(0.2)
         with tiledb.DenseArray(self.path("foo"), mode="w") as T:
             T[1:2] = 2
 


### PR DESCRIPTION
In https://github.com/TileDB-Inc/TileDB-Py/pull/1953, some tests were modified to ensure that https://github.com/TileDB-Inc/TileDB/pull/4800 worked as intended. Previously, the `timestamp` argument was occasionally used for writes to avoid failures when writes occurred *almost* concurrently. Following that change, some tests were made temporarily conditional for error identification purposes. Over the subsequent eight months, no related test failures have remained unresolved. The only directly connected issue identified and solved during this time is https://github.com/TileDB-Inc/TileDB-Py/pull/2090.

This PR removes the use of the `timestamp` argument where it was employed in a hacky manner and eliminates the use of `time.sleep`. However, not all parameterization introduced in https://github.com/TileDB-Inc/TileDB-Py/pull/1953 have been reverted, as the use of `use_timestamps` parameter increases test coverage for scenarios where users want to utilize the time-travel capabilities provided by TileDB.