### PR TITLE
Skip faketime tests on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-13
-          # libfaketime tests fail on macos arm. Disable tests for now.
-          # - macos-14
+          - macos-14
           - windows-latest
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
       fail-fast: false
@@ -66,8 +65,8 @@ jobs:
         run: brew install pkg-config
         if: startsWith(matrix.os, 'macos')
 
-      - name: "Install libfaketime (linux and macOS)"
-        if: ${{ ! startsWith(matrix.os, 'windows') }}
+      - name: "Install libfaketime (Linux only)"
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: |
           git clone https://github.com/wolfcw/libfaketime/
           cd libfaketime

--- a/tiledb/tests/test_timestamp_overrides.py
+++ b/tiledb/tests/test_timestamp_overrides.py
@@ -20,8 +20,8 @@ def has_libfaketime():
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32" or not has_libfaketime(),
-    reason=f"libfaketime not installed. {'Not supported on Windows.' if sys.platform == 'win32' else ''}",
+    sys.platform != "linux2" or not has_libfaketime(),
+    reason=f"This test is only supported on Linux with libfaketime installed.",
 )
 class TestTimestampOverrides(DiskTestCase):
     def test_timestamp_overrides(self):


### PR DESCRIPTION
This PR fixes the issue we are experiencing with macOS 13 runners when running tests that require faketime. Let's disable faketime tests on macOS.

Log: https://gist.github.com/kounelisagis/d88c23c65e1198556f0493e45c357e4c

---

[sc-63017]