### PR TITLE
Skip Profiles example test if TILEDB_TOKEN is not set

### DIFF
--- a/tiledb/tests/test_profile.py
+++ b/tiledb/tests/test_profile.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,12 @@ from .common import DiskTestCase
 if lt.version() < (2, 28, 1):
     pytest.skip(
         "Profile is only available in TileDB 2.28.1 and later",
+        allow_module_level=True,
+    )
+
+if os.getenv("TILEDB_TOKEN") == None:
+    pytest.skip(
+        "No token was provided. Please set the TILEDB_TOKEN environment variable to run this test.",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
xref: https://github.com/TileDB-Inc/TileDB-Py/pull/2189, https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/53#issuecomment-3108263515

Unfortunately the tests are not skipped properly. When I run this locally or in my [fork](https://github.com/jdblischak/TileDB-Py/actions/runs/16473340348) (where `TILEDB_TOKEN` is not set), the tests are still run and fail.

My local setup:

```sh
python -m pip install -v --editable .[test]
pytest -vv
##
## tiledb/tests/test_examples.py::ExamplesTest::test_examples[/home/wsl/repos/TileDB-Py/examples/profile.py] FAILED [ 22%]
##
## ========================================== short test summary info ===========================================
## FAILED tiledb/tests/test_examples.py::ExamplesTest::test_examples[/home/wsl/repos/TileDB-Py/examples/profile.py] - Failed: Traceback (most recent call last):
##   File "/home/wsl/repos/TileDB-Py/examples/profile.py", line 79, in <module>
##     create_and_save_profile()
##   File "/home/wsl/repos/TileDB-Py/examples/profile.py", line 45, in create_and_save_profile
##     p1["rest.token"] = tiledb_token
##   File "/home/wsl/repos/TileDB-Py/tiledb/profile.py", line 48, in __setitem__
##     self._set_param(param, value)
## TypeError: _set_param(): incompatible function arguments. The following argument types are supported:
##     1. (self: tiledb.libtiledb.Profile, param: str, value: str) -> None
##
## Invoked with: {
##   "my_profile_name": null
## }, 'rest.token', None
## ================ 1 failed, 1034 passed, 7 skipped, 8 xfailed, 1 xpassed in 160.67s (0:02:40) =================
```
