### PR TITLE
Fix: Consider index passed, even if the current domain is present

### DIFF
--- a/tiledb/array.py
+++ b/tiledb/array.py
@@ -150,18 +150,13 @@ def index_domain_subarray(array, dom, idx: tuple):
 
         # In the case that current domain is non-empty, we need to consider it
         if (
-            start is None
-            and stop is None
-            and hasattr(array.schema, "current_domain")
+            hasattr(array.schema, "current_domain")
             and not array.schema.current_domain.is_empty
         ):
-            subarray.append(
-                (
-                    array.schema.current_domain.ndrectangle.range(r)[0],
-                    array.schema.current_domain.ndrectangle.range(r)[1],
-                )
-            )
-            continue
+            if start is None:
+                dim_lb = array.schema.current_domain.ndrectangle.range(r)[0]
+            if stop is None:
+                dim_ub = array.schema.current_domain.ndrectangle.range(r)[1]
 
         if np.issubdtype(dim_dtype, np.str_) or np.issubdtype(dim_dtype, np.bytes_):
             if start is None or stop is None:

--- a/tiledb/array.py
+++ b/tiledb/array.py
@@ -128,21 +128,6 @@ def index_domain_subarray(array, dom, idx: tuple):
 
     subarray = list()
 
-    # In the case that current domain is non-empty, we need to consider it
-    if (
-        hasattr(array.schema, "current_domain")
-        and not array.schema.current_domain.is_empty
-    ):
-        for i in range(array.schema.domain.ndim):
-            subarray.append(
-                (
-                    array.schema.current_domain.ndrectangle.range(i)[0],
-                    array.schema.current_domain.ndrectangle.range(i)[1],
-                )
-            )
-
-        return subarray
-
     for r in range(ndim):
         # extract lower and upper bounds for domain dimension extent
         dim = dom.dim(r)
@@ -162,6 +147,21 @@ def index_domain_subarray(array, dom, idx: tuple):
             raise IndexError("invalid index type: {!r}".format(type(dim_slice)))
 
         start, stop, step = dim_slice.start, dim_slice.stop, dim_slice.step
+
+        # In the case that current domain is non-empty, we need to consider it
+        if (
+            start is None
+            and stop is None
+            and hasattr(array.schema, "current_domain")
+            and not array.schema.current_domain.is_empty
+        ):
+            subarray.append(
+                (
+                    array.schema.current_domain.ndrectangle.range(r)[0],
+                    array.schema.current_domain.ndrectangle.range(r)[1],
+                )
+            )
+            continue
 
         if np.issubdtype(dim_dtype, np.str_) or np.issubdtype(dim_dtype, np.bytes_):
             if start is None or stop is None:

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -263,7 +263,7 @@ def getitem_ranges_with_labels(
             dim_ranges[dim_idx] = dim_ranges_from_selection(
                 dim_sel,
                 ned[dim_idx],
-                current_domain.ndrectangle.range(i) if current_domain else None,
+                current_domain.ndrectangle.range(dim_idx) if current_domain else None,
                 is_sparse,
             )
     return dim_ranges, label_ranges

--- a/tiledb/tests/test_current_domain.py
+++ b/tiledb/tests/test_current_domain.py
@@ -308,10 +308,24 @@ class CurrentDomainTest(DiskTestCase):
 
             # check indexing the array inside the range of the current domain
             assert_array_equal(A[11:14, 33:35]["a"], expected_array[1:4, 3:5])
+            filtered_df = expected_df.query(
+                "d1 >= 11 and d1 <= 14 and d2 >= 33 and d2 <= 35"
+            ).reset_index(drop=True)
+            assert_array_equal(A.df[11:14, 33:35], filtered_df)
+
+            # check only one side of the range
+            assert_array_equal(A[11:, :35]["a"], expected_array[1:, :5])
+            filtered_df = expected_df.query("d1 >= 11 and d2 <= 35").reset_index(
+                drop=True
+            )
+            assert_array_equal(A.df[11:, :35], filtered_df)
 
             # check indexing the array outside the range of the current domain - should raise an error
             with self.assertRaises(tiledb.TileDBError):
                 A[11:55, 33:34]
+
+            with self.assertRaises(tiledb.TileDBError):
+                A.df[11:55, 33:34]
 
     def test_take_current_domain_into_account_sparse_indexing_sc61914(self):
         uri = self.path("test_sc61914")

--- a/tiledb/tests/test_current_domain.py
+++ b/tiledb/tests/test_current_domain.py
@@ -304,7 +304,14 @@ class CurrentDomainTest(DiskTestCase):
             )
 
             assert_array_equal(A, expected_array)
-            assert_array_equal(A.df[:], expected_df)
+            assert_array_equal(A.df[:, :], expected_df)
+
+            # check indexing the array inside the range of the current domain
+            assert_array_equal(A[11:14, 33:35]["a"], expected_array[1:4, 3:5])
+
+            # check indexing the array outside the range of the current domain - should raise an error
+            with self.assertRaises(tiledb.TileDBError):
+                A[11:55, 33:34]
 
     def test_take_current_domain_into_account_sparse_indexing_sc61914(self):
         uri = self.path("test_sc61914")


### PR DESCRIPTION
This PR fixes an issue originating from https://github.com/TileDB-Inc/TileDB-Py/pull/2156, which resulted in the current domain being used whenever it was present. This caused problems when indexing with an explicit `idx` while a current domain was present, leading to `idx` and nonempty domain not being used.

cc. @ypatia

---

[sc-64437]