### PR TITLE
Bugfix: Arrays losing CloudArray interface

### DIFF
--- a/tiledb/array.py
+++ b/tiledb/array.py
@@ -416,17 +416,14 @@ class Array:
         if ctx is None:
             ctx = default_ctx()
 
-        from .dense_array import DenseArrayImpl
-        from .sparse_array import SparseArrayImpl
-
         tmp_array = preload_array(uri, mode, key, timestamp, ctx)
 
         if tmp_array._schema()._array_type == lt.ArrayType.SPARSE:
-            return SparseArrayImpl(
+            return tiledb.SparseArray(
                 uri, mode, key, timestamp, attr, ctx, preloaded_array=tmp_array
             )
         else:
-            return DenseArrayImpl(
+            return tiledb.DenseArray(
                 uri, mode, key, timestamp, attr, ctx, preloaded_array=tmp_array
             )
 


### PR DESCRIPTION
This PR fixes the case when `tiledb-cloud` package is present but instances of Dense and Sparse Array are returned without the correct inheritance from: https://github.com/TileDB-Inc/TileDB-Py/blob/e1f57bd940731460d8cfbcdb74a1f763aef521c9/tiledb/array.py#L425-L431.

---

[sc-61938]