### PR TITLE
Avoid deprecation warnings for special attribute access in `CCProxy` after Hypothesis 6.131.1 update

### DIFF
--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -110,15 +110,16 @@ __version__ = version.version
 group_create = Group.create
 
 
-# Create a proxy object to wrap libtiledb and provide a `cc` alias
+# Create a proxy class to handle the deprecation of `tiledb.cc`
 class CCProxy:
     def __init__(self, module):
         self._module = module
 
     def __getattr__(self, name):
-        warnings.warn(
-            "`tiledb.cc` is deprecated. Please use `tiledb.libtiledb` instead.",
-        )
+        if not name.startswith("__"):
+            warnings.warn(
+                "`tiledb.cc` is deprecated. Please use `tiledb.libtiledb` instead.",
+            )
         return getattr(self._module, name)
 
     def __repr__(self):
@@ -128,9 +129,10 @@ class CCProxy:
         return self._module.__repr__()
 
 
+# Create a proxy object to wrap libtiledb and provide a `cc` alias
 cc = CCProxy(libtiledb)
 sys.modules["tiledb.cc"] = cc
-cc = cc
+# Delete the class to avoid namespace pollution
 del CCProxy
 
 # Note: we use a modified namespace packaging to allow continuity of existing TileDB-Py imports.


### PR DESCRIPTION
This PR prevents `CCProxy.__getattr__` from emitting deprecation warnings when accessing special attributes, such as `__file__`.

Hypothesis 6.131.1 [introduced logic that inspects local modules by accessing constant values](https://github.com/HypothesisWorks/hypothesis/releases/tag/hypothesis-python-6.131.1), including attributes like `__file__`. This triggered warnings during test runs due to our proxy class warning.

Closes #2183, closes https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/47

cc. @jdblischak