### PR TITLE
Fix `hdfs` KeyError for libtiledb>=2.28

### DIFF
--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -3958,8 +3958,11 @@ class TestAsBuilt(DiskTestCase):
 
         if vfs.supports("hdfs"):
             assert x["hdfs"]["enabled"] == True
-        else:
+        elif tiledb.libtiledb.version() < (2, 28, 0):
             assert x["hdfs"]["enabled"] == False
+        else:
+            # hdfs is not supported in libtiledb >= 2.28.0
+            "hdfs" not in x
 
         if vfs.supports("s3"):
             assert x["s3"]["enabled"] == True


### PR DESCRIPTION
Since TileDB version 2.28.0, `hdfs` is no longer supported. As a result, the dictionary returned by `tiledb.as_built()` does not contain the `hdfs` key.

Fixes https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/184

cc. @jdblischak