### PR TITLE
Enable `from_pandas` for dense arrays without full-row consumption

### DIFF
--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -776,7 +776,6 @@ def _write_array(
                 A._setitem_impl(slice(row_start_idx, row_end_idx), write_dict, nullmaps)
 
 
-
 def open_dataframe(uri, *, attrs=None, use_arrow=None, idx=slice(None), ctx=None):
     """Open TileDB array at given URI as a Pandas dataframe
 

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -344,18 +344,27 @@ class TestDimType:
 class TestPandasDataFrameRoundtrip(DiskTestCase):
     def test_dataframe_fit_to_df(self):
         uri = self.path("dataframe_subarray")
-        vartypes = {'Z': RaggedDtype(np.float32), 'W': RaggedDtype(np.float32)}
-        xytypes = {'X': np.int32, 'Y': np.int32}
+        vartypes = {"Z": RaggedDtype(np.float32), "W": RaggedDtype(np.float32)}
+        xytypes = {"X": np.int32, "Y": np.int32}
         alltypes = vartypes | xytypes
-        trntypes = xytypes | {'Z': 'O', 'W': 'O'}
+        trntypes = xytypes | {"Z": "O", "W": "O"}
 
         # make data
-        df = pd.DataFrame(columns=['X','Y','Z','W'])
-        for x in range(5,10):
-            for y in range(5,10):
-                df2 = pd.DataFrame([[x,y, np.random.rand(y+1).astype('float32'), np.random.rand(y+2).astype('float32')]],
-                    columns=['X','Y','Z','W'])
-                df = pd.concat((df,df2), ignore_index=True)
+        df = pd.DataFrame(columns=["X", "Y", "Z", "W"])
+        for x in range(5, 10):
+            for y in range(5, 10):
+                df2 = pd.DataFrame(
+                    [
+                        [
+                            x,
+                            y,
+                            np.random.rand(y + 1).astype("float32"),
+                            np.random.rand(y + 2).astype("float32"),
+                        ]
+                    ],
+                    columns=["X", "Y", "Z", "W"],
+                )
+                df = pd.concat((df, df2), ignore_index=True)
 
         # give correct types
         df = df.astype(trntypes)
@@ -363,7 +372,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         # make schema
         dom = tiledb.Domain(
             tiledb.Dim(name="X", domain=(0, 9), tile=1, dtype=np.int32),
-            tiledb.Dim(name="Y", domain=(0, 9), tile=1, dtype=np.int32)
+            tiledb.Dim(name="Y", domain=(0, 9), tile=1, dtype=np.int32),
         )
         attrs = [
             tiledb.Attr(name="Z", dtype=np.float32, var=True),
@@ -372,15 +381,21 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
         schema = tiledb.ArraySchema(domain=dom, attrs=attrs, sparse=False)
         tiledb.Array.create(uri, schema)
 
-        tiledb.from_pandas(uri, df, mode="append", column_types=alltypes,
-            varlen_types={vartypes['Z'], vartypes['W']}, fit_to_df=True)
+        tiledb.from_pandas(
+            uri,
+            df,
+            mode="append",
+            column_types=alltypes,
+            varlen_types={vartypes["Z"], vartypes["W"]},
+            fit_to_df=True,
+        )
 
         with tiledb.open(uri) as A:
-            adf = A.query(coords=True).df[5:9,5:9]
+            adf = A.query(coords=True).df[5:9, 5:9]
 
             # make sure they're indexed the same way and then compare
-            adf = adf.set_index(['X','Y'])
-            df = df.set_index(['X','Y'])
+            adf = adf.set_index(["X", "Y"])
+            df = df.set_index(["X", "Y"])
             tm.assert_frame_equal(df, adf)
 
     def test_dataframe_basic_rt1_manual(self):


### PR DESCRIPTION
Addressing #2158, realized I never actually made a pull request for the issue. 

This PR features a change to the `from_pandas` method, adding the argument `fit_to_df`, which lets you append to a dense array without needing to insert an entire row. 

I also added a test that checks to make sure that everything is consistent going in and coming out of TileDB using this method.