### PR TITLE
Pin TileDB 2.26.2 to prevent backward compatibility daily test failures

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -15,7 +15,7 @@ jobs:
   ci2:
     uses: ./.github/workflows/daily-test-build.yml
     with:
-      libtiledb_version: '2.26.3'
+      libtiledb_version: '2.26.2'
 
   ci3:
     uses: ./.github/workflows/daily-test-build-numpy.yml
@@ -25,4 +25,4 @@ jobs:
   ci4:
     uses: ./.github/workflows/daily-test-build-numpy.yml
     with:
-      libtiledb_version: '2.26.3'
+      libtiledb_version: '2.26.2'


### PR DESCRIPTION
TileDB [2.26.3](https://github.com/TileDB-Inc/TileDB/releases/tag/2.26.3) is a build system-only update release. As a result, no artifacts are present, causing daily tests that check for backward compatibility to fail. This PR pins the version to [2.26.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.26.2).

Fixes #2163