### PR TITLE
Bug fix: Data buffer is not resized for byte objects after completing the buffer and offsets conversion

### DIFF
--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -211,6 +211,8 @@ if (PyUnicode_Check(u.ptr())) {
       output_p += sz;
       idx++;
     }
+
+    data_buf_->resize(data_nbytes_);
   }
 
   void convert_object() {

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -357,14 +357,17 @@ class FixesTest(DiskTestCase):
     @pytest.mark.parametrize(
         "array_data",
         [
-            np.array([b"", b"1", b"", b"", b"f", b""], dtype="S"),
-            np.array([b"", b"1", b"", b"", b"f", b"3"], dtype="S"),
+            np.array([b"", b"testing", b"", b"with empty", b"bytes"], dtype="S"),
+            np.array([b"and", b"", b"again"], dtype="S"),
+            np.array(
+                [b"", b"and with", b"the last one", b"", b"emtpy", b""], dtype="S"
+            ),
         ],
     )
     def test_sc62594_buffer_resize(self, array_data):
         uri = self.path("test_agis")
         dom = tiledb.Domain(
-            tiledb.Dim(name="dim", domain=(0, 5), tile=2, dtype=np.int64),
+            tiledb.Dim(name="dim", domain=(0, len(array_data) - 1), dtype=np.int64)
         )
 
         schema = tiledb.ArraySchema(

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -358,7 +358,7 @@ class FixesTest(DiskTestCase):
         "array_data",
         [
             np.array([b"", b"testing", b"", b"with empty", b"bytes"], dtype="S"),
-            np.array([b"and", b"", b"again"], dtype="S"),
+            np.array([b"and", b"\0\0", b"again"], dtype="S"),
             np.array(
                 [b"", b"and with", b"the last one", b"", b"emtpy", b""], dtype="S"
             ),


### PR DESCRIPTION
This PR fixes an issue with the incorrect calculation of the `data_buffer` size when empty bytes are present in the Python list being written to a TileDB Array. The size of the `data_buffer` was incorrectly set to the size of the Python list, which is incorrect because empty bytes are not included in the `data_buffer` being sent to the `QueryExperimental::set_data_buffer` C++ API.

---

[sc-62594]