### PR TITLE
Update HISTORY for 0.33.5 against TileDB 2.27.2

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -10,7 +10,7 @@ jobs:
   ci1:
     uses: ./.github/workflows/daily-test-build.yml
     with:
-      libtiledb_version: '2.27.1'
+      libtiledb_version: '2.27.2'
 
   ci2:
     uses: ./.github/workflows/daily-test-build.yml
@@ -20,7 +20,7 @@ jobs:
   ci3:
     uses: ./.github/workflows/daily-test-build-numpy.yml
     with:
-      libtiledb_version: '2.27.1'
+      libtiledb_version: '2.27.2'
 
   ci4:
     uses: ./.github/workflows/daily-test-build-numpy.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ if (NOT TileDB_FOUND)
         message(STATUS "Downloading TileDB default version ...")
         # Download latest release
         fetch_prebuilt_tiledb(
-                VERSION 2.27.1
-                RELLIST_HASH SHA256=ded52a6dd95ef139fed369920d2c6c6c92d9e49bca935ca65d51e6dcf9902daa
+                VERSION 2.27.2
+                RELLIST_HASH SHA256=b514c20cfd45c2250fea5c2efcb80facf953e647416fc1fdc6ac8133a7f8dc4d
         )
     endif()
     find_package(TileDB REQUIRED)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,18 @@
+# Release 0.33.5
+
+* TileDB-Py 0.33.5 includes TileDB Embedded [2.27.2](https://github.com/TileDB-Inc/TileDB/releases/tag/2.27.2)
+
+## Bug Fixes
+
+* Fix `stats_reset()` behavior by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/2172
+* Fix for query conditions that contain attributes with dot(s) when using the `in` operator by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/2171
+
+## Improvements
+* Expand `.df` Array/Query accessor to allow indexing with NumPy and PyArrow arrays by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/2170
+* Improve the logic for using Arrow when it is not explicitly requested by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/2168
+
+**Full Changelog**: https://github.com/TileDB-Inc/TileDB-Py/compare/0.33.4...0.33.5
+
 # Release 0.33.4
 
 * TileDB-Py 0.33.4 includes TileDB Embedded [2.27.1](https://github.com/TileDB-Inc/TileDB/releases/tag/2.27.1)


### PR DESCRIPTION
Update HISTORY for 0.33.5 against TileDB 2.27.2