### PR TITLE
Switch from `pytest-retry` to `pytest-rerunfailures`

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install test dependencies
-        run: pip install pytest pytest-retry hypothesis psutil pyarrow
+        run: pip install pytest pytest-rerunfailures hypothesis psutil pyarrow
 
       - name: Run tests
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ doc = [
 ]
 test = [
     "pytest",
-    "pytest-retry",
+    "pytest-rerunfailures",
     "hypothesis",
     "psutil",
     "pyarrow",
@@ -113,7 +113,7 @@ select = ["NPY201"]
 [tool.cibuildwheel]
 test-requires = [
     "pytest",
-    "pytest-retry",
+    "pytest-rerunfailures",
     "hypothesis",
     "psutil",
     "pyarrow",


### PR DESCRIPTION
In https://github.com/TileDB-Inc/TileDB-Py/pull/2162, `rerun_except="TileDBError"` was used to handle the sporadic failure of `test_dask_multiattr_2d` due to a `distributed.comm.core.CommClosedError`, which caused the error:

```
ERROR - Failed to communicate with scheduler during heartbeat.
```

However, it appears that this was not working as intended, and the test was never retried (causing daily tests to fail: https://github.com/TileDB-Inc/TileDB-Py/issues/2196). The reason for this is that I was using `pytest-rerunfailures` locally, but only `pytest-retry` was installed in CI.

`pytest-retry` appears to be significantly less maintainable and capable compared to `pytest-rerunfailures`, so switching to `pytest-rerunfailures` would be a far better choice. This change is also expected to resolve the `test_dask_multiattr_2d` issue.

---

Closes https://github.com/TileDB-Inc/TileDB-Py/issues/2196