### PR TITLE
Throw an exception when the data buffer size for allocation is too large

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -98,6 +98,10 @@ struct BufferInfo {
         try {
             dtype = tiledb_dtype(data_type, cell_val_num);
             elem_nbytes = tiledb_datatype_size(type);
+            if (data_nbytes >
+                static_cast<uint64_t>(std::numeric_limits<intptr_t>::max())) {
+                throw std::overflow_error("Data buffer size is too large");
+            }
             data = py::array(py::dtype("uint8"), data_nbytes);
             offsets = py::array_t<uint64_t>(offsets_num);
             validity = py::array_t<uint8_t>(validity_num);

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -382,6 +382,26 @@ class FixesTest(DiskTestCase):
         with tiledb.DenseArray(uri) as T:
             assert_array_equal(array_data, T)
 
+    def test_data_buffer_too_large(self):
+        uri = self.path("test_agis")
+        dim1 = tiledb.Dim(
+            name="dim_0", domain=(0, 10000000000), tile=512, dtype=np.int64
+        )
+        dim2 = tiledb.Dim(
+            name="dim_1", domain=(0, 10000000000), tile=512, dtype=np.int64
+        )
+        att = tiledb.Attr(name="data", dtype="int8")
+        schema = tiledb.ArraySchema(
+            domain=tiledb.Domain(dim1, dim2),
+            attrs=(att,),
+        )
+        tiledb.Array.create(uri, schema)
+
+        with tiledb.open(uri, mode="r") as A:
+            with pytest.raises(OverflowError) as exc:
+                A[:]
+            assert "Data buffer size is too large" in str(exc.value)
+
 
 class SOMA919Test(DiskTestCase):
     """


### PR DESCRIPTION
Let's throw an exception for the cases that the total domain size overflows a `uint64`, and the estimator returns the maximum amount of data that can be read at once (`UINT64_MAX`).