### PR TITLE
Add tests with heterogeneous arrays that contain variable-length nullable numeric attributes

### DIFF
--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -217,38 +217,6 @@ class NumpyConvert {
         data_buf_->resize(data_nbytes_);
     }
 
-    void convert_numeric() {
-        // Convert numeric numpy arrays to buffer+offsets
-
-        assert(input_.itemsize() > 0);  // must have fixed-length array
-
-        // we know exact offset count
-        offset_buf_->resize(input_len_);
-
-        // we reserve the input length as a minimum size for output
-        data_buf_->resize(input_len_ * input_.itemsize());
-
-        // size (bytes) of current object data
-        Py_ssize_t sz = input_.itemsize();
-        // object data (numeric)
-        const char* input_p = static_cast<const char*>(input_.data());
-
-        unsigned char* output_p = data_buf_->data();
-
-        for (size_t idx = 0; idx < input_len_; idx++) {
-            // record the offset (equal to the current bytes written)
-            offset_buf_->data()[idx] = data_nbytes_;
-
-            memcpy(output_p, input_p, sz);
-
-            data_nbytes_ += sz;
-            output_p += sz;
-            input_p += sz;
-        }
-
-        data_buf_->resize(data_nbytes_);
-    }
-
     void convert_object() {
         // Convert np.dtype("O") array of objects to buffer+offsets
 
@@ -575,16 +543,6 @@ class NumpyConvert {
             }
         } else if (issubdtype(input_dtype, py::dtype("bytes"))) {
             convert_bytes();
-        } else if (
-            issubdtype(input_dtype, py::dtype("uint16")) ||
-            issubdtype(input_dtype, py::dtype("int16")) ||
-            issubdtype(input_dtype, py::dtype("uint32")) ||
-            issubdtype(input_dtype, py::dtype("int32")) ||
-            issubdtype(input_dtype, py::dtype("int64")) ||
-            issubdtype(input_dtype, py::dtype("uint64")) ||
-            issubdtype(input_dtype, py::dtype("float32")) ||
-            issubdtype(input_dtype, py::dtype("float64"))) {
-            convert_numeric();
         } else if (!input_dtype.equal(py::dtype("O"))) {
             // TODO TPY_ERROR_LOC
             throw std::runtime_error("expected object array");

--- a/tiledb/tests/test_attribute.py
+++ b/tiledb/tests/test_attribute.py
@@ -311,3 +311,95 @@ class AttributeTest(DiskTestCase):
         with tiledb.DenseArray(self.path("foo"), mode="r") as T:
             for i in range(2):
                 assert_array_equal(T[:][i].tobytes(), A[i])
+
+    def test_var_numeric_attribute(self):
+        uri = self.path("test_var_numeric_attribute")
+        ctx = tiledb.Ctx()
+
+        schema = tiledb.ArraySchema(
+            domain=tiledb.Domain(
+                tiledb.Dim(name="sample", domain=(None, None), dtype="ascii")
+            ),
+            attrs=[tiledb.Attr(name="value", dtype="uint32", var=True, nullable=False)],
+            sparse=True,
+            allows_duplicates=True,
+        )
+
+        data = np.array(
+            [
+                np.array([1, 2], dtype="uint32"),
+                np.array([3], dtype="uint32"),
+                np.array([4], dtype="uint32"),
+            ],
+            dtype="O",
+        )
+
+        tiledb.Array.create(uri, schema)
+
+        with tiledb.open(uri, "w", ctx=ctx) as A:
+            A[[b"sample1", b"sample2", b"sample3"]] = data
+
+        with tiledb.open(uri, "r", ctx=ctx) as A:
+            assert_array_equal(A[:]["value"][0], data[0])
+            assert_array_equal(A[:]["value"][1], data[1])
+            assert_array_equal(A[:]["value"][2], data[2])
+
+            with pytest.raises(tiledb.TileDBError) as exc:
+                A.df[:]
+            assert (
+                "Variable-length numeric attributes are not supported in Arrow"
+                in str(exc.value)
+            )
+
+            with pytest.raises(tiledb.TileDBError) as exc:
+                A.query(use_arrow=True).df[:]
+            assert (
+                "Variable-length numeric attributes are not supported in Arrow"
+                in str(exc.value)
+            )
+
+    def test_var_nullable_numeric_attribute(self):
+        uri = self.path("test_var_nullable_numeric_attribute")
+        ctx = tiledb.Ctx()
+
+        schema = tiledb.ArraySchema(
+            domain=tiledb.Domain(
+                tiledb.Dim(name="sample", domain=(None, None), dtype="ascii")
+            ),
+            attrs=[tiledb.Attr(name="value", dtype="float32", var=True, nullable=True)],
+            sparse=True,
+            allows_duplicates=True,
+        )
+
+        data = np.array(
+            [
+                np.array([1.0, 2.0], dtype="float32"),
+                np.array(np.nan, dtype="float32"),
+                np.array([4.0], dtype="float32"),
+            ],
+            dtype="O",
+        )
+
+        tiledb.Array.create(uri, schema)
+
+        with tiledb.open(uri, "w", ctx=ctx) as A:
+            A[[b"sample1", b"sample2", b"sample3"]] = data
+
+        with tiledb.open(uri, "r", ctx=ctx) as A:
+            assert_array_equal(A[:]["value"][0], data[0])
+            assert_array_equal(A[:]["value"][1], data[1])
+            assert_array_equal(A[:]["value"][2], data[2])
+
+            with pytest.raises(tiledb.TileDBError) as exc:
+                A.df[:]
+            assert (
+                "Variable-length numeric attributes are not supported in Arrow"
+                in str(exc.value)
+            )
+
+            with pytest.raises(tiledb.TileDBError) as exc:
+                A.query(use_arrow=True).df[:]
+            assert (
+                "Variable-length numeric attributes are not supported in Arrow"
+                in str(exc.value)
+            )

--- a/tiledb/tests/test_attribute.py
+++ b/tiledb/tests/test_attribute.py
@@ -344,19 +344,20 @@ class AttributeTest(DiskTestCase):
             assert_array_equal(A[:]["value"][1], data[1])
             assert_array_equal(A[:]["value"][2], data[2])
 
-            with pytest.raises(tiledb.TileDBError) as exc:
-                A.df[:]
-            assert (
-                "Variable-length numeric attributes are not supported in Arrow"
-                in str(exc.value)
-            )
+            if has_pandas():
+                with pytest.raises(tiledb.TileDBError) as exc:
+                    A.df[:]
+                assert (
+                    "Variable-length numeric attributes are not supported in Arrow"
+                    in str(exc.value)
+                )
 
-            with pytest.raises(tiledb.TileDBError) as exc:
-                A.query(use_arrow=True).df[:]
-            assert (
-                "Variable-length numeric attributes are not supported in Arrow"
-                in str(exc.value)
-            )
+                with pytest.raises(tiledb.TileDBError) as exc:
+                    A.query(use_arrow=True).df[:]
+                assert (
+                    "Variable-length numeric attributes are not supported in Arrow"
+                    in str(exc.value)
+                )
 
     def test_var_nullable_numeric_attribute(self):
         uri = self.path("test_var_nullable_numeric_attribute")
@@ -390,16 +391,17 @@ class AttributeTest(DiskTestCase):
             assert_array_equal(A[:]["value"][1], data[1])
             assert_array_equal(A[:]["value"][2], data[2])
 
-            with pytest.raises(tiledb.TileDBError) as exc:
-                A.df[:]
-            assert (
-                "Variable-length numeric attributes are not supported in Arrow"
-                in str(exc.value)
-            )
+            if has_pandas():
+                with pytest.raises(tiledb.TileDBError) as exc:
+                    A.df[:]
+                assert (
+                    "Variable-length numeric attributes are not supported in Arrow"
+                    in str(exc.value)
+                )
 
-            with pytest.raises(tiledb.TileDBError) as exc:
-                A.query(use_arrow=True).df[:]
-            assert (
-                "Variable-length numeric attributes are not supported in Arrow"
-                in str(exc.value)
-            )
+                with pytest.raises(tiledb.TileDBError) as exc:
+                    A.query(use_arrow=True).df[:]
+                assert (
+                    "Variable-length numeric attributes are not supported in Arrow"
+                    in str(exc.value)
+                )

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -1343,8 +1343,12 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
 
         with tiledb.open(uri) as A:
             # TODO: update the test when we support Arrow lists
-            with pytest.raises(pyarrow.lib.ArrowInvalid):
+            with pytest.raises(tiledb.TileDBError) as exc:
                 A.df[:]
+            assert (
+                "Variable-length numeric attributes are not supported in Arrow"
+                in str(exc.value)
+            )
 
             df2 = A.query(use_arrow=False).df[:]
             tm.assert_frame_equal(df, df2, check_dtype=False)


### PR DESCRIPTION
This PR adds tests with heterogeneous arrays that contain variable-length nullable numeric attributes. Additionally, it provides an appropriate error message when `Arrow` is used in such cases. The new message replaces the misleading `Expected 2 buffers for imported type uint32, ArrowArray struct has 3` error that was previously displayed.

In a future PR, support for Arrow could be added once this is supported by Arrow C Data Interface.

---

[sc-41582]