### PR TITLE
Avoid double opening arrays

### DIFF
--- a/tiledb/array.py
+++ b/tiledb/array.py
@@ -364,9 +364,10 @@ class Array:
         if ctx is None:
             ctx = default_ctx()
 
-        self.array = kwargs.get(
-            "preloaded_array", preload_array(uri, mode, key, timestamp, ctx)
-        )
+        if "preloaded_array" in kwargs:
+            self.array = kwargs.get("preloaded_array")
+        else:
+            self.array = preload_array(uri, mode, key, timestamp, ctx)
 
         # view on a single attribute
         schema = self.array._schema()


### PR DESCRIPTION
Upon opening a TileDB Array with `tiledb.open` or using the Array constructors directly they code was unintentionally calling preload_array twice. In order to determine the type of the array Sparse or Dense, the code first calls preload_array to load a pybind11 Array object which contains the ArraySchema. This opened array was then passed into the python Sparse/DenseArray class, which passes it to the base Array class. Unfortunately in the Array constructor the call to `self.array = kwargs.get("preloaded_array", preload_array(uri, ...)` yielded calling `preload_array` regardless if the preloaded_array argument was passed or not. The intention was to only call preloaded_array if the constructor did not recieve an open array.

This code was internal to the implementation, and the user effect now is that open times should be improved.