### PR TITLE
Explicitly set the numpy type passed in `QueryExperimental::set_data_buffer`

### DIFF
--- a/tiledb/array.py
+++ b/tiledb/array.py
@@ -899,7 +899,7 @@ class Array:
             q.set_data_buffer(
                 buffer_name,
                 output_values[i],
-                buffer_sizes[i] * ncells,
+                np.uint64(buffer_sizes[i] * ncells),
             )
 
             # Set offsets buffer


### PR DESCRIPTION
`QueryExperimental::set_data_buffer` requires an unsigned integer as its last argument. It seems that with numpy versions earlier than 2, this argument becomes a numpy float64 (with `buffer_sizes[i]` being a numpy uint64 and `ncells` being a Python int).

Let's fix it by explicitly cast to numpy uint64.

Closes https://github.com/TileDB-Inc/TileDB-Py/issues/2127, closes https://github.com/TileDB-Inc/TileDB-Py/issues/2124.