### PR TITLE
Fix bug with printing array schemas to HTML

### DIFF
--- a/tiledb/array_schema.py
+++ b/tiledb/array_schema.py
@@ -499,7 +499,7 @@ class ArraySchema(CtxMixin, lt.ArraySchema):
         output.write(f"<tr><td>{self.sparse}</td></tr>")
 
         if self.sparse:
-            output.write("<tr><th>Allows DuplicatesK/th></tr>")
+            output.write("<tr><th>Allows Duplicates</th></tr>")
             output.write(f"<tr><td>{self.allows_duplicates}</td></tr>")
 
         output.write("</table>")


### PR DESCRIPTION
I noticed the HTML generated after using the `.schema` property on an open array was incorrect and missing a closing tag.