### PR TITLE
Remove failing test now that HDFS support has been removed

### DIFF
--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -3956,11 +3956,6 @@ class TestAsBuilt(DiskTestCase):
         else:
             assert x["gcs"]["enabled"] == False
 
-        if vfs.supports("hdfs"):
-            assert x["hdfs"]["enabled"] == True
-        else:
-            assert x["hdfs"]["enabled"] == False
-
         if vfs.supports("s3"):
             assert x["s3"]["enabled"] == True
         else:


### PR DESCRIPTION
Support for HDFS was removed upstream in TileDB in https://github.com/TileDB-Inc/TileDB/pull/5496. Now the nightly TileDB-Py builds against nightly TileDB fail this test with a `KeyError`.

xref: https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/182#issuecomment-2806755307, https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/46#issuecomment-2806899886