### PR TITLE
Fix `NDRectangle::set_range` overloads

### DIFF
--- a/tiledb/libtiledb/current_domain.cc
+++ b/tiledb/libtiledb/current_domain.cc
@@ -24,166 +24,123 @@ void init_current_domain(py::module& m) {
 
         .def(
             "_set_range",
-            py::overload_cast<const std::string&, uint64_t, uint64_t>(
-                &NDRectangle::set_range<uint64_t>),
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<const std::string&, int64_t, int64_t>(
-                &NDRectangle::set_range<int64_t>),
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<const std::string&, uint32_t, uint32_t>(
-                &NDRectangle::set_range<uint32_t>),
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<const std::string&, int32_t, int32_t>(
-                &NDRectangle::set_range<int32_t>),
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<const std::string&, uint16_t, uint16_t>(
-                &NDRectangle::set_range<uint16_t>),
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<const std::string&, int16_t, int16_t>(
-                &NDRectangle::set_range<int16_t>),
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<const std::string&, uint8_t, uint8_t>(
-                &NDRectangle::set_range<uint8_t>),
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<const std::string&, int8_t, int8_t>(
-                &NDRectangle::set_range<int8_t>),
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<const std::string&, double, double>(
-                &NDRectangle::set_range<double>),
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<const std::string&, float, float>(
-                &NDRectangle::set_range<float>),
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
             [](NDRectangle& ndrect,
                const std::string& dim_name,
-               const std::string& start,
-               const std::string& end) {
-                return ndrect.set_range(dim_name, start, end);
-            },
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<uint32_t, uint64_t, uint64_t>(
-                &NDRectangle::set_range<uint64_t>),
-            py::arg("dim_idx"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<uint32_t, int64_t, int64_t>(
-                &NDRectangle::set_range<int64_t>),
-            py::arg("dim_idx"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<uint32_t, uint32_t, uint32_t>(
-                &NDRectangle::set_range<uint32_t>),
-            py::arg("dim_idx"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<uint32_t, int32_t, int32_t>(
-                &NDRectangle::set_range<int32_t>),
-            py::arg("dim_idx"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<uint32_t, uint16_t, uint16_t>(
-                &NDRectangle::set_range<uint16_t>),
-            py::arg("dim_idx"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<uint32_t, int16_t, int16_t>(
-                &NDRectangle::set_range<int16_t>),
-            py::arg("dim_idx"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<uint32_t, uint8_t, uint8_t>(
-                &NDRectangle::set_range<uint8_t>),
-            py::arg("dim_idx"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<uint32_t, int8_t, int8_t>(
-                &NDRectangle::set_range<int8_t>),
-            py::arg("dim_idx"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<uint32_t, double, double>(
-                &NDRectangle::set_range<double>),
-            py::arg("dim_idx"),
-            py::arg("start"),
-            py::arg("end"))
-        .def(
-            "_set_range",
-            py::overload_cast<uint32_t, float, float>(
-                &NDRectangle::set_range<float>),
-            py::arg("dim_idx"),
-            py::arg("start"),
-            py::arg("end"))
+               py::object start,
+               py::object end) {
+                const tiledb_datatype_t n_type = ndrect.range_dtype(dim_name);
+
+                if (n_type == TILEDB_UINT64) {
+                    auto start_val = start.cast<uint64_t>();
+                    auto end_val = end.cast<uint64_t>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else if (n_type == TILEDB_INT64) {
+                    auto start_val = start.cast<int64_t>();
+                    auto end_val = end.cast<int64_t>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else if (n_type == TILEDB_UINT32) {
+                    auto start_val = start.cast<uint32_t>();
+                    auto end_val = end.cast<uint32_t>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else if (n_type == TILEDB_INT32) {
+                    auto start_val = start.cast<int32_t>();
+                    auto end_val = end.cast<int32_t>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else if (n_type == TILEDB_UINT16) {
+                    auto start_val = start.cast<uint16_t>();
+                    auto end_val = end.cast<uint16_t>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else if (n_type == TILEDB_INT16) {
+                    auto start_val = start.cast<int16_t>();
+                    auto end_val = end.cast<int16_t>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else if (n_type == TILEDB_UINT8) {
+                    auto start_val = start.cast<uint8_t>();
+                    auto end_val = end.cast<uint8_t>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else if (n_type == TILEDB_INT8) {
+                    auto start_val = start.cast<int8_t>();
+                    auto end_val = end.cast<int8_t>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else if (n_type == TILEDB_FLOAT64) {
+                    auto start_val = start.cast<double>();
+                    auto end_val = end.cast<double>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else if (n_type == TILEDB_FLOAT32) {
+                    auto start_val = start.cast<float>();
+                    auto end_val = end.cast<float>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else if (
+                    n_type == TILEDB_STRING_ASCII ||
+                    n_type == TILEDB_STRING_UTF8) {
+                    auto start_val = start.cast<std::string>();
+                    auto end_val = end.cast<std::string>();
+                    ndrect.set_range(dim_name, start_val, end_val);
+                } else {
+                    TPY_ERROR_LOC(
+                        "Unsupported type for NDRectangle's set_range");
+                }
+            })
+
         .def(
             "_set_range",
             [](NDRectangle& ndrect,
                uint32_t dim_idx,
-               const std::string& start,
-               const std::string& end) {
-                return ndrect.set_range(dim_idx, start, end);
-            },
-            py::arg("dim_name"),
-            py::arg("start"),
-            py::arg("end"))
+               py::object start,
+               py::object end) {
+                const tiledb_datatype_t n_type = ndrect.range_dtype(dim_idx);
+
+                if (n_type == TILEDB_UINT64) {
+                    auto start_val = start.cast<uint64_t>();
+                    auto end_val = end.cast<uint64_t>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else if (n_type == TILEDB_INT64) {
+                    auto start_val = start.cast<int64_t>();
+                    auto end_val = end.cast<int64_t>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else if (n_type == TILEDB_UINT32) {
+                    auto start_val = start.cast<uint32_t>();
+                    auto end_val = end.cast<uint32_t>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else if (n_type == TILEDB_INT32) {
+                    auto start_val = start.cast<int32_t>();
+                    auto end_val = end.cast<int32_t>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else if (n_type == TILEDB_UINT16) {
+                    auto start_val = start.cast<uint16_t>();
+                    auto end_val = end.cast<uint16_t>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else if (n_type == TILEDB_INT16) {
+                    auto start_val = start.cast<int16_t>();
+                    auto end_val = end.cast<int16_t>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else if (n_type == TILEDB_UINT8) {
+                    auto start_val = start.cast<uint8_t>();
+                    auto end_val = end.cast<uint8_t>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else if (n_type == TILEDB_INT8) {
+                    auto start_val = start.cast<int8_t>();
+                    auto end_val = end.cast<int8_t>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else if (n_type == TILEDB_FLOAT64) {
+                    auto start_val = start.cast<double>();
+                    auto end_val = end.cast<double>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else if (n_type == TILEDB_FLOAT32) {
+                    auto start_val = start.cast<float>();
+                    auto end_val = end.cast<float>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else if (
+                    n_type == TILEDB_STRING_ASCII ||
+                    n_type == TILEDB_STRING_UTF8) {
+                    auto start_val = start.cast<std::string>();
+                    auto end_val = end.cast<std::string>();
+                    ndrect.set_range(dim_idx, start_val, end_val);
+                } else {
+                    TPY_ERROR_LOC(
+                        "Unsupported type for NDRectangle's set_range");
+                }
+            })
 
         .def(
             "_range",

--- a/tiledb/tests/test_current_domain.py
+++ b/tiledb/tests/test_current_domain.py
@@ -16,7 +16,7 @@ if not (lt.version()[0] == 2 and lt.version()[1] >= 25):
     )
 
 
-class NDRectangleTest(unittest.TestCase):
+class NDRectangleTest(DiskTestCase):
     def test_ndrectagle_standalone_string(self):
         ctx = tiledb.Ctx()
         dom = tiledb.Domain(
@@ -58,6 +58,33 @@ class NDRectangleTest(unittest.TestCase):
         # should be the same
         self.assertEqual(ndrect.range("x"), range_one)
         self.assertEqual(ndrect.range("y"), range_two)
+
+    @pytest.mark.parametrize(
+        "dtype_, range_",
+        (
+            (np.int32, (0, 1)),
+            (np.int64, (2, 7)),
+            (np.uint32, (1, 5)),
+            (np.uint64, (5, 9)),
+            (np.float32, (0.0, 1.0)),
+            (np.float64, (2.0, 4.0)),
+            (np.dtype(bytes), (b"abc", b"def")),
+        ),
+    )
+    def test_set_range_different_types(self, dtype_, range_):
+        domain = tiledb.Domain(
+            *[
+                tiledb.Dim(
+                    name="rows",
+                    domain=(0, 9),
+                    dtype=dtype_,
+                ),
+            ]
+        )
+
+        ctx = tiledb.Ctx()
+        ndrect = tiledb.NDRectangle(ctx, domain)
+        ndrect.set_range("rows", range_[0], range_[1])
 
 
 class CurrentDomainTest(DiskTestCase):
@@ -215,30 +242,3 @@ class CurrentDomainTest(DiskTestCase):
         n = cd.ndrectangle
         self.assertEqual(n.range(0), new_range)
         A.close()
-
-    @pytest.mark.parametrize(
-        "dtype_, range_",
-        (
-            (np.int32, (0, 1)),
-            (np.int64, (2, 7)),
-            (np.uint32, (1, 5)),
-            (np.uint64, (5, 9)),
-            (np.float32, (0.0, 1.0)),
-            (np.float64, (2.0, 4.0)),
-            (np.dtype(bytes), (b"abc", b"def")),
-        ),
-    )
-    def test_current_domain_types(self, dtype_, range_):
-        domain = tiledb.Domain(
-            *[
-                tiledb.Dim(
-                    name="rows",
-                    domain=(0, 9),
-                    dtype=dtype_,
-                ),
-            ]
-        )
-
-        ctx = tiledb.Ctx()
-        ndrect = tiledb.NDRectangle(ctx, domain)
-        ndrect.set_range("rows", range_[0], range_[1])


### PR DESCRIPTION
This PR addresses an issue where the `NDRectangle::set_range` overloads were ignored, and only the first overload (`uint64_t`) was used after casting the arguments to `uint64_t`. The `NDRectangle::range_dtype` is now utilized to determine the appropriate type (`T`) to use.