### PR TITLE
Fix `stats_reset()` behavior

### DIFF
--- a/tiledb/stats.py
+++ b/tiledb/stats.py
@@ -20,9 +20,9 @@ def stats_disable():
 
 def stats_reset():
     """Reset all TileDB internal statistics to 0."""
-    from .main import init_stats
+    from .main import reset_stats
 
-    init_stats()
+    reset_stats()
 
 
 def stats_dump(

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -363,7 +363,9 @@ def assert_dict_arrays_equal(d1, d2, ordered=True):
         assert_unordered_equal(array1, array2, True)
 
 
-def assert_captured(cap, expected):
+def assert_captured(cap, val, expected=True):
+    """Assert that the captured output contains
+    or does not contain a value"""
     if sys.platform != "win32":
         import ctypes
 
@@ -372,7 +374,7 @@ def assert_captured(cap, expected):
 
         out, err = cap.readouterr()
         assert not err
-        assert expected in out
+        assert (val in out) == expected
 
 
 @pytest.fixture(scope="module", params=["hilbert", "row-major", "col-major"])


### PR DESCRIPTION
This PR fixes `stats_reset()`, which was noticed to not reset stats after calling `tiledb.stats_reset()`.

---

[sc-63203]