### PR TITLE
Constrain pybind11 version to less than 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core",
-    "pybind11",
+    "pybind11<3",
     "numpy>=2.0.1"
 ]
 build-backend = "scikit_build_core.build"


### PR DESCRIPTION
Daily tests and nightly feedstock builds have been consistently failing since the release of pybind11 3.0.0:
https://github.com/pybind/pybind11/releases/tag/v3.0.0 / https://pypi.org/project/pybind11/3.0.0/

More specifically, the daily tests fail on macOS 13 with Python 3.13, and the feedstock builds fail on Linux ppc64le with Python 3.9.

The failing test appears to be unrelated, and after some experimentation, there doesn't seem to be an easy fix. This PR constrains the pybind11 version to less than 3 to avoid these issues for now.

Daily tests workflow run on this branch: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/16321135225

Support for pybind11 3.0 will be addressed in a future PR, as outlined in CORE-304.

cc. @jdblischak 

---

The failure log:

```
=================================== FAILURES ===================================
__________________________________ test_array __________________________________

    def test_array():
        uri = tempfile.mkdtemp()
    
        # TODO BOOTSTRAP
        tiledb.from_numpy(uri, np.random.rand(4)).close()
        # lt.from_numpy(uri, np.random.rand(4)).close()
    
        ctx = lt.Context()
        arr = lt.Array(ctx, uri, lt.QueryType.READ)
        assert arr._is_open()
        assert os.path.basename(arr._uri()) == os.path.basename(uri)
        assert arr._schema == arr._schema
    
        arr._reopen()
        arr._set_open_timestamp_start(0)
        arr._set_open_timestamp_end(1)
        arr._reopen()
        assert arr._open_timestamp_start == 0
        assert arr._open_timestamp_end == 1
    
        arr._close()
        assert not arr._is_open()
    
        arr = lt.Array(ctx, uri, lt.QueryType.READ)
    
        # TODO test
        # consolidate sig1
        # consolidate sig2
        # vacuum
        # load_schema
        # create
        lt.Array._encryption_type(ctx, uri) == lt.EncryptionType.NO_ENCRYPTION
        # TODO assert lt.Array.load_schema(ctx, uri) == arr._schema
        assert arr._query_type() == lt.QueryType.READ
    
        arr._close()
        ####
        arr = lt.Array(ctx, uri, lt.QueryType.WRITE)
        arr._set_open_timestamp_start(1)
        arr._set_open_timestamp_end(1)
        arr._close()
    
        arr._open(lt.QueryType.WRITE)
        data = b"abcdef"
        arr._put_metadata("key", lt.DataType.STRING_ASCII, len(data), data)
        arr._close()
    
        arr._set_open_timestamp_start(1)
        arr._set_open_timestamp_end(1)
        arr._open(lt.QueryType.READ)
        assert arr._metadata_num() == 1
        assert arr._has_metadata("key")
        mv = arr._get_metadata("key")
        assert mv == (data, lt.DataType.STRING_ASCII)
    
        assert arr._get_metadata_from_index(0)[0] == lt.DataType.STRING_ASCII
        mv = arr._get_metadata_from_index(0)[1]
        assert bytes(mv) == data
        with pytest.raises(lt.TileDBError):
            arr._get_metadata_from_index(1)
        arr._close()
    
        arr._open(lt.QueryType.WRITE)
        arr._set_open_timestamp_start(2)
        arr._set_open_timestamp_end(2)
        arr._delete_metadata("key")
        arr._close()
    
        arr._set_open_timestamp_start(3)
        arr._set_open_timestamp_end(3)
        arr._open(lt.QueryType.READ)
>       with pytest.raises(KeyError):
             ^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE <class 'KeyError'>

arr        = <tiledb.libtiledb.Array object at 0x129f66d70>
ctx        = <tiledb.libtiledb.Context object at 0x1291a7570>
data       = b'abcdef'
mv         = <memory at 0x129d962c0>
uri        = '/var/folders/vk/nx37ffx50hv5djclhltc26vw0000gn/T/tmp7cejoteb'

/Users/runner/work/TileDB-Py/TileDB-Py/tiledb/tests/cc/test_cc.py:155: Failed
```
