### PR TITLE
Fix `view_attr` not being respected by `__getitem__` and `subarray`

### DIFF
--- a/tiledb/dense_array.py
+++ b/tiledb/dense_array.py
@@ -77,8 +77,7 @@ class DenseArrayImpl(Array):
 
         """
         if self.view_attr:
-            result = self.subarray(selection, attrs=(self.view_attr,))
-            return result[self.view_attr]
+            return self.subarray(selection)
 
         result = self.subarray(selection)
         for i in range(self.schema.nattr):
@@ -269,6 +268,8 @@ class DenseArrayImpl(Array):
             attr = self.schema.attr(0)
             if attr.isanon:
                 return out[attr._internal_name]
+        if self.view_attr:
+            return out[self.view_attr]
         return out
 
     def _read_dense_subarray(

--- a/tiledb/dense_array.py
+++ b/tiledb/dense_array.py
@@ -268,7 +268,7 @@ class DenseArrayImpl(Array):
             attr = self.schema.attr(0)
             if attr.isanon:
                 return out[attr._internal_name]
-        if self.view_attr:
+        if self.view_attr is not None:
             return out[self.view_attr]
         return out
 

--- a/tiledb/sparse_array.py
+++ b/tiledb/sparse_array.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import OrderedDict
 
 import numpy as np
@@ -292,6 +293,9 @@ class SparseArrayImpl(Array):
         >>> # A[5.0:579.9]
 
         """
+        if self.view_attr:
+            return self.subarray(selection)
+
         result = self.subarray(selection)
         for i in range(self.schema.nattr):
             attr = self.schema.attr(i)
@@ -506,7 +510,11 @@ class SparseArrayImpl(Array):
 
         attr_names = list()
 
-        if attrs is None:
+        if self.view_attr is not None:
+            if attrs is not None:
+                warnings.warn("view_attr is set, ignoring attrs parameter", UserWarning)
+            attr_names.extend(self.view_attr)
+        elif attrs is None:
             attr_names.extend(
                 self.schema.attr(i)._internal_name for i in range(self.schema.nattr)
             )

--- a/tiledb/sparse_array.py
+++ b/tiledb/sparse_array.py
@@ -293,7 +293,7 @@ class SparseArrayImpl(Array):
         >>> # A[5.0:579.9]
 
         """
-        if self.view_attr:
+        if self.view_attr is not None:
             return self.subarray(selection)
 
         result = self.subarray(selection)


### PR DESCRIPTION
This PR fixes an issue where the `attr` argument in the `Array.open` method (internally stored as `view_attr`) was not respected during query operations. Consequently, the `Array.query` method ignored the specified attribute(s) and returned all attributes instead. The issue has been resolved by updating the `__getitem__` and `subarray` methods of both Sparse and Dense Arrays.

---

[sc-61659]