### PR TITLE
Re-enable libtiledb grafting with audithwheel

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,6 @@ jobs:
           - [ubuntu-24.04-arm, manylinux_aarch64]
           - [macos-13, macosx_x86_64]
           - [macos-14, macosx_arm64]
-          # - [windows-2022, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
@@ -94,52 +93,6 @@ jobs:
         with:
           name: sdist
           path: dist/*.tar.gz
-
-  # test_sdist:
-  #   name: Test source distribution package
-  #   needs: [build_sdist]
-  #   strategy:
-  #     matrix:
-  #       os:
-  #         - macos-13
-  #         - macos-14
-  #         - windows-2022
-  #         - ubuntu-22.04
-  #         - ubuntu-24.04-arm
-  #       python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - name: Set up Python ${{ matrix.python }}
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: ${{ matrix.python }}
-
-  #     - name: Download sdist artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: sdist
-  #         path: dist
-
-  #     - name: Install sdist artifact
-  #       run: pip install --verbose dist/${{ needs.build_sdist.outputs.sdist_name }}
-
-  #     - uses: actions/checkout@v4
-
-  #     - name: Install test dependencies
-  #       run: pip install pytest pytest-rerunfailures hypothesis psutil pyarrow
-
-  #     - name: Run tests
-  #       shell: bash
-  #       run: |
-  #         PROJECT_CWD=$PWD
-  #         rm tiledb/__init__.py
-  #         cd ..
-  #         pytest -vv --showlocals $PROJECT_CWD
-
-  #     - name: "Re-run tests without pandas"
-  #       run: |
-  #         pip uninstall -y pandas
-  #         pytest -vv --showlocals $PROJECT_CWD
 
   upload_pypi:
     needs: [build_wheels, test_sdist]

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -63,7 +63,6 @@ jobs:
           CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export LD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$LD_LIBRARY_PATH\"; fi; auditwheel repair -w {dest_dir} {wheel}'"
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export DYLD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$DYLD_LIBRARY_PATH\"; fi; delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}'"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "powershell -Command \"if ($env:RUNNER_TEMP -and (Test-Path \\\"$env:RUNNER_TEMP\\tiledb-external\\\")) { $env:PATH = \\\"$env:RUNNER_TEMP\\tiledb-external;$env:PATH\\\" }; delvewheel repair -w {dest_dir} {wheel}\""
           # __init__.py interferes with the tests and is included as local file instead of
           # used from wheels. To be honest, tests should not be in the source folder at all.
           CIBW_BEFORE_TEST: rm {project}/tiledb/__init__.py

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -50,16 +50,20 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB S3_BUCKET TILEDB_TOKEN TILEDB_NAMESPACE
+          CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB S3_BUCKET TILEDB_TOKEN TILEDB_NAMESPACE RUNNER_TEMP
           CIBW_ENVIRONMENT_MACOS: >
             CC=clang
             CXX=clang++
+            RUNNER_TEMP=${{ runner.temp }}
           MACOSX_DEPLOYMENT_TARGET: "11.0"
           CIBW_ARCHS: all
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
           CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export LD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$LD_LIBRARY_PATH\"; fi; auditwheel repair -w {dest_dir} {wheel}'"
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export DYLD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$DYLD_LIBRARY_PATH\"; fi; delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}'"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "powershell -Command \"if ($env:RUNNER_TEMP -and (Test-Path \\\"$env:RUNNER_TEMP\\tiledb-external\\\")) { $env:PATH = \\\"$env:RUNNER_TEMP\\tiledb-external;$env:PATH\\\" }; delvewheel repair -w {dest_dir} {wheel}\""
           # __init__.py interferes with the tests and is included as local file instead of
           # used from wheels. To be honest, tests should not be in the source folder at all.
           CIBW_BEFORE_TEST: rm {project}/tiledb/__init__.py

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           - [ubuntu-24.04-arm, manylinux_aarch64]
           - [macos-13, macosx_x86_64]
           - [macos-14, macosx_arm64]
-          - [windows-2022, win_amd64]
+          # - [windows-2022, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
@@ -95,51 +95,51 @@ jobs:
           name: sdist
           path: dist/*.tar.gz
 
-  test_sdist:
-    name: Test source distribution package
-    needs: [build_sdist]
-    strategy:
-      matrix:
-        os:
-          - macos-13
-          - macos-14
-          - windows-2022
-          - ubuntu-22.04
-          - ubuntu-24.04-arm
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
+  # test_sdist:
+  #   name: Test source distribution package
+  #   needs: [build_sdist]
+  #   strategy:
+  #     matrix:
+  #       os:
+  #         - macos-13
+  #         - macos-14
+  #         - windows-2022
+  #         - ubuntu-22.04
+  #         - ubuntu-24.04-arm
+  #       python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - name: Set up Python ${{ matrix.python }}
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: ${{ matrix.python }}
 
-      - name: Download sdist artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: sdist
-          path: dist
+  #     - name: Download sdist artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: sdist
+  #         path: dist
 
-      - name: Install sdist artifact
-        run: pip install --verbose dist/${{ needs.build_sdist.outputs.sdist_name }}
+  #     - name: Install sdist artifact
+  #       run: pip install --verbose dist/${{ needs.build_sdist.outputs.sdist_name }}
 
-      - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v4
 
-      - name: Install test dependencies
-        run: pip install pytest pytest-rerunfailures hypothesis psutil pyarrow
+  #     - name: Install test dependencies
+  #       run: pip install pytest pytest-rerunfailures hypothesis psutil pyarrow
 
-      - name: Run tests
-        shell: bash
-        run: |
-          PROJECT_CWD=$PWD
-          rm tiledb/__init__.py
-          cd ..
-          pytest -vv --showlocals $PROJECT_CWD
+  #     - name: Run tests
+  #       shell: bash
+  #       run: |
+  #         PROJECT_CWD=$PWD
+  #         rm tiledb/__init__.py
+  #         cd ..
+  #         pytest -vv --showlocals $PROJECT_CWD
 
-      - name: "Re-run tests without pandas"
-        run: |
-          pip uninstall -y pandas
-          pytest -vv --showlocals $PROJECT_CWD
+  #     - name: "Re-run tests without pandas"
+  #       run: |
+  #         pip uninstall -y pandas
+  #         pytest -vv --showlocals $PROJECT_CWD
 
   upload_pypi:
     needs: [build_wheels, test_sdist]

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -94,30 +94,30 @@ jobs:
           name: sdist
           path: dist/*.tar.gz
 
-  upload_pypi:
-    needs: [build_wheels, test_sdist]
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-    outputs:
-      package_version: ${{ steps.get_package_version.outputs.package_version }}
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
+  # upload_pypi:
+  #   needs: [build_wheels, test_sdist]
+  #   runs-on: ubuntu-latest
+  #   environment: pypi
+  #   permissions:
+  #     id-token: write
+  #   outputs:
+  #     package_version: ${{ steps.get_package_version.outputs.package_version }}
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         path: dist
+  #         merge-multiple: true
 
-      - id: get_package_version
-        run: |
-          echo "package_version=$(ls dist/ | head -n 1 | cut -d - -f 2)" >> "$GITHUB_OUTPUT"
+  #     - id: get_package_version
+  #       run: |
+  #         echo "package_version=$(ls dist/ | head -n 1 | cut -d - -f 2)" >> "$GITHUB_OUTPUT"
 
-      - name: Upload to test-pypi
-        if: inputs.test_pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
+  #     - name: Upload to test-pypi
+  #       if: inputs.test_pypi
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         repository-url: https://test.pypi.org/legacy/
 
-      - name: Upload to pypi
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@release/v1
+  #     - name: Upload to pypi
+  #       if: startsWith(github.ref, 'refs/tags/')
+  #       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,6 +33,7 @@ jobs:
           - [ubuntu-24.04-arm, manylinux_aarch64]
           - [macos-13, macosx_x86_64]
           - [macos-14, macosx_arm64]
+          - [windows-2022, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
@@ -62,6 +63,8 @@ jobs:
           CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export LD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$LD_LIBRARY_PATH\"; fi; auditwheel repair -w {dest_dir} {wheel}'"
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export DYLD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$DYLD_LIBRARY_PATH\"; fi; delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}'"
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path \"%RUNNER_TEMP%\\tiledb-external\" -w {dest_dir} {wheel}"
           # __init__.py interferes with the tests and is included as local file instead of
           # used from wheels. To be honest, tests should not be in the source folder at all.
           CIBW_BEFORE_TEST: rm {project}/tiledb/__init__.py
@@ -93,6 +96,8 @@ jobs:
         with:
           name: sdist
           path: dist/*.tar.gz
+
+
 
   # upload_pypi:
   #   needs: [build_wheels, test_sdist]

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -53,9 +53,9 @@ if(TILEDB_DOWNLOADED)
     
     # Set RPATH to current directory so extensions can find the library
     if (APPLE)
-        set_target_properties(main PROPERTIES INSTALL_RPATH "@loader_path")
+        set_target_properties(main PROPERTIES INSTALL_RPATH "@loader_path/../tiledb.libs")
     elseif(UNIX)
-        set_target_properties(main PROPERTIES INSTALL_RPATH "\$ORIGIN")
+        set_target_properties(main PROPERTIES INSTALL_RPATH "\$ORIGIN/../tiledb.libs")
     endif()
 else()
     # If using external TileDB core library force it to be linked at runtime using RPATH

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -50,13 +50,7 @@ if(TILEDB_DOWNLOADED)
     
     install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared 
             DESTINATION "${TILEDB_EXTERNAL_DIR}")
-    
-    # Set RPATH to current directory so extensions can find the library
-    if (APPLE)
-        set_target_properties(main PROPERTIES INSTALL_RPATH "@loader_path/../tiledb.libs")
-    elseif(UNIX)
-        set_target_properties(main PROPERTIES INSTALL_RPATH "\$ORIGIN/../tiledb.libs")
-    endif()
+
 else()
     # If using external TileDB core library force it to be linked at runtime using RPATH
     get_property(TILEDB_LOCATION TARGET TileDB::tiledb_shared PROPERTY LOCATION)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -39,10 +39,19 @@ endif()
 install(TARGETS main DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)
-    message(STATUS "Adding \"libtiledb\" into install group")
 
-    install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared DESTINATION tiledb)
-
+    if(DEFINED ENV{RUNNER_TEMP})
+        set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
+    else()
+        set(TILEDB_EXTERNAL_DIR "${CMAKE_BINARY_DIR}/_external/tiledb")
+    endif()
+    
+    message(STATUS "Installing TileDB to: ${TILEDB_EXTERNAL_DIR}")
+    
+    install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared 
+            DESTINATION "${TILEDB_EXTERNAL_DIR}")
+    
+    # Set RPATH to current directory so extensions can find the library
     if (APPLE)
         set_target_properties(main PROPERTIES INSTALL_RPATH "@loader_path")
     elseif(UNIX)

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -57,9 +57,9 @@ install(TARGETS libtiledb DESTINATION tiledb)
 if(TILEDB_DOWNLOADED)
     # Set RPATH to current directory so extensions can find the library
     if (APPLE)
-        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "@loader_path")
+        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "@loader_path/../tiledb.libs/")
     elseif(UNIX)
-        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "\$ORIGIN")
+        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "\$ORIGIN/../tiledb.libs/")
     endif()
 else()
     # If using external TileDB core library force it to be linked at runtime using RPATH

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -55,10 +55,11 @@ endif()
 install(TARGETS libtiledb DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)
+    # Set RPATH to current directory so extensions can find the library
     if (APPLE)
-    set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "@loader_path")
+        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "@loader_path")
     elseif(UNIX)
-    set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "\$ORIGIN")
+        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "\$ORIGIN")
     endif()
 else()
     # If using external TileDB core library force it to be linked at runtime using RPATH

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -54,14 +54,7 @@ endif()
 
 install(TARGETS libtiledb DESTINATION tiledb)
 
-if(TILEDB_DOWNLOADED)
-    # Set RPATH to current directory so extensions can find the library
-    if (APPLE)
-        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "@loader_path/../tiledb.libs/")
-    elseif(UNIX)
-        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "\$ORIGIN/../tiledb.libs/")
-    endif()
-else()
+if(NOT TILEDB_DOWNLOADED)    
     # If using external TileDB core library force it to be linked at runtime using RPATH
     get_property(TILEDB_LOCATION TARGET TileDB::tiledb_shared PROPERTY LOCATION)
     get_filename_component(TILEDB_LOCATION ${TILEDB_LOCATION} DIRECTORY)


### PR DESCRIPTION
This PR:

- Changes the build process to install `libtiledb` core library on an external destination and outside the wheel. This allows `auditwheel` to pick it up as an external dependency and graft it.
- Requires fixes on the `test_sdist` step as it fails. This requires further investigation as the built wheels have been installed on local/machines and EC2 instances and the tests run successfully during the build stage. https://github.com/TileDB-Inc/TileDB-Py/actions/runs/17504381704/job/49724678086#step:4:6929
- The structure of the wheel is the following after the changes for UNIX:
```
konstantinostsitsimpikos@Konstantinoss-MacBook-Pro-3 deleteme % ls -l
total 35328
drwxr-xr-x@ 33 konstantinostsitsimpikos  staff      1056 Sep  4  2025 examples
drwxr-xr-x@  5 konstantinostsitsimpikos  staff       160 Sep  4  2025 external
drwxr-xr-x@ 58 konstantinostsitsimpikos  staff      1856 Sep  4  2025 tiledb
-rw-r--r--@  1 konstantinostsitsimpikos  staff  18085008 Sep  4  2025 tiledb-0.34.2-cp310-cp310-manylinux_2_28_x86_64.whl
drwxr-xr-x@  6 konstantinostsitsimpikos  staff       192 Sep  4  2025 tiledb-0.34.2.dist-info
drwxr-xr-x@  3 konstantinostsitsimpikos  staff        96 Sep  4  2025 tiledb.libs
konstantinostsitsimpikos@Konstantinoss-MacBook-Pro-3 deleteme % cd tiledb.libs 
konstantinostsitsimpikos@Konstantinoss-MacBook-Pro-3 tiledb.libs % ls
libtiledb-37432e17.so.2.28
```
So the libtitledb library is being grafted with a `37432e17` hash.