### PR TITLE
Fix the error caused by non-decodable bytes when retrieving the non-empty domain for `TILEDB_ASCII` dimensions

### DIFF
--- a/tiledb/array.py
+++ b/tiledb/array.py
@@ -673,10 +673,12 @@ class Array:
 
             res_x, res_y = self.array._non_empty_domain(dim_idx, dim_dtype)
 
+            # convert to bytes if needed
             if dim_dtype == np.bytes_:
-                # convert to bytes if needed
-                res_x = bytes(res_x, encoding="utf8")
-                res_y = bytes(res_y, encoding="utf8")
+                if not isinstance(res_x, bytes):
+                    res_x = bytes(res_x, encoding="utf8")
+                if not isinstance(res_y, bytes):
+                    res_y = bytes(res_y, encoding="utf8")
 
             if np.issubdtype(dim_dtype, np.datetime64):
                 # convert to np.datetime64

--- a/tiledb/libtiledb/array.cc
+++ b/tiledb/libtiledb/array.cc
@@ -234,11 +234,13 @@ void init_array(py::module& m) {
                 } else if (n_type.is(py::dtype::of<float>())) {
                     auto domain = self.non_empty_domain<float>(dim_idx);
                     return py::make_tuple(domain.first, domain.second);
-                } else if (
-                    py::getattr(n_type, "kind").is(py::str("S")) ||
-                    py::getattr(n_type, "kind").is(py::str("U"))) {
+                } else if (py::getattr(n_type, "kind").is(py::str("S"))) {
                     auto domain = self.non_empty_domain_var(dim_idx);
-                    return py::make_tuple(domain.first, domain.second);
+                    return py::make_tuple(
+                        py::bytes(domain.first), py::bytes(domain.second));
+                } else if (py::getattr(n_type, "kind").is(py::str("U"))) {
+                    TPY_ERROR_LOC(
+                        "Unicode strings are not supported as dimension types");
                     // np.datetime64
                 } else if (py::getattr(n_type, "kind").is(py::str("M"))) {
                     auto domain = self.non_empty_domain<int64_t>(dim_idx);

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2285,6 +2285,7 @@ class TestSparseArray(DiskTestCase):
             ([b"aa", b"bbb", b"c", b"dddd"], [b"aa", b"dddd"], False),
             ([b""], [b"", b""], True),
             ([b"", b"", b"", b""], [b"", b""], True),
+            ([b"\x81", b"\x82", b"\x83", b"\x84"], [b"\x81", b"\x84"], False),
         ],
     )
     def test_sparse_string_domain(


### PR DESCRIPTION
As discovered in [TileDB-ML](https://github.com/TileDB-Inc/TileDB-ML/actions/runs/13406770379/job/37448019451#step:8:35492), calling the `Array::_non_empty_domain` pybind11 function on a `TILEDB_ASCII` dimension containing non-decodable bytes (in terms of UTF-8) resulted in errors such as:  
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0x81 in position 0: invalid start byte`.  
The `pybind11::make_tuple` function assumed that the input would always be a printable string, requiring special handling for this case.  
This PR addresses the issue and also ensures that an exception is thrown for dimensions of unicode string type, as this is not supported until TileDB 2.27.0.