### PR TITLE
Add the missing `keep_alive` for `ctx` passed to pybind11 class constructors

### DIFF
--- a/tiledb/libtiledb/attribute.cc
+++ b/tiledb/libtiledb/attribute.cc
@@ -75,11 +75,15 @@ void init_attribute(py::module& m) {
     py::class_<tiledb::Attribute>(m, "Attribute")
         .def(py::init<Attribute>())
 
-        .def(py::init<Context&, std::string&, tiledb_datatype_t>())
+        .def(
+            py::init<Context&, std::string&, tiledb_datatype_t>(),
+            py::keep_alive<1, 2>())
 
-        .def(py::init<Context&, std::string&, tiledb_datatype_t, FilterList&>())
+        .def(
+            py::init<Context&, std::string&, tiledb_datatype_t, FilterList&>(),
+            py::keep_alive<1, 2>())
 
-        .def(py::init<const Context&, py::capsule>())
+        .def(py::init<const Context&, py::capsule>(), py::keep_alive<1, 2>())
 
         .def(
             "__capsule__",

--- a/tiledb/libtiledb/current_domain.cc
+++ b/tiledb/libtiledb/current_domain.cc
@@ -229,7 +229,7 @@ void init_current_domain(py::module& m) {
     py::class_<CurrentDomain>(m, "CurrentDomain")
         .def(py::init<CurrentDomain>())
 
-        .def(py::init<const Context&>())
+        .def(py::init<const Context&>(), py::keep_alive<1, 2>())
 
         .def(
             "__capsule__",

--- a/tiledb/libtiledb/dimension_label.cc
+++ b/tiledb/libtiledb/dimension_label.cc
@@ -18,7 +18,7 @@ void init_dimension_label(py::module& m) {
     py::class_<DimensionLabel>(m, "DimensionLabel")
         .def(py::init<DimensionLabel>())
 
-        .def(py::init<const Context&, py::capsule>())
+        .def(py::init<const Context&, py::capsule>(), py::keep_alive<1, 2>())
 
         .def(
             "__capsule__",

--- a/tiledb/libtiledb/enumeration.cc
+++ b/tiledb/libtiledb/enumeration.cc
@@ -18,63 +18,69 @@ void init_enumeration(py::module& m) {
     py::class_<Enumeration>(m, "Enumeration")
         .def(py::init<Enumeration>())
 
-        .def(py::init([](const Context& ctx,
-                         const std::string& name,
-                         py::dtype type,
-                         bool ordered) {
-            tiledb_datatype_t data_type;
-            try {
-                data_type = np_to_tdb_dtype(type);
-            } catch (const TileDBPyError& e) {
-                throw py::type_error(e.what());
-            }
-            py::size_t cell_val_num = get_ncells(type);
+        .def(
+            py::init([](const Context& ctx,
+                        const std::string& name,
+                        py::dtype type,
+                        bool ordered) {
+                tiledb_datatype_t data_type;
+                try {
+                    data_type = np_to_tdb_dtype(type);
+                } catch (const TileDBPyError& e) {
+                    throw py::type_error(e.what());
+                }
+                py::size_t cell_val_num = get_ncells(type);
 
-            return Enumeration::create_empty(
-                ctx, name, data_type, cell_val_num, ordered);
-        }))
+                return Enumeration::create_empty(
+                    ctx, name, data_type, cell_val_num, ordered);
+            }),
+            py::keep_alive<1, 2>())
 
-        .def(py::init([](const Context& ctx,
-                         const std::string& name,
-                         std::vector<std::string>& values,
-                         bool ordered,
-                         tiledb_datatype_t type) {
-            return Enumeration::create(ctx, name, values, ordered, type);
-        }))
+        .def(
+            py::init([](const Context& ctx,
+                        const std::string& name,
+                        std::vector<std::string>& values,
+                        bool ordered,
+                        tiledb_datatype_t type) {
+                return Enumeration::create(ctx, name, values, ordered, type);
+            }),
+            py::keep_alive<1, 2>())
 
-        .def(py::init([](const Context& ctx,
-                         const std::string& name,
-                         bool ordered,
-                         py::array data,
-                         py::array offsets) {
-            tiledb_datatype_t data_type;
-            try {
-                data_type = np_to_tdb_dtype(data.dtype());
-            } catch (const TileDBPyError& e) {
-                throw py::type_error(e.what());
-            }
+        .def(
+            py::init([](const Context& ctx,
+                        const std::string& name,
+                        bool ordered,
+                        py::array data,
+                        py::array offsets) {
+                tiledb_datatype_t data_type;
+                try {
+                    data_type = np_to_tdb_dtype(data.dtype());
+                } catch (const TileDBPyError& e) {
+                    throw py::type_error(e.what());
+                }
 
-            py::buffer_info data_buffer = data.request();
-            if (data_buffer.ndim != 1)
-                throw py::type_error(
-                    "Only 1D Numpy arrays can be stored as "
-                    "enumeration values");
+                py::buffer_info data_buffer = data.request();
+                if (data_buffer.ndim != 1)
+                    throw py::type_error(
+                        "Only 1D Numpy arrays can be stored as "
+                        "enumeration values");
 
-            py::size_t cell_val_num = offsets.size() == 0 ?
-                                          get_ncells(data.dtype()) :
-                                          TILEDB_VAR_NUM;
+                py::size_t cell_val_num = offsets.size() == 0 ?
+                                              get_ncells(data.dtype()) :
+                                              TILEDB_VAR_NUM;
 
-            return Enumeration::create(
-                ctx,
-                name,
-                data_type,
-                cell_val_num,
-                ordered,
-                data.data(),
-                data.nbytes(),
-                offsets.size() == 0 ? nullptr : offsets.data(),
-                offsets.nbytes());
-        }))
+                return Enumeration::create(
+                    ctx,
+                    name,
+                    data_type,
+                    cell_val_num,
+                    ordered,
+                    data.data(),
+                    data.nbytes(),
+                    offsets.size() == 0 ? nullptr : offsets.data(),
+                    offsets.nbytes());
+            }),
+            py::keep_alive<1, 2>())
 
         .def(py::init<const Context&, py::capsule>(), py::keep_alive<1, 2>())
 

--- a/tiledb/libtiledb/filter.cc
+++ b/tiledb/libtiledb/filter.cc
@@ -16,7 +16,9 @@ namespace py = pybind11;
 
 void init_filter(py::module& m) {
     py::class_<Filter>(m, "Filter")
-        .def(py::init<const Context&, tiledb_filter_type_t>())
+        .def(
+            py::init<const Context&, tiledb_filter_type_t>(),
+            py::keep_alive<1, 2>())
 
         .def_property_readonly("_type", &Filter::filter_type)
 

--- a/tiledb/libtiledb/schema.cc
+++ b/tiledb/libtiledb/schema.cc
@@ -196,9 +196,9 @@ void init_schema(py::module& m) {
 
         .def(py::init<Context&, tiledb_array_type_t>(), py::keep_alive<1, 2>())
 
-        .def(py::init<Context&, std::string&>())
+        .def(py::init<Context&, std::string&>(), py::keep_alive<1, 2>())
 
-        .def(py::init<Context&, py::capsule>())
+        .def(py::init<Context&, py::capsule>(), py::keep_alive<1, 2>())
 
         .def(
             "__capsule__",

--- a/tiledb/schema_evolution.cc
+++ b/tiledb/schema_evolution.cc
@@ -18,19 +18,21 @@ using ArraySchemaEvolution = PyArraySchemaEvolution;
 
 void init_schema_evolution(py::module& m) {
     py::class_<ArraySchemaEvolution>(m, "ArraySchemaEvolution")
-        .def(py::init([](py::object ctx_py) {
-            tiledb_ctx_t* ctx_c = (py::capsule)ctx_py.attr("__capsule__")();
-            if (ctx_c == nullptr)
-                TPY_ERROR_LOC("Invalid context pointer");
+        .def(
+            py::init([](py::object ctx_py) {
+                tiledb_ctx_t* ctx_c = (py::capsule)ctx_py.attr("__capsule__")();
+                if (ctx_c == nullptr)
+                    TPY_ERROR_LOC("Invalid context pointer");
 
-            tiledb_array_schema_evolution_t* evol_p;
-            int rc = tiledb_array_schema_evolution_alloc(ctx_c, &evol_p);
-            if (rc != TILEDB_OK) {
-                TPY_ERROR_LOC(get_last_ctx_err_str(ctx_c, rc));
-            }
+                tiledb_array_schema_evolution_t* evol_p;
+                int rc = tiledb_array_schema_evolution_alloc(ctx_c, &evol_p);
+                if (rc != TILEDB_OK) {
+                    TPY_ERROR_LOC(get_last_ctx_err_str(ctx_c, rc));
+                }
 
-            return new PyArraySchemaEvolution({ctx_c, evol_p});
-        }))
+                return new PyArraySchemaEvolution({ctx_c, evol_p});
+            }),
+            py::keep_alive<1, 2>())
         .def(
             "add_attribute",
             [](ArraySchemaEvolution& inst, py::object attr_py) {

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -385,16 +385,12 @@ class FixesTest(DiskTestCase):
     def test_sc_64885_ctx_reference_lost(self):
         uri = self.path("test_sc_64885_ctx_reference_lost")
         config = tiledb.Config()
+
         enmr = tiledb.Enumeration("e", True, dtype="int")
         attrs = [tiledb.Attr(name="a", dtype=int, enum_label="e")]
         domain = tiledb.Domain(tiledb.Dim(domain=(0, 3), dtype=np.uint64))
         schema = tiledb.ArraySchema(domain=domain, attrs=attrs, enums=[enmr])
         tiledb.Array.create(uri, schema, ctx=tiledb.Ctx(config=config.dict()))
-
-        with tiledb.open(uri, ctx=tiledb.Ctx(config=config.dict())) as A:
-            assert A.schema.has_attr("a")
-            assert A.attr("a").enum_label == "e"
-            assert A.enum("e") == enmr
 
         se = tiledb.ArraySchemaEvolution(ctx=tiledb.Ctx(config=config.dict()))
         data = [1, 2, 3, 4]


### PR DESCRIPTION
This PR links the lifetime of the constructor's `ctx` element to the constructed object of each pybind11 class. This will fix instances failing to hold a Python pointer to the provided context, which causes errors when the `ctx` object is garbage collected.

---

[sc-64885]