### PR TITLE
Run tests of `test_fork_ctx` as subprocesses

### DIFF
--- a/tiledb/tests/test_fork_ctx.py
+++ b/tiledb/tests/test_fork_ctx.py
@@ -9,14 +9,35 @@ Python 3.14 will make it so you never accidentally fork():
 multiprocessing will default to "spawn" on Linux.
 """
 
-import multiprocessing
-import os
+import subprocess
 import sys
-import warnings
 
 import pytest
 
+
+def run_in_subprocess(code):
+    """Runs code in a separate subprocess."""
+    script = f"""
+import os
+import warnings
 import tiledb
+import multiprocessing
+
+warnings.simplefilter('error')
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+warnings.filterwarnings("ignore", category=UserWarning)
+
+def wrapper_func():
+    {code}
+
+wrapper_func()
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(result.stderr)
+    assert result.returncode == 0
 
 
 @pytest.mark.skipif(
@@ -24,43 +45,49 @@ import tiledb
 )
 def test_no_warning_fork_without_ctx():
     """Get no warning if no tiledb context exists."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        pid = os.fork()
-        if pid == 0:
-            os._exit(0)
-        else:
-            os.wait()
+    run_in_subprocess(
+        """
+    pid = os.fork()
+    if pid == 0:
+        os._exit(0)
+    else:
+        os.wait()
+    """
+    )
 
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="fork() is not available on Windows"
 )
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_warning_fork_with_ctx():
     """Get a warning if we fork after creating a tiledb context."""
+    run_in_subprocess(
+        """
     _ = tiledb.Ctx()
-    with pytest.warns(UserWarning, match="TileDB is a multithreading library"):
-        pid = os.fork()
-        if pid == 0:
-            os._exit(0)
-        else:
-            os.wait()
+    pid = os.fork()
+    if pid == 0:
+        os._exit(0)
+    else:
+        os.wait()
+    """
+    )
 
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="fork() is not available on Windows"
 )
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_warning_fork_with_default_ctx():
     """Get a warning if we fork after creating a default context."""
+    run_in_subprocess(
+        """
     _ = tiledb.default_ctx()
-    with pytest.warns(UserWarning, match="TileDB is a multithreading library"):
-        pid = os.fork()
-        if pid == 0:
-            os._exit(0)
-        else:
-            os.wait()
+    pid = os.fork()
+    if pid == 0:
+        os._exit(0)
+    else:
+        os.wait()
+    """
+    )
 
 
 @pytest.mark.skipif(
@@ -68,37 +95,43 @@ def test_warning_fork_with_default_ctx():
 )
 def test_no_warning_multiprocessing_without_ctx():
     """Get no warning if no tiledb context exists."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        mp = multiprocessing.get_context("fork")
-        p = mp.Process()
-        p.start()
-        p.join()
+    run_in_subprocess(
+        """
+    mp = multiprocessing.get_context("fork")
+    p = mp.Process()
+    p.start()
+    p.join()
+    """
+    )
 
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="fork() is not available on Windows"
 )
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_warning_multiprocessing_with_ctx():
     """Get a warning if we fork after creating a tiledb context."""
+    run_in_subprocess(
+        """
     _ = tiledb.Ctx()
     mp = multiprocessing.get_context("fork")
     p = mp.Process()
-    with pytest.warns(UserWarning, match="TileDB is a multithreading library"):
-        p.start()
+    p.start()
     p.join()
+    """
+    )
 
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="fork() is not available on Windows"
 )
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_warning_multiprocessing_with_default_ctx():
     """Get a warning if we fork after creating a default context."""
+    run_in_subprocess(
+        """
     _ = tiledb.default_ctx()
     mp = multiprocessing.get_context("fork")
     p = mp.Process()
-    with pytest.warns(UserWarning, match="TileDB is a multithreading library"):
-        p.start()
+    p.start()
     p.join()
+    """
+    )


### PR DESCRIPTION
This PR modifies the tests in `test_fork_ctx.py` to run as subprocesses, fixing #2175. This has been verified by running the "Build and test wheels" workflow against the current branch: [run](https://github.com/TileDB-Inc/TileDB-Py/actions/runs/14227535058/job/39870535651). The failure rate was previously 100% for macos.

---

[sc-64149][sc-57975]