### PR TITLE
Fix failing tests

### DIFF
--- a/tiledb/tests/test_current_domain.py
+++ b/tiledb/tests/test_current_domain.py
@@ -351,4 +351,4 @@ class CurrentDomainTest(DiskTestCase):
             assert_array_equal(A[:]["a"], expected_array["a"])
 
             expected_df = pd.DataFrame(expected_array)
-            assert pd.DataFrame.equals(A.df[:], expected_df)
+            assert_array_equal(A.df[:], expected_df)

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -1,6 +1,4 @@
-import sys
 import warnings
-from datetime import datetime
 
 import numpy as np
 import pytest
@@ -44,9 +42,7 @@ class TestDaskSupport(DiskTestCase):
 
         tiledb.DenseArray.create(uri, schema)
 
-    @pytest.mark.flaky(
-        reruns=3, reruns_delay=2, only_rerun=(CommClosedError, StreamClosedError)
-    )
+    @pytest.mark.flaky(reruns=3, reruns_delay=2, rerun_except="TileDBError")
     @pytest.mark.filterwarnings("ignore:There is no current event loop")
     def test_dask_multiattr_2d(self):
         uri = self.path("multiattr")

--- a/tiledb/tests/test_dask.py
+++ b/tiledb/tests/test_dask.py
@@ -2,8 +2,6 @@ import warnings
 
 import numpy as np
 import pytest
-from distributed.comm.core import CommClosedError
-from tornado.iostream import StreamClosedError
 
 import tiledb
 


### PR DESCRIPTION
We currently have two failing tests:
- `test_take_current_domain_into_account_sparse_indexing_sc61914` - Changed to our own assertion function since using `pd.DataFrame.equals` was resulting in an error for windows with numpy 1 even though the Dataframes were equal.
     More: https://github.com/TileDB-Inc/TileDB-Py/issues/2161
- `test_dask_multiattr_2d` - used `rerun_except="TileDBError"` instead of needing to import error types from two different packages. This was leading to `ModuleNotFoundError: No module named 'distributed'` for Windows platforms. This was maybe caused by missing test dependencies, but we can avoid that.
     More: https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=41877&view=logs&j=ea6b747a-d678-5a49-8233-1092783ec463&t=1da0fa6e-ac3c-538d-9479-a05b27431549&l=1694

Daily tests run: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/13333400928