### PR TITLE
Increase test_memory_cleanup target ratio

### DIFF
--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -3385,7 +3385,7 @@ class MemoryTest(DiskTestCase):
         print("  final RSS after forced GC: {}".format(round(final_gc / 1e6, 2)))
 
         assert_captured(capfd, "final RSS")
-        self.assertTrue(final < (2 * initial))
+        self.assertTrue(final < (2.5 * initial))
 
 
 class TestHighlevel(DiskTestCase):


### PR DESCRIPTION
(fix local failure on macos-arm64)

This is a very crude memory cleanup test which runs queries in a loop, and compares the starting and ending RSS to catch large leaks.

It fails at the current 2x ratio on macos-arm64. Increase the ratio to 2.5.

To confirm that this is not masking an arch-specific leak, I ran 10x iterations of the target function.

- `final / initial` RSS for 100 runs (current default) vs 1000 runs (local modification) in the `use_many_buffers` loop:
```
(Pdb) 1029292032 / 431456256
2.3856231487810433

(Pdb) p 1023819776 / 427802624
2.393205928535866
```