### PR TITLE
Increase the data size to avoid random failures in `test_qc_enumeration`

### DIFF
--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -874,7 +874,7 @@ class QueryConditionTest(DiskTestCase):
 
     def test_qc_enumeration(self):
         uri = self.path("test_qc_enumeration")
-        dom = tiledb.Domain(tiledb.Dim(domain=(1, 8), tile=1))
+        dom = tiledb.Domain(tiledb.Dim(domain=(1, 100), tile=1))
         enum1 = tiledb.Enumeration("enmr1", True, [0, 1, 2])
         enum2 = tiledb.Enumeration("enmr2", True, ["a", "bb", "ccc"])
         attr1 = tiledb.Attr("attr1", dtype=np.int32, enum_label="enmr1")
@@ -884,8 +884,8 @@ class QueryConditionTest(DiskTestCase):
         )
         tiledb.Array.create(uri, schema)
 
-        data1 = np.random.randint(0, 3, 8)
-        data2 = np.random.randint(0, 3, 8)
+        data1 = np.random.randint(0, 3, 100)
+        data2 = np.random.randint(0, 3, 100)
 
         with tiledb.open(uri, "w") as A:
             A[:] = {"attr1": data1, "attr2": data2}


### PR DESCRIPTION
`test_qc_enumeration` has been observed to [fail](https://github.com/TileDB-Inc/TileDB-Py/actions/runs/12718853000/job/35458017629#step:12:1147) randomly. The data of the Array in that test is random, and its domain is relatively small; `(1, 100)`. As seen in the logs, this results in the `result` array containing only fill values, indicating that the condition is too strict for the Array we have. Increasing the size of the Array should resolve the issue permanently.