### PR TITLE
Fix the logic of daily tests to ensure both variations of numpy are run

### DIFF
--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -23,24 +23,34 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, macos-14, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        include:
-          # https://github.com/scipy/oldest-supported-numpy/blob/main/setup.cfg
-          - python-version: "3.13"
-            numpy-version: "2.1.0"
-          - python-version: "3.12"
-            numpy-version: "1.26.4"
-          - python-version: "3.12"
-            numpy-version: "2.0.1"
-          - python-version: "3.11"
-            numpy-version: "1.25.2"
-          - python-version: "3.11"
-            numpy-version: "2.0.1"
-          - python-version: "3.10"
-            numpy-version: "1.25.2"
-          - python-version: "3.10"
-            numpy-version: "2.0.1"
+        numpy-version: ["1.25.2", "1.26.4", "2.0.2", "2.2.1"]
+        exclude:
           - python-version: "3.9"
+            numpy-version: "1.26.4"
+          - python-version: "3.9"
+            numpy-version: "2.2.1"
+
+          - python-version: "3.10"
+            numpy-version: "1.26.4"
+          - python-version: "3.10"
+            numpy-version: "2.0.2"
+          
+          - python-version: "3.11"
+            numpy-version: "1.26.4"
+          - python-version: "3.11"
+            numpy-version: "2.0.2"
+
+          - python-version: "3.12"
             numpy-version: "1.25.2"
+          - python-version: "3.12"
+            numpy-version: "2.0.2"
+
+          - python-version: "3.13"
+            numpy-version: "1.25.2"
+          - python-version: "3.13"
+            numpy-version: "1.26.4"
+          - python-version: "3.13"
+            numpy-version: "2.0.2"
       fail-fast: false
     env:
       TILEDB_VERSION: ${{ inputs.libtiledb_version }}

--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -20,4 +20,9 @@ jobs:
   ci3:
     uses: ./.github/workflows/daily-test-build-numpy.yml
     with:
+      libtiledb_version: '2.27.0'
+
+  ci4:
+    uses: ./.github/workflows/daily-test-build-numpy.yml
+    with:
       libtiledb_version: '2.26.0'


### PR DESCRIPTION
Daily tests, and specifically `daily-test-build-numpy.yml`, are a way to test TileDB-Py against different versions of numpy. Historically, the workflow checks TileDB-Py with the oldest and newest supported numpy versions.

It turns out that the logic is not working as intended. As shown in the latest scheduled workflow, it appears that `ci3`, which uses `daily-test-build-numpy.yml`, only runs once for each Python version and operating system combination. There is no numpy dimension. This was discovered after https://github.com/TileDB-Inc/TileDB-Py/issues/2127, which could have been prevented.

It seems we have used the configuration expansion described here: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-expanding-configurations. In practice, this adds an additional variable named `numpy-version` with just one of the specified values, but not all of them. I guess the selected one depends on the order of presence in the yaml file.

This PR resolves the issue and includes all the variations we want to check in the strategy matrix making use of the exclude syntax, the only way I can think of without having to explicitly set every combination.

I know that the combinations are a lot and I'm, of course, open to reduce them, even if this workflow runs once per day.

Latest scheduled workflow: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/12645542541
Workflow of this branch: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/12657985171

---

[sc-61402]