### PR TITLE
Remove testing of non-existent VFS parent directories

### DIFF
--- a/tiledb/tests/test_vfs.py
+++ b/tiledb/tests/test_vfs.py
@@ -50,12 +50,6 @@ class TestVFS(DiskTestCase):
 
         # create nested path
         dir = self.path("foo/bar")
-        if pytest.tiledb_vfs != "s3":
-            # this fails locally because "foo" base path does not exist
-            # this will not fail on s3 because there is no concept of directory
-            with self.assertRaises(tiledb.TileDBError):
-                vfs.create_dir(dir)
-
         vfs.create_dir(self.path("foo"))
         vfs.create_dir(self.path("foo/bar"))
         if pytest.tiledb_vfs != "s3":
@@ -77,11 +71,6 @@ class TestVFS(DiskTestCase):
 
         # check nested path
         file = self.path("foo/bar")
-        if pytest.tiledb_vfs != "s3":
-            # this fails locally because "foo" base path does not exist
-            # this will not fail on s3 because there is no concept of directory
-            with self.assertRaises(tiledb.TileDBError):
-                vfs.touch(file)
 
     def test_move(self):
         vfs = tiledb.VFS()
@@ -96,13 +85,6 @@ class TestVFS(DiskTestCase):
 
         self.assertFalse(vfs.is_file(self.path("bar/baz")))
         self.assertTrue(vfs.is_file(self.path("foo/baz")))
-
-        # moving to invalid dir should raise an error
-        if pytest.tiledb_vfs != "s3":
-            # this fails locally because "foo" base path does not exist
-            # this will not fail on s3 because there is no concept of directory
-            with self.assertRaises(tiledb.TileDBError):
-                vfs.move_dir(self.path("foo/baz"), self.path("do_not_exist/baz"))
 
     @pytest.mark.skipif(
         sys.platform == "win32",


### PR DESCRIPTION
Following https://github.com/TileDB-Inc/TileDB/pull/5480, let's remove the code that tests non-existent VFS parent directories.
We could make the code conditional based on the TileDB Arrays version, but I would prefer not to.

Addresses a part of https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/180
cc. @jdblischak