### PR TITLE
Fix: fixture `sparse_array_1d` not found

### DIFF
--- a/tiledb/tests/test_multi_index-hp.py
+++ b/tiledb/tests/test_multi_index-hp.py
@@ -58,7 +58,6 @@ class TestMultiIndexPropertySparse:
     dmin, dmax = -100, 100
 
     @pytest.fixture(scope="class")
-    @classmethod
     def sparse_array_1d(cls, checked_path):
         def write_sparse_contig(uri):
             data = np.arange(cls.dmin, cls.dmax, dtype=np.int64)


### PR DESCRIPTION
For an unknown reason, Python 3.13 fails when running tests in `test_multi_index-hp.py`:

```
E       fixture 'sparse_array_1d' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, capteesys, checked_path, doctest_namespace, isolate_os_fork, monkeypatch, no_output, original_os_fork, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```

This appears to be related to https://github.com/pytest-dev/pytest/issues/13479.

Removing the `classmethod` decorator seems to resolve the issue without affecting the behavior of the tests.

Fixes https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/186
Fixes part of https://github.com/TileDB-Inc/TileDB-Py/issues/2196

---

cc. @jdblischak 