### PR TITLE
Update assignees for nightly build workflows

### DIFF
--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -128,4 +128,4 @@ jobs:
         with:
           name: nightly build with earliest supported numpy
           label: bug,nightly-failure
-          assignee: kounelisagis,nguyenv,ihnorton
+          assignee: kounelisagis,ypatia,ihnorton

--- a/.github/workflows/daily-test-build.yml
+++ b/.github/workflows/daily-test-build.yml
@@ -91,4 +91,4 @@ jobs:
         with:
           name: nightly build
           label: bug,nightly-failure
-          assignee: kounelisagis,nguyenv,ihnorton
+          assignee: kounelisagis,ypatia,ihnorton


### PR DESCRIPTION
This is expected to resolve the "could not assign - user not found" error observed in the recent daily test failures.