### PR TITLE
Add support for `not` in query conditions

### DIFF
--- a/tiledb/query_condition.cc
+++ b/tiledb/query_condition.cc
@@ -112,6 +112,17 @@ class PyQueryCondition {
         return pyqc;
     }
 
+    PyQueryCondition negate() const {
+        try {
+            auto negated_qc = qc_->negate();
+            auto pyqc = PyQueryCondition(nullptr, ctx_.ptr().get());
+            pyqc.qc_ = std::make_shared<QueryCondition>(std::move(negated_qc));
+            return pyqc;
+        } catch (TileDBError& e) {
+            TPY_ERROR_LOC(e.what());
+        }
+    }
+
    private:
     PyQueryCondition(shared_ptr<QueryCondition> qc, tiledb_ctx_t* c_ctx)
         : qc_(qc) {
@@ -194,6 +205,7 @@ void init_query_condition(py::module& m) {
         .def("__capsule__", &PyQueryCondition::__capsule__)
 
         .def("combine", &PyQueryCondition::combine)
+        .def("negate", &PyQueryCondition::negate)
 
         .def_static(
             "create_string",

--- a/tiledb/query_condition.py
+++ b/tiledb/query_condition.py
@@ -493,6 +493,13 @@ class QueryConditionTree(ast.NodeVisitor):
         return node
 
     def visit_UnaryOp(self, node: ast.UnaryOp, sign: int = 1):
+        if isinstance(node.op, ast.Not):
+            operand = self.visit(node.operand)
+            if not isinstance(operand, qc.PyQueryCondition):
+                raise TileDBError(
+                    f"`not` can only be applied to a query condition, got {type(operand)}"
+                )
+            return operand.negate()
         if isinstance(node.op, ast.UAdd):
             sign *= 1
         elif isinstance(node.op, ast.USub):

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -1023,6 +1023,14 @@ class QueryConditionTest(DiskTestCase):
         with tiledb.open(path) as A:
             assert_array_equal(A.query(cond="")[:]["a"], [0])
 
+    def test_not_operator(self):
+        with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
+            all_U = set(A[:]["U"])
+            result_lt5 = set(A.query(cond="U < 5", attrs=["U"])[:]["U"])
+            result_not_lt5 = set(A.query(cond="not U < 5", attrs=["U"])[:]["U"])
+            assert result_lt5.isdisjoint(result_not_lt5)
+            assert result_lt5.union(result_not_lt5) == all_U
+
 
 class QueryDeleteTest(DiskTestCase):
     def test_basic_sparse(self):


### PR DESCRIPTION
This PR adds wraps the `QueryCondition::negate` CPP API.

Closes CORE-199