### PR TITLE
Update HISTORY for 0.34.0 against TileDB 2.28.0

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -10,19 +10,19 @@ jobs:
   ci1:
     uses: ./.github/workflows/daily-test-build.yml
     with:
-      libtiledb_version: '2.27.2'
+      libtiledb_version: '2.28.0'
 
   ci2:
     uses: ./.github/workflows/daily-test-build.yml
     with:
-      libtiledb_version: '2.26.2'
+      libtiledb_version: '2.27.2'
 
   ci3:
     uses: ./.github/workflows/daily-test-build-numpy.yml
     with:
-      libtiledb_version: '2.27.2'
+      libtiledb_version: '2.28.0'
 
   ci4:
     uses: ./.github/workflows/daily-test-build-numpy.yml
     with:
-      libtiledb_version: '2.26.2'
+      libtiledb_version: '2.27.2'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,8 @@ if (NOT TileDB_FOUND)
         message(STATUS "Downloading TileDB default version ...")
         # Download latest release
         fetch_prebuilt_tiledb(
-                VERSION 2.27.2
-                RELLIST_HASH SHA256=b514c20cfd45c2250fea5c2efcb80facf953e647416fc1fdc6ac8133a7f8dc4d
+                VERSION 2.28.0
+                RELLIST_HASH SHA256=40c8a0b5b7ddfe6150e3ce390fd95761d2b7d5910ea3fd5c7dfb67d431e64660
         )
     endif()
     find_package(TileDB REQUIRED)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,18 @@
+# Release 0.34.0
+
+* TileDB-Py 0.34.0 includes TileDB Embedded [2.28.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.28.0)
+
+## Improvements
+
+* Add Building from Source docs by @nickvigilante in https://github.com/TileDB-Inc/TileDB-Py/pull/2190
+* Remove support for HDFS by @jdblischak, @kounelisagis, and @teo-tsirpanis in https://github.com/TileDB-Inc/TileDB-Py/pull/2185, https://github.com/TileDB-Inc/TileDB-Py/pull/2184, and https://github.com/TileDB-Inc/TileDB-Py/pull/2191
+* Consider index passed, even if the current domain is present by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/2178
+
+## Build system changes
+* Set manylinux images to `manylinux_2_28` for build wheels workflow by @kounelisagis in https://github.com/TileDB-Inc/TileDB-Py/pull/2192
+
+**Full Changelog**: https://github.com/TileDB-Inc/TileDB-Py/compare/0.33.6...0.34.0
+
 # Release 0.33.6
 
 ## Bug Fixes


### PR DESCRIPTION
Update HISTORY for 0.34.0 against TileDB 2.28.0