### PR TITLE
Update references after renaming `dev` branch to `main`

### DIFF
--- a/.github/workflows/ci-tiledb-from-source.yml
+++ b/.github/workflows/ci-tiledb-from-source.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       libtiledb_ref:
-        default: dev
+        default: main
         type: string
       libtiledb_version:
         type: string
@@ -14,11 +14,11 @@ jobs:
   build_libtiledb:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout TileDB Core ${{ inputs.libtiledb_ref || 'dev' }}
+      - name: Checkout TileDB Core ${{ inputs.libtiledb_ref || 'main' }}
         uses: actions/checkout@v4
         with:
           repository: TileDB-Inc/TileDB
-          ref: ${{ inputs.libtiledb_ref || 'dev' }}
+          ref: ${{ inputs.libtiledb_ref || 'main' }}
 
       - name: Configure TileDB
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: "11"
     steps:
-      - name: Checkout TileDB-Py `dev`
+      - name: Checkout TileDB-Py `main`
         uses: actions/checkout@v4
 
       - name: Setup MSVC toolset (VS 2022)

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -47,7 +47,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "11"
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
     steps:
-      - name: Checkout TileDB-Py `dev`
+      - name: Checkout TileDB-Py `main`
         uses: actions/checkout@v4
 
       - name: Setup MSVC toolset (VS 2022)
@@ -85,7 +85,7 @@ jobs:
       - name: Print env
         run: printenv
 
-      - name: Checkout TileDB-Py `dev`
+      - name: Checkout TileDB-Py `main`
         uses: actions/checkout@v3
 
       - name: Build TileDB-Py

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -65,7 +65,7 @@ jobs:
         run: brew install pkg-config
         if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
 
-      - name: Checkout TileDB-Py `dev`
+      - name: Checkout TileDB-Py `main`
         uses: actions/checkout@v4
 
       - name: Build and install TileDB-Py and dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thanks for your interest in TileDB-Py. The notes below give some pointers for fi
 - Please paste code blocks with triple backquotes (```) so that github will format it nicely. See [GitHub's guide on Markdown](https://guides.github.com/features/mastering-markdown) for more formatting tricks.
 
 ## Contributing Code
-*By contributing code to TileDB-Py, you are agreeing to release it under the [MIT License](https://github.com/TileDB-Inc/TileDB/tree/dev/LICENSE).*
+*By contributing code to TileDB-Py, you are agreeing to release it under the [MIT License](https://github.com/TileDB-Inc/TileDB/tree/main/LICENSE).*
 
 ### Contribution Workflow
 
@@ -45,4 +45,4 @@ Thanks for your interest in TileDB-Py. The notes below give some pointers for fi
 - Make changes locally, then rebuild with `python setup.py develop [--tiledb=<>]`
 - Make sure to run `pytest` to verify changes against tests (add new tests where applicable).
   - Execute the tests as `pytest tiledb` from the top-level directory or `pytest` in the `tiledb/` directory.
-- Please submit [pull requests](https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request) against the default [`dev` branch of TileDB-Py](https://github.com/TileDB-Inc/TileDB-Py/tree/dev)
+- Please submit [pull requests](https://help.github.com/en/desktop/contributing-to-projects/creating-a-pull-request) against the default [`main` branch of TileDB-Py](https://github.com/TileDB-Inc/TileDB-Py/tree/main)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<a href="https://tiledb.com"><img src="https://github.com/TileDB-Inc/TileDB/raw/dev/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
+<a href="https://tiledb.com"><img src="https://github.com/TileDB-Inc/TileDB/raw/main/doc/source/_static/tiledb-logo_color_no_margin_@4x.png" alt="TileDB logo" width="400"></a>
 
 
-[![Build Status](https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/TileDB-Inc.TileDB-Py?branchName=dev)](https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=1&branchName=dev)
-![](https://raw.githubusercontent.com/TileDB-Inc/TileDB/dev/doc/anaconda.svg?sanitize=true)[![Anaconda download count badge](https://anaconda.org/conda-forge/TileDB-Py/badges/downloads.svg)](https://anaconda.org/conda-forge/TileDB-Py)
+[![Build Status](https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/TileDB-Inc.TileDB-Py?branchName=main)](https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=1&branchName=main)
+![](https://raw.githubusercontent.com/TileDB-Inc/TileDB/main/doc/anaconda.svg?sanitize=true)[![Anaconda download count badge](https://anaconda.org/conda-forge/TileDB-Py/badges/downloads.svg)](https://anaconda.org/conda-forge/TileDB-Py)
 
 
 # TileDB-Py
@@ -35,6 +35,6 @@ Dataframes functionality (`tiledb.from_pandas`, `Array.df[]`) requires [Pandas](
 
 # Contributing
 
-We welcome contributions, please see [`CONTRIBUTING.md`](https://github.com/TileDB-Inc/TileDB-Py/blob/dev/CONTRIBUTING.md) for suggestions and
+We welcome contributions, please see [`CONTRIBUTING.md`](https://github.com/TileDB-Inc/TileDB-Py/blob/main/CONTRIBUTING.md) for suggestions and
 development-build instructions. For larger features, please open an issue to discuss goals and
 approach in order to ensure a smooth PR integration and review process.

--- a/tiledb/tests/perf/asv.conf.json
+++ b/tiledb/tests/perf/asv.conf.json
@@ -28,9 +28,9 @@
     //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     // ],
 
-    // List of branches to benchmark. If not provided, defaults to "master"
+    // List of branches to benchmark. If not provided, defaults to "main"
     // (for git) or "default" (for mercurial).
-    "branches": ["dev"], // for git
+    "branches": ["main"], // for git
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL


### PR DESCRIPTION
This PR updates all references to the `dev` branch, changing them to `main`. After merging, the `dev` branch should be renamed to `main`.
This is a follow-up to https://github.com/TileDB-Inc/TileDB/pull/5407, which makes the same change for that repository.

cc. @dudoslav