### PR TITLE
Fix: Conditionally include serialization sources with respect to the `TILEDB_SERIALIZATION` flag

### DIFF
--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -8,11 +8,13 @@ pybind11_add_module(
     fragment.cc
     schema_evolution.cc
     util.cc
-    serialization.cc
     tests/test_metadata.cc
     tests/test_webp.cc
-    tests/test_serialization.cc
 )
+
+if (TILEDB_SERIALIZATION)
+    target_sources(main PRIVATE serialization.cc tests/test_serialization.cc)
+endif()
 
 target_link_libraries(
     main


### PR DESCRIPTION
This PR updates the CMake to properly respect the `TILEDB_SERIALIZATION` option when compiling. Previously, `serialization.cc` and `tests/test_serialization.cc` were always included, regardless of whether `TILEDB_SERIALIZATION` was enabled. (This was potentially broke during our transition to scikit-build-core)

This ensures that serialization-related code is only compiled when explicitly enabled via the `-Cskbuild.cmake.define.TILEDB_SERIALIZATION` flag during `pip install`.

### How to Test

Build [libtiledb](https://github.com/TileDB-Inc/TileDB) with and without the [`--enable-serialization`](https://github.com/TileDB-Inc/TileDB/blob/main/BUILDING_FROM_SOURCE.md?plain=1#L37) flag.

1. **Without serialization support**:
   When using a version of libtiledb that does **not** support serialization, install TileDB-Py as follows:

   ```bash
   pip install . --config-settings=cmake.define.TILEDB_SERIALIZATION=OFF -C skbuild.cmake.define.TILEDB_PATH=/home/tiledb/dist
   ```

   * Running `pytest tiledb/tests/test_serialization.py` should skip the test.
   * Accessing `tiledb.main.tiledb_serialization_type_t.TILEDB_CAPNP` should raise an `AttributeError`.

2. **With serialization support**:
   When using a version of libtiledb that **does** support serialization, install TileDB-Py like this:

   ```bash
   pip install . --config-settings=cmake.define.TILEDB_SERIALIZATION=ON -C skbuild.cmake.define.TILEDB_PATH=/home/tiledb/dist
   ```

   * Running `pytest tiledb/tests/test_serialization.py` should execute the test.
   * `tiledb.main.tiledb_serialization_type_t.TILEDB_CAPNP` should be available as expected.

---

cc. @jdblischak for visibility, although I strongly believe this won't affect you.