### PR TITLE
Remove outdated lock handling from `create_array_from_fragments`

### DIFF
--- a/tiledb/fragment.py
+++ b/tiledb/fragment.py
@@ -322,15 +322,6 @@ def create_array_from_fragments(
     if not dry_run:
         vfs.create_dir(dst_uri)
 
-    src_lock = os.path.join(src_uri, "__lock.tdb")
-    dst_lock = os.path.join(dst_uri, "__lock.tdb")
-
-    if verbose or dry_run:
-        print(f"Copying lock file {dst_uri}\n")
-
-    if not dry_run:
-        vfs.copy_file(f"{src_lock}", f"{dst_lock}")
-
     list_new_style_schema = [ver >= 10 for ver in fragment_info.version]
     is_mixed_versions = len(set(list_new_style_schema)) > 1
     if is_mixed_versions:


### PR DESCRIPTION
The `__lock.tdb` file was removed from the array folder in [TileDB 2.7.0](https://github.com/TileDB-Inc/TileDB/releases/tag/2.7.0). This PR removes support for handling these files.

Closes https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/54

cc. @jdblischak