### PR TITLE
Fix `test_multi_index_two_way_query` FailedHealthCheck

### DIFF
--- a/tiledb/tests/strategies.py
+++ b/tiledb/tests/strategies.py
@@ -6,15 +6,6 @@ from hypothesis.strategies import composite
 
 
 @composite
-def bounded_ntuple(draw, *, length=1, min_value=0, max_value=10):
-    """hypothesis composite strategy that returns a `length` tuple of integers
-    within the range (min_value, max_value)
-    """
-
-    return draw(st.tuples(*[st.integers(min_value, max_value) for _ in range(length)]))
-
-
-@composite
 def ranged_slices(draw, min_value=0, max_value=10):
     bdd = st.one_of(st.none(), st.integers(min_value=min_value, max_value=max_value))
     start = draw(bdd)

--- a/tiledb/tests/test_multi_index-hp.py
+++ b/tiledb/tests/test_multi_index-hp.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_array_equal
 import tiledb
 from tiledb import SparseArray
 
-from .strategies import bounded_ntuple, ranged_slices
+from .strategies import ranged_slices
 
 
 def is_boundserror(exc: Exception):
@@ -89,7 +89,12 @@ class TestMultiIndexPropertySparse:
 
     @given(
         order=st.sampled_from(["C", "F", "U"]),
-        ranges=st.lists(bounded_ntuple(length=2, min_value=-100, max_value=100)),
+        ranges=st.lists(
+            st.tuples(
+                st.integers(min_value=-100, max_value=100),
+                st.integers(min_value=-100, max_value=100),
+            ).map(lambda x: (min(x), max(x)))
+        ),
     )
     @hp.settings(deadline=None)
     def test_multi_index_two_way_query(self, order, ranges, sparse_array_1d):
@@ -98,7 +103,6 @@ class TestMultiIndexPropertySparse:
         uri = sparse_array_1d
 
         assert isinstance(uri, str)
-        assume(v[0] <= v[1] for v in ranges)
 
         try:
             with tiledb.open(uri) as A:


### PR DESCRIPTION
The test `TestMultiIndexPropertySparse.test_multi_index_two_way_query` has been frequently failing due to `hypothesis.errors.FailedHealthCheck`, with error messages such as:

`It looks like your strategy is filtering out a lot of data. The health check found 50 filtered examples but only 9 valid ones.`

This PR changes `ranges` strategy to prevent Hypothesis health check failures caused by excessive test case filtering while still ensuring coverage of all valid ranges.