### PR TITLE
Wrap `Profile`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ if (NOT TileDB_FOUND)
         message(STATUS "Downloading TileDB default version ...")
         # Download latest release
         fetch_prebuilt_tiledb(
-                VERSION 2.28.0
-                RELLIST_HASH SHA256=40c8a0b5b7ddfe6150e3ce390fd95761d2b7d5910ea3fd5c7dfb67d431e64660
+                VERSION 2.28.1-rc1
+                RELLIST_HASH SHA256=af1840944e71172463bbf5811ec4426db573c2baf4b708f1eb2c0546e2a3121e
         )
     endif()
     find_package(TileDB REQUIRED)

--- a/examples/profile.py
+++ b/examples/profile.py
@@ -1,4 +1,4 @@
-# query_condition_sparse.py
+# profile.py
 #
 # LICENSE
 #
@@ -40,27 +40,19 @@ tiledb_namespace = os.getenv("TILEDB_NAMESPACE")
 s3_bucket = os.getenv("S3_BUCKET")
 
 
-def create_and_save_profiles():
-    p1 = tiledb.Profile()
+def create_and_save_profile():
+    p1 = tiledb.Profile("my_profile_name")
     p1["rest.token"] = tiledb_token
     p1.save()
 
-    p2 = tiledb.Profile("my_profile_name")
-    p2["rest.server_address"] = "https://my.address"
-    p2.save()
 
-
-def use_profiles():
+def use_profile():
     # Create a config object. This will use the default profile.
-    cfg = tiledb.Config()
+    cfg = tiledb.Config({"profile_name": "my_profile_name"})
     print("rest.token:", cfg["rest.token"])
 
-    # Create a config object using a specific profile name.
-    cfg_with_profile = tiledb.Config({"profile_name": "my_profile_name"})
-    print("rest.server_address:", cfg_with_profile["rest.server_address"])
-
     # Use on of the profile to create a context.
-    ctx = tiledb.Ctx(cfg_with_profile)
+    ctx = tiledb.Ctx(cfg)
 
     # Use the context to create a new array. The REST credentials from the profile will be used.
     # Useful to include the datetime in the array name to handle multiple consecutive runs of the test.
@@ -78,15 +70,12 @@ def use_profiles():
     tiledb.Array.create(uri, schema, ctx=ctx)
 
 
-def remove_profiles():
+def remove_profile():
     # Remove the default profile
-    tiledb.Profile.remove()
-
-    # Remove a specific profile by name
     tiledb.Profile.remove("my_profile_name")
 
 
 if __name__ == "__main__":
-    create_and_save_profiles()
-    use_profiles()
-    remove_profiles()
+    create_and_save_profile()
+    use_profile()
+    remove_profile()

--- a/examples/profile.py
+++ b/examples/profile.py
@@ -1,0 +1,76 @@
+# query_condition_sparse.py
+#
+# LICENSE
+#
+# The MIT License
+#
+# Copyright (c) 2025 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+# This example demonstrates how to create, save, and use profiles in TileDB.
+# It also shows how to remove profiles when they are no longer needed.
+
+import tiledb
+
+
+def create_and_save_profiles():
+    p1 = tiledb.Profile()
+    p1["rest.token"] = "my_token"
+    p1.save()
+
+    p2 = tiledb.Profile("my_profile_name")
+    p2["rest.server_address"] = "https://my.address"
+    p2.save()
+
+
+def use_profiles():
+    # Create a config object. This will use the default profile.
+    cfg = tiledb.Config()
+    print("rest.token:", cfg["rest.token"])
+
+    # Create a config object using a specific profile name.
+    cfg_with_profile = tiledb.Config({"profile_name": "my_profile_name"})
+    print("rest.server_address:", cfg_with_profile["rest.server_address"])
+
+    # Use on of the profile to create a context.
+    ctx = tiledb.Ctx(cfg_with_profile)
+
+    # Use the context to create a new array. The REST credentials from the profile will be used.
+    array_name = "tiledb://my_workspace/my_teamspace/my_array"
+    dom = tiledb.Domain(tiledb.Dim(name="d", domain=(1, 10), tile=5, dtype="int32"))
+    schema = tiledb.ArraySchema(
+        domain=dom, sparse=False, attrs=[tiledb.Attr(name="a", dtype="float64")]
+    )
+    tiledb.Array.create(array_name, schema, ctx=ctx)
+
+
+def remove_profiles():
+    # Remove the default profile
+    tiledb.Profile.remove()
+
+    # Remove a specific profile by name
+    tiledb.Profile.remove("my_profile_name")
+
+
+if __name__ == "__main__":
+    create_and_save_profiles()
+    use_profiles()
+    remove_profiles()

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -25,6 +25,9 @@ if libtiledb_version() >= (2, 26):
     from .current_domain import CurrentDomain
     from .ndrectangle import NDRectangle
 
