### PR TITLE
Expand GIL release scope for improved threading support

### DIFF
--- a/tiledb/libtiledb/group.cc
+++ b/tiledb/libtiledb/group.cc
@@ -109,13 +109,15 @@ void init_group(py::module& m) {
             &Group::consolidate_metadata,
             py::arg("ctx"),
             py::arg("uri"),
-            py::arg("config") = (Config*)nullptr)
+            py::arg("config") = (Config*)nullptr,
+            py::call_guard<py::gil_scoped_release>())
         .def_static(
             "_vacuum_metadata",
             &Group::vacuum_metadata,
             py::arg("ctx"),
             py::arg("uri"),
-            py::arg("config") = (Config*)nullptr);
+            py::arg("config") = (Config*)nullptr,
+            py::call_guard<py::gil_scoped_release>());
 }
 
 }  // namespace libtiledbcpp

--- a/tiledb/libtiledb/object.cc
+++ b/tiledb/libtiledb/object.cc
@@ -29,9 +29,16 @@ void init_object(py::module& m) {
         .def_property_readonly("_name", &Object::name)
         .def("__repr__", &Object::to_str)
 
-        .def_static("_object", &Object::object)
-        .def_static("_remove", &Object::remove)
-        .def_static("_move", &Object::move);
+        .def_static(
+            "_object",
+            &Object::object,
+            py::call_guard<py::gil_scoped_release>())
+        .def_static(
+            "_remove",
+            &Object::remove,
+            py::call_guard<py::gil_scoped_release>())
+        .def_static(
+            "_move", &Object::move, py::call_guard<py::gil_scoped_release>());
 }
 
 }  // namespace libtiledbcpp


### PR DESCRIPTION
Previously, we only released the GIL during query execution. However, C++ API calls such as `Array::open`, `ArraySchema::load`, and `Array::consolidate` could still unnecessarily block Python threads. This PR expands the scope of GIL release within the pybind11 bindings, focusing primarily on I/O-intensive operations where the impact is most significant. These improvements aim to enhance overall concurrency and responsiveness in multithreaded Python environments.

Probably closes CORE-262