### PR TITLE
Add installation recipe for `tiledb-client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ or from [conda-forge](https://anaconda.org/conda-forge/tiledb-py) with
 conda install -c conda-forge tiledb-py
 ```
 
+To install with the [TileDB client](https://pypi.org/project/tiledb-client/) for cloud services:
+
+```
+pip install tiledb[client]
+```
+
 Dataframes functionality (`tiledb.from_pandas`, `Array.df[]`) requires [Pandas](https://pandas.pydata.org/) 1.0 or higher, and [PyArrow](https://arrow.apache.org/docs/python/) 1.0 or higher.
 
 # Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ test = [
     "pandas",
     "dask[distributed]",
 ]
+client = [
+    "tiledb-client",
+]
 
 [project.urls]
 homepage = "https://github.com/TileDB-Inc/TileDB-Py"


### PR DESCRIPTION
This PR adds an installation recipe for installing `tiledb-client` (https://pypi.org/project/tiledb-client/) together with `tiledb-py` using `pip install tiledb[client]`.

cc. @nickvigilante

Closes CORE-359