+if libtiledb_version()[0] == 2 and libtiledb_version()[1] >= 29:
+    from .profile import Profile
+
 del libtiledb_version  # no longer needed
 
 from .array import Array

--- a/tiledb/__init__.py
+++ b/tiledb/__init__.py
@@ -25,7 +25,7 @@ if libtiledb_version() >= (2, 26):
     from .current_domain import CurrentDomain
     from .ndrectangle import NDRectangle
 
-if libtiledb_version()[0] == 2 and libtiledb_version()[1] >= 29:
+if libtiledb_version() >= (2, 28, 1):
     from .profile import Profile
 
 del libtiledb_version  # no longer needed

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -16,6 +16,7 @@ pybind11_add_module(
     group.cc
     metadata.h
     object.cc
+    profile.cc
     query.cc
     schema.cc
     subarray.cc

--- a/tiledb/libtiledb/profile.cc
+++ b/tiledb/libtiledb/profile.cc
@@ -14,7 +14,10 @@ using namespace tiledbpy::common;
 namespace py = pybind11;
 
 void init_profile(py::module& m) {
-#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 29
+#if TILEDB_VERSION_MAJOR > 2 ||                                 \
+    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR > 28) || \
+    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR == 28 && \
+     TILEDB_VERSION_PATCH >= 1)
     py::class_<tiledb::Profile>(m, "Profile")
 
         .def(

--- a/tiledb/libtiledb/profile.cc
+++ b/tiledb/libtiledb/profile.cc
@@ -1,0 +1,61 @@
+#include <tiledb/tiledb>
+#include <tiledb/tiledb_experimental>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <pybind11/stl.h>
+
+#include "common.h"
+
+namespace libtiledbcpp {
+
+using namespace tiledb;
+using namespace tiledbpy::common;
+namespace py = pybind11;
+
+void init_profile(py::module& m) {
+#if TILEDB_VERSION_MAJOR >= 2 && TILEDB_VERSION_MINOR >= 29
+    py::class_<tiledb::Profile>(m, "Profile")
+
+        .def(
+            py::init<std::optional<std::string>, std::optional<std::string>>(),
+            py::arg("name") = std::nullopt,
+            py::arg("dir") = std::nullopt)
+
+        .def(py::init<Profile>())
+
+        .def_property_readonly("_name", &tiledb::Profile::name)
+
+        .def_property_readonly("_dir", &tiledb::Profile::dir)
+
+        .def(
+            "_set_param",
+            &tiledb::Profile::set_param,
+            py::arg("param"),
+            py::arg("value"))
+
+        .def("_get_param", &tiledb::Profile::get_param, py::arg("param"))
+
+        .def("_save", &tiledb::Profile::save)
+
+        .def_static(
+            "_load",
+            py::overload_cast<
+                std::optional<std::string>,
+                std::optional<std::string>>(&tiledb::Profile::load),
+            py::arg("name") = std::nullopt,
+            py::arg("dir") = std::nullopt)
+
+        .def_static(
+            "_remove",
+            py::overload_cast<
+                std::optional<std::string>,
+                std::optional<std::string>>(&tiledb::Profile::remove),
+            py::arg("name") = std::nullopt,
+            py::arg("dir") = std::nullopt)
+
+        .def("_dump", &tiledb::Profile::dump);
+#endif
+}
+
+}  // namespace libtiledbcpp

--- a/tiledb/libtiledb/tiledbcpp.cc
+++ b/tiledb/libtiledb/tiledbcpp.cc
@@ -29,6 +29,7 @@ void init_filestore(py::module& m);
 void init_filter(py::module&);
 void init_group(py::module&);
 void init_object(py::module& m);
+void init_profile(py::module& m);
 void init_query(py::module& m);
 void init_schema(py::module&);
 void init_subarray(py::module&);
@@ -50,6 +51,7 @@ PYBIND11_MODULE(libtiledb, m) {
     init_filter(m);
     init_group(m);
     init_object(m);
+    init_profile(m);
     init_query(m);
     init_schema(m);
     init_subarray(m);

--- a/tiledb/profile.py
+++ b/tiledb/profile.py
@@ -68,13 +68,11 @@ class Profile(lt.Profile):
         :raises KeyError: If the parameter does not exist and raise_keyerror is True.
         :raises tiledb.TileDBError:
         """
-        try:
-            return self._get_param(param)
-        except Exception:
-            if raise_keyerror:
-                raise KeyError(param)
-            else:
-                return None
+        val = self._get_param(param)
+        if val is None and raise_keyerror:
+            raise KeyError(param)
+
+        return val
 
     def save(self):
         """Saves the profile to storage.

--- a/tiledb/profile.py
+++ b/tiledb/profile.py
@@ -1,0 +1,90 @@
+import tiledb.libtiledb as lt
+
+
+class Profile(lt.Profile):
+    """
+    Represents a TileDB profile.
+    """
+
+    def __init__(self, name: str = None, dir: str = None):
+        """Class representing a TileDB profile.
+
+        :param name: The name of the profile.
+        :param dir: The directory of the profile.
+        :raises tiledb.TileDBError:
+        """
+        super().__init__(name, dir)
+
+    @property
+    def name(self):
+        """The name of the profile.
+
+        :rtype: str
+        """
+        return self._name
+
+    @property
+    def dir(self):
+        """The directory of the profile.
+
+        :rtype: str
+        """
+        return self._dir
+
+    def __repr__(self):
+        """String representation of the profile.
+
+        :rtype: str
+        """
+        return self._dump()
+
+    def __setitem__(self, param: str, value: str):
+        """Sets a parameter for the profile.
+
+        :param param: The parameter name.
+        :param value: The parameter value.
+        :raises tiledb.TileDBError:
+        """
+        self._set_param(param, value)
+
+    def __getitem__(self, param: str):
+        """Gets a parameter for the profile.
+
+        :param param: The parameter name.
+        :raises tiledb.TileDBError:
+        """
+        return self._get_param(param)
+
+    def save(self):
+        """Saves the profile to storage.
+
+        :raises tiledb.TileDBError:
+        """
+        self._save()
+
+    @classmethod
+    def load(cls, name: str = None, dir: str = None) -> "Profile":
+        """Loads a profile from storage.
+
+        :param name: The name of the profile.
+        :param dir: The directory of the profile.
+        :return: The loaded profile.
+        :rtype: tiledb.Profile
+        :raises tiledb.TileDBError:
+        """
+        # This is a workaround for the from_pybind11 method due to the fact
+        # that this class does not inherit from CtxMixin, as is commonly done.
+        lt_obj = lt.Profile._load(name, dir)
+        py_obj = cls.__new__(cls)
+        lt.Profile.__init__(py_obj, lt_obj)
+        return py_obj
+
+    @classmethod
+    def remove(cls, name: str = None, dir: str = None):
+        """Removes a profile from storage.
+
+        :param name: The name of the profile.
+        :param dir: The directory of the profile.
+        :raises tiledb.TileDBError:
+        """
+        lt.Profile._remove(name, dir)

--- a/tiledb/profile.py
+++ b/tiledb/profile.py
@@ -47,10 +47,25 @@ class Profile(lt.Profile):
         """
         self._set_param(param, value)
 
-    def __getitem__(self, param: str, raise_keyerror: bool = True):
+    def __getitem__(self, param: str):
         """Gets a parameter for the profile.
 
         :param param: The parameter name.
+        :return: The parameter value.
+        :rtype: str
+        :raises KeyError: If the parameter does not exist.
+        :raises tiledb.TileDBError:
+        """
+        return self.get(param, raise_keyerror=True)
+
+    def get(self, param: str, raise_keyerror: bool = True):
+        """Gets a parameter for the profile.
+
+        :param param: The parameter name.
+        :param raise_keyerror: Whether to raise a KeyError if the parameter does not exist.
+        :return: The parameter value or None if it does not exist and raise_keyerror is False.
+        :rtype: str or None
+        :raises KeyError: If the parameter does not exist and raise_keyerror is True.
         :raises tiledb.TileDBError:
         """
         try:

--- a/tiledb/profile.py
+++ b/tiledb/profile.py
@@ -47,13 +47,19 @@ class Profile(lt.Profile):
         """
         self._set_param(param, value)
 
-    def __getitem__(self, param: str):
+    def __getitem__(self, param: str, raise_keyerror: bool = True):
         """Gets a parameter for the profile.
 
         :param param: The parameter name.
         :raises tiledb.TileDBError:
         """
-        return self._get_param(param)
+        try:
+            return self._get_param(param)
+        except Exception:
+            if raise_keyerror:
+                raise KeyError(param)
+            else:
+                return None
 
     def save(self):
         """Saves the profile to storage.

--- a/tiledb/tests/test_examples.py
+++ b/tiledb/tests/test_examples.py
@@ -42,6 +42,9 @@ class ExamplesTest:
         else:
             with tempfile.TemporaryDirectory() as tmpdir:
                 try:
+                    # Create environment with current env vars
+                    env = os.environ.copy()
+
                     subprocess.run(
                         [sys.executable, path],
                         cwd=tmpdir,
@@ -49,6 +52,7 @@ class ExamplesTest:
                         stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE,
                         encoding="utf8",
+                        env=env,
                     )
                 except subprocess.CalledProcessError as ex:
                     pytest.fail(ex.stderr, pytrace=False)

--- a/tiledb/tests/test_profile.py
+++ b/tiledb/tests/test_profile.py
@@ -63,6 +63,9 @@ class ProfileTest(ProfileTestCase):
         self.profile1["rest.server_address"] = server_address
         self.profile1["rest.token"] = token
         self.profile1["rest.username"] = username
+        with pytest.raises(KeyError):
+            # This should raise KeyError because the profile does not have this parameter
+            self.profile1["rest.non_existent_param"]
 
         goal_dict = {
             "default": {

--- a/tiledb/tests/test_profile.py
+++ b/tiledb/tests/test_profile.py
@@ -82,7 +82,6 @@ class ProfileTest(ProfileTestCase):
     def test_profile_save_load_remove(self):
         token = "testing_the_token_for_profile2"
         payer_namespace = "testing_the_namespace_for_profile2"
-        default_server_address = "https://api.tiledb.com"
 
         self.profile2["rest.token"] = token
         self.profile2["rest.payer_namespace"] = payer_namespace
@@ -96,9 +95,6 @@ class ProfileTest(ProfileTestCase):
         # check that the loaded profile has the same parameters
         assert loaded_profile.name == "profile2_name"
         assert Path(loaded_profile.dir) == Path(self.path("profile2_dir"))
-        assert loaded_profile["rest.username"] == ""
-        assert loaded_profile["rest.password"] == ""
-        assert loaded_profile["rest.server_address"] == default_server_address
         assert loaded_profile["rest.token"] == token
         assert loaded_profile["rest.payer_namespace"] == payer_namespace
 

--- a/tiledb/tests/test_profile.py
+++ b/tiledb/tests/test_profile.py
@@ -8,9 +8,9 @@ import tiledb.libtiledb as lt
 
 from .common import DiskTestCase
 
-if not (lt.version()[0] == 2 and lt.version()[1] >= 29):
+if lt.version() < (2, 28, 1):
     pytest.skip(
-        "Profile is only available in TileDB 2.29 and later",
+        "Profile is only available in TileDB 2.28.1 and later",
         allow_module_level=True,
     )
 

--- a/tiledb/tests/test_profile.py
+++ b/tiledb/tests/test_profile.py
@@ -1,0 +1,138 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import tiledb
+import tiledb.libtiledb as lt
+
+from .common import DiskTestCase
+
+if not (lt.version()[0] == 2 and lt.version()[1] >= 29):
+    pytest.skip(
+        "Profile is only available in TileDB 2.29 and later",
+        allow_module_level=True,
+    )
+
+"""
+Due to the nature of Profiles, they are touching the filesystem,
+so we need to be careful and not affect the user's Profiles.
+Thus we use DiskTestCase to create temporary directories.
+"""
+
+
+class ProfileTestCase(DiskTestCase):
+    def setup_method(self):
+        super().setup_method()
+        self.profile1 = tiledb.Profile(
+            dir=self.path("profile1_dir")
+        )  # profile with custom directory
+        self.profile2 = tiledb.Profile(
+            "profile2_name", self.path("profile2_dir")
+        )  # named profile with custom directory
+
+
+class ProfileTest(ProfileTestCase):
+    def test_profile_name(self):
+        assert self.profile1.name == "default"
+        assert self.profile2.name == "profile2_name"
+
+    def test_profile_dir(self):
+        assert Path(self.profile1.dir) == Path(self.path("profile1_dir"))
+        assert Path(self.profile2.dir) == Path(self.path("profile2_dir"))
+
+    def test_profile_set_get_param(self):
+        username = "my_username"
+        server_address = "https://my.address"
+
+        self.profile1["rest.username"] = username
+        assert self.profile1["rest.username"] == username
+
+        self.profile1["rest.server_address"] = server_address
+        assert self.profile1["rest.server_address"] == server_address
+
+    def test_profile_repr(self):
+        password = "testing_the_password"
+        payer_namespace = "testing_the_namespace"
+        server_address = "https://testing_the_address.com"
+        token = "testing_the_token"
+        username = "testing_the_username"
+
+        self.profile1["rest.password"] = password
+        self.profile1["rest.payer_namespace"] = payer_namespace
+        self.profile1["rest.server_address"] = server_address
+        self.profile1["rest.token"] = token
+        self.profile1["rest.username"] = username
+
+        goal_dict = {
+            "default": {
+                "rest.password": password,
+                "rest.payer_namespace": payer_namespace,
+                "rest.server_address": server_address,
+                "rest.token": token,
+                "rest.username": username,
+            }
+        }
+
+        assert goal_dict == json.loads(repr(self.profile1))
+
+    def test_profile_save_load_remove(self):
+        token = "testing_the_token_for_profile2"
+        payer_namespace = "testing_the_namespace_for_profile2"
+        default_server_address = "https://api.tiledb.com"
+
+        self.profile2["rest.token"] = token
+        self.profile2["rest.payer_namespace"] = payer_namespace
+
+        # save the profile
+        self.profile2.save()
+
+        # load the profile
+        loaded_profile = tiledb.Profile.load("profile2_name", self.path("profile2_dir"))
+
+        # check that the loaded profile has the same parameters
+        assert loaded_profile.name == "profile2_name"
+        assert Path(loaded_profile.dir) == Path(self.path("profile2_dir"))
+        assert loaded_profile["rest.username"] == ""
+        assert loaded_profile["rest.password"] == ""
+        assert loaded_profile["rest.server_address"] == default_server_address
+        assert loaded_profile["rest.token"] == token
+        assert loaded_profile["rest.payer_namespace"] == payer_namespace
+
+        # remove the profile
+        tiledb.Profile.remove("profile2_name", self.path("profile2_dir"))
+
+
+class ConfigWithProfileTest(ProfileTestCase):
+    def test_config_with_profile(self):
+        username = "username_coming_from_profile"
+        password = "password_coming_from_profile"
+        server_address = "https://profile_address.com"
+
+        # Create a profile and set some parameters
+        profile = tiledb.Profile(dir=self.path("profile_with_config_dir"))
+        profile["rest.username"] = username
+        profile["rest.password"] = password
+        profile["rest.server_address"] = server_address
+
+        # Save the profile
+        profile.save()
+
+        # -----
+        # The above is done only once, so we can use the same profile later
+        # -----
+
+        # Create a config and set the profile directory
+        config = tiledb.Config()
+        config["profile_dir"] = self.path("profile_with_config_dir")
+        # Test that the config parameters are set correctly
+        assert config["rest.username"] == username
+        assert config["rest.password"] == password
+        assert config["rest.server_address"] == server_address
+
+        # Alternatively, we can set the profile details directly in the Config constructor
+        config2 = tiledb.Config({"profile_dir": self.path("profile_with_config_dir")})
+        # Test that the config parameters are set correctly
+        assert config2["rest.username"] == username
+        assert config2["rest.password"] == password
+        assert config2["rest.server_address"] == server_address


### PR DESCRIPTION
Wrapping https://github.com/TileDB-Inc/TileDB/pull/5492, https://github.com/TileDB-Inc/TileDB/pull/5498, https://github.com/TileDB-Inc/TileDB/pull/5539, https://github.com/TileDB-Inc/TileDB/pull/5547, and https://github.com/TileDB-Inc/TileDB/pull/5552.

The above PRs introduce the Profiles functionality, aimed at providing users with a seamless experience across all TileDB APIs. With Profiles, users can log in once and only once, interacting with a single source of truth across all APIs - without needing to be aware of the underlying implementation details.

On the TileDB-Py side, this is achieved by integrating Profiles into the Config via new `profile_name` and `profile_dir` Config parameters. Profiles created with the default name and directory are automatically loaded, eliminating the need to set any Config parameter explicitly. When retrieving `rest.*` parameters from a Config, Profiles act as a third fallback after user-set Config values and environment variables.

cc. @bekadavis9, @rroelke for visibility.

---

Closes CORE-128