### PR TITLE
Fix URI passed to consolidation

### DIFF
--- a/tiledb/array.py
+++ b/tiledb/array.py
@@ -738,7 +738,7 @@ class Array:
                     "passed to `fragment_uris` will be consolidate",
                     DeprecationWarning,
                 )
-            lt.Array._consolidate(self.array.uri, self.ctx, fragment_uris, config)
+            lt.Array._consolidate(self.uri, self.ctx, fragment_uris, config)
             return
         elif timestamp is not None:
             warnings.warn(


### PR DESCRIPTION
`self.array.uri` would need to be changed to private method `self.array._uri()`. But the attribute is stored to the Py class so use it as is done in logic down on ln 766.

This impacts APIs including tiledb-py, cloud-py and any other API consolidating with specific fragments URIs