### PR TITLE
Fix: respect context params during array consolidation when no config is provided

### DIFF
--- a/tiledb/highlevel.py
+++ b/tiledb/highlevel.py
@@ -255,7 +255,7 @@ def consolidate(uri, config=None, ctx=None, fragment_uris=None, timestamp=None):
     """
     ctx = _get_ctx(ctx)
     if config is None:
-        config = lt.Config()
+        config = ctx.config()
 
     if fragment_uris is not None:
         if timestamp is not None:

--- a/tiledb/tests/test_fragments.py
+++ b/tiledb/tests/test_fragments.py
@@ -358,7 +358,22 @@ class FragmentInfoTest(DiskTestCase):
 
         self.assertEqual(fragment_info.get_cell_num(), (len(a), len(b)))
 
-    def test_consolidated_fragment_metadata(self):
+    @pytest.mark.parametrize(
+        "consolidate_kwargs",
+        [
+            {
+                "config": tiledb.Config(
+                    params={"sm.consolidation.mode": "fragment_meta"}
+                )
+            },
+            {
+                "ctx": tiledb.Ctx(
+                    config=tiledb.Config({"sm.consolidation.mode": "fragment_meta"})
+                )
+            },
+        ],
+    )
+    def test_consolidated_fragment_metadata(self, consolidate_kwargs):
         fragments = 3
 
         A = np.zeros(fragments)
@@ -381,9 +396,7 @@ class FragmentInfoTest(DiskTestCase):
             fragment_info.get_has_consolidated_metadata(), (False, False, False)
         )
 
-        tiledb.consolidate(
-            uri, config=tiledb.Config(params={"sm.consolidation.mode": "fragment_meta"})
-        )
+        tiledb.consolidate(uri, **consolidate_kwargs)
 
         fragment_info = PyFragmentInfo(uri, schema, False, tiledb.default_ctx())
 


### PR DESCRIPTION
This PR addresses an issue that occurred when no Config was provided by the user during array consolidation. In such cases, the consolidation parameters set in the Context were ignored because an empty Config object was implicitly created in the Python layer and passed to the C++ API, which then took precedence over the Context.

Closes CORE-288