### PR TITLE
Skip test that randomly fails on linux-64 tiledb-py-feedstock Azure builds

### DIFF
--- a/tiledb/tests/test_multi_index-hp.py
+++ b/tiledb/tests/test_multi_index-hp.py
@@ -2,10 +2,10 @@
 # Property-based tests for Array.multi_index using Hypothesis
 #
 
+import os
 import warnings
 
 import hypothesis as hp
-import os
 import numpy as np
 import pytest
 from hypothesis import assume, given

--- a/tiledb/tests/test_multi_index-hp.py
+++ b/tiledb/tests/test_multi_index-hp.py
@@ -5,6 +5,7 @@
 import warnings
 
 import hypothesis as hp
+import os
 import numpy as np
 import pytest
 from hypothesis import assume, given
@@ -95,6 +96,10 @@ class TestMultiIndexPropertySparse:
                 st.integers(min_value=-100, max_value=100),
             ).map(lambda x: (min(x), max(x)))
         ),
+    )
+    @pytest.mark.skipif(
+        os.environ.get("CONDA_BUILD") == "1",
+        reason="Randomly fails on linux-64 tiledb-py-feedstock Azure builds (unable to reproduce)",
     )
     @hp.settings(deadline=None)
     def test_multi_index_two_way_query(self, order, ranges, sparse_array_1d):


### PR DESCRIPTION
This test regularly fails on linux-64 tiledb-py-feedstocks builds (https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/167, https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/170, https://github.com/conda-forge/tiledb-py-feedstock/pull/256), but we have been unable to reproduce it elsewhere (even when using `build-locally.py` to locally mimic the conda-forge feedstock setup in a Docker container).

This PR skips the problematic test when the env var `CONDA_BUILD` is set to `1` (set by [conda-build](https://docs.conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html)). I tested this branch in my [feedstock fork](https://github.com/jdblischak/tiledb-py-feedstock/commit/55ba65ada03a75165ba1bb61132528d94c8679a6) to confirm the flaky test was skipped:

```
tiledb/tests/test_multi_index-hp.py::TestMultiIndexPropertySparse::test_multi_index_two_way_query SKIPPED [ 44%]
```

We should merge this PR only once we are done troubleshooting the feedstock test failure, eg using `libSegFault` (https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/170#issuecomment-2682344663).

Closes https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/170