### PR TITLE
Add pytest flaky-retry mechanism for handling intermittent test failures

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install test dependencies
-        run: pip install pytest hypothesis psutil pyarrow
+        run: pip install pytest pytest-retry hypothesis psutil pyarrow
 
       - name: Run tests
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ doc = [
 ]
 test = [
     "pytest",
+    "pytest-retry",
     "hypothesis",
     "psutil",
     "pyarrow",
@@ -112,6 +113,7 @@ select = ["NPY201"]
 [tool.cibuildwheel]
 test-requires = [
     "pytest",
+    "pytest-retry",
     "hypothesis",
     "psutil",
     "pyarrow",

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -42,6 +42,7 @@ class TestDaskSupport(DiskTestCase):
 
         tiledb.DenseArray.create(uri, schema)
 
+    @pytest.mark.flaky(reruns=3, reruns_delay=2)
     @pytest.mark.filterwarnings("ignore:There is no current event loop")
     def test_dask_multiattr_2d(self):
         uri = self.path("multiattr")

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 import numpy as np
 import pytest
+from distributed.comm.core import CommClosedError
+from tornado.iostream import StreamClosedError
 
 import tiledb
 
@@ -42,7 +44,9 @@ class TestDaskSupport(DiskTestCase):
 
         tiledb.DenseArray.create(uri, schema)
 
-    @pytest.mark.flaky(reruns=3, reruns_delay=2)
+    @pytest.mark.flaky(
+        reruns=3, reruns_delay=2, only_rerun=(CommClosedError, StreamClosedError)
+    )
     @pytest.mark.filterwarnings("ignore:There is no current event loop")
     def test_dask_multiattr_2d(self):
         uri = self.path("multiattr")


### PR DESCRIPTION
This PR introduces the `@pytest.mark.flaky` decorator to retry `test_dask_multiattr_2d` up to 3 times with a 2-second delay between attempts. This helps mitigate intermittent test failures caused by factors such as network instability, timeouts, or race conditions.

Fixes https://github.com/TileDB-Inc/TileDB-Py/issues/2149