### PR TITLE
Use CMake variables instead on environment variables for CIBW fix

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,6 @@ jobs:
           - [ubuntu-24.04-arm, manylinux_aarch64]
           - [macos-13, macosx_x86_64]
           - [macos-14, macosx_arm64]
-          # - [windows-2022, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
@@ -94,52 +93,6 @@ jobs:
         with:
           name: sdist
           path: dist/*.tar.gz
-
-  # test_sdist:
-  #   name: Test source distribution package
-  #   needs: [build_sdist]
-  #   strategy:
-  #     matrix:
-  #       os:
-  #         - macos-13
-  #         - macos-14
-  #         - windows-2022
-  #         - ubuntu-22.04
-  #         - ubuntu-24.04-arm
-  #       python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - name: Set up Python ${{ matrix.python }}
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: ${{ matrix.python }}
-
-  #     - name: Download sdist artifact
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: sdist
-  #         path: dist
-
-  #     - name: Install sdist artifact
-  #       run: pip install --verbose dist/${{ needs.build_sdist.outputs.sdist_name }}
-
-  #     - uses: actions/checkout@v4
-
-  #     - name: Install test dependencies
-  #       run: pip install pytest pytest-rerunfailures hypothesis psutil pyarrow
-
-  #     - name: Run tests
-  #       shell: bash
-  #       run: |
-  #         PROJECT_CWD=$PWD
-  #         rm tiledb/__init__.py
-  #         cd ..
-  #         pytest -vv --showlocals $PROJECT_CWD
-
-  #     - name: "Re-run tests without pandas"
-  #       run: |
-  #         pip uninstall -y pandas
-  #         pytest -vv --showlocals $PROJECT_CWD
 
   upload_pypi:
     needs: [build_wheels, test_sdist]

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -97,32 +97,76 @@ jobs:
           name: sdist
           path: dist/*.tar.gz
 
+  test_sdist:
+      name: Test source distribution package
+      needs: [build_sdist]
+      strategy:
+        matrix:
+          os:
+            - macos-13
+            - macos-14
+            - windows-2022
+            - ubuntu-22.04
+            - ubuntu-24.04-arm
+          python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+      runs-on: ${{ matrix.os }}
+      steps:
+        - name: Set up Python ${{ matrix.python }}
+          uses: actions/setup-python@v5
+          with:
+            python-version: ${{ matrix.python }}
 
+        - name: Download sdist artifact
+          uses: actions/download-artifact@v4
+          with:
+            name: sdist
+            path: dist
 
-  # upload_pypi:
-  #   needs: [build_wheels, test_sdist]
-  #   runs-on: ubuntu-latest
-  #   environment: pypi
-  #   permissions:
-  #     id-token: write
-  #   outputs:
-  #     package_version: ${{ steps.get_package_version.outputs.package_version }}
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         path: dist
-  #         merge-multiple: true
+        - name: Install sdist artifact
+          run: pip install --verbose dist/${{ needs.build_sdist.outputs.sdist_name }}
 
-  #     - id: get_package_version
-  #       run: |
-  #         echo "package_version=$(ls dist/ | head -n 1 | cut -d - -f 2)" >> "$GITHUB_OUTPUT"
+        - uses: actions/checkout@v4
 
-  #     - name: Upload to test-pypi
-  #       if: inputs.test_pypi
-  #       uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         repository-url: https://test.pypi.org/legacy/
+        - name: Install test dependencies
+          run: pip install pytest pytest-rerunfailures hypothesis psutil pyarrow
 
-  #     - name: Upload to pypi
-  #       if: startsWith(github.ref, 'refs/tags/')
-  #       uses: pypa/gh-action-pypi-publish@release/v1
+        - name: Run tests
+          shell: bash
+          run: |
+            PROJECT_CWD=$PWD
+            rm tiledb/__init__.py
+            cd ..
+            pytest -vv --showlocals $PROJECT_CWD
+
+        - name: "Re-run tests without pandas"
+          run: |
+            pip uninstall -y pandas
+            pytest -vv --showlocals $PROJECT_CWD
+
+  upload_pypi:
+    needs: [build_wheels, test_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    outputs:
+      package_version: ${{ steps.get_package_version.outputs.package_version }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - id: get_package_version
+        run: |
+          echo "package_version=$(ls dist/ | head -n 1 | cut -d - -f 2)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to test-pypi
+        if: inputs.test_pypi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Upload to pypi
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           - [ubuntu-24.04-arm, manylinux_aarch64]
           - [macos-13, macosx_x86_64]
           - [macos-14, macosx_arm64]
-          - [windows-2022, win_amd64]
+          # - [windows-2022, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
@@ -49,7 +49,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
         env:
-          CI_WHEEL_BUILD: true
+          CIBW_ENVIRONMENT:
+            CI_WHEEL_BUILD=true
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB S3_BUCKET TILEDB_TOKEN TILEDB_NAMESPACE RUNNER_TEMP
           CIBW_ENVIRONMENT_MACOS: >

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -50,7 +50,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_ENVIRONMENT:
-            CI_WHEEL_BUILD=true
+            CI_WHEEL_BUILD=1
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB S3_BUCKET TILEDB_TOKEN TILEDB_NAMESPACE RUNNER_TEMP
           CIBW_ENVIRONMENT_MACOS: >
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUNNER_TEMP: ""
-      CI_WHEEL_BUILD: false
+      CI_WHEEL_BUILD: 0
     outputs:
       sdist_name: ${{ steps.get_sdist_name.outputs.sdist_name }}
     steps:
@@ -116,7 +116,7 @@ jobs:
           python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       runs-on: ${{ matrix.os }}
       env:
-        CI_WHEEL_BUILD: false
+        CI_WHEEL_BUILD: 0
         RUNNER_TEMP: ""
       steps:
         - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -63,7 +63,6 @@ jobs:
           CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export LD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$LD_LIBRARY_PATH\"; fi; auditwheel repair -w {dest_dir} {wheel}'"
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export DYLD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$DYLD_LIBRARY_PATH\"; fi; delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}'"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "powershell -Command \"if ($env:RUNNER_TEMP -and (Test-Path \\\"$env:RUNNER_TEMP\\tiledb-external\\\")) { $env:PATH = \\\"$env:RUNNER_TEMP\\tiledb-external;$env:PATH\\\" }; delvewheel repair -w {dest_dir} {wheel}\""
           # __init__.py interferes with the tests and is included as local file instead of
           # used from wheels. To be honest, tests should not be in the source folder at all.
           CIBW_BEFORE_TEST: rm {project}/tiledb/__init__.py

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -50,16 +50,20 @@ jobs:
         uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB S3_BUCKET TILEDB_TOKEN TILEDB_NAMESPACE
+          CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB S3_BUCKET TILEDB_TOKEN TILEDB_NAMESPACE RUNNER_TEMP
           CIBW_ENVIRONMENT_MACOS: >
             CC=clang
             CXX=clang++
+            RUNNER_TEMP=${{ runner.temp }}
           MACOSX_DEPLOYMENT_TARGET: "11.0"
           CIBW_ARCHS: all
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
           CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export LD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$LD_LIBRARY_PATH\"; fi; auditwheel repair -w {dest_dir} {wheel}'"
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export DYLD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$DYLD_LIBRARY_PATH\"; fi; delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}'"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "powershell -Command \"if ($env:RUNNER_TEMP -and (Test-Path \\\"$env:RUNNER_TEMP\\tiledb-external\\\")) { $env:PATH = \\\"$env:RUNNER_TEMP\\tiledb-external;$env:PATH\\\" }; delvewheel repair -w {dest_dir} {wheel}\""
           # __init__.py interferes with the tests and is included as local file instead of
           # used from wheels. To be honest, tests should not be in the source folder at all.
           CIBW_BEFORE_TEST: rm {project}/tiledb/__init__.py

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -79,6 +79,8 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    env:
+      RUNNER_TEMP: ""
     outputs:
       sdist_name: ${{ steps.get_sdist_name.outputs.sdist_name }}
     steps:
@@ -110,6 +112,8 @@ jobs:
             - ubuntu-24.04-arm
           python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       runs-on: ${{ matrix.os }}
+      env:
+        RUNNER_TEMP: ""
       steps:
         - name: Set up Python ${{ matrix.python }}
           uses: actions/setup-python@v5
@@ -134,7 +138,6 @@ jobs:
           shell: bash
           run: |
             PROJECT_CWD=$PWD
-            ls -la /Users/runner/hostedtoolcache/Python/3.9.23/x64/lib/python3.9/site-packages/tiledb/
             rm tiledb/__init__.py
             cd ..
             pytest -vv --showlocals $PROJECT_CWD

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
         env:
+          CI_WHEEL_BUILD: true
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB S3_BUCKET TILEDB_TOKEN TILEDB_NAMESPACE RUNNER_TEMP
           CIBW_ENVIRONMENT_MACOS: >
@@ -81,6 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUNNER_TEMP: ""
+      CI_WHEEL_BUILD: false
     outputs:
       sdist_name: ${{ steps.get_sdist_name.outputs.sdist_name }}
     steps:
@@ -113,6 +115,7 @@ jobs:
           python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       runs-on: ${{ matrix.os }}
       env:
+        CI_WHEEL_BUILD: false
         RUNNER_TEMP: ""
       steps:
         - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
         env:
-          CIBW_ENVIRONMENT:
-            CI_WHEEL_BUILD=1
+          CIBW_CONFIG_SETTINGS:
+            "--config-setting=cmake.args=-DCI_WHEEL_BUILD=ON;-DTILEDB_TEMP_DIR=${{ runner.temp }}"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB S3_BUCKET TILEDB_TOKEN TILEDB_NAMESPACE RUNNER_TEMP
           CIBW_ENVIRONMENT_MACOS: >
@@ -82,8 +82,8 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     env:
-      RUNNER_TEMP: ""
-      CI_WHEEL_BUILD: 0
+      CIBW_CONFIG_SETTINGS:
+        "--config-setting=cmake.args=-DCI_WHEEL_BUILD=ON;-DTILEDB_TEMP_DIR=${{ runner.temp }}"
     outputs:
       sdist_name: ${{ steps.get_sdist_name.outputs.sdist_name }}
     steps:
@@ -116,8 +116,8 @@ jobs:
           python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       runs-on: ${{ matrix.os }}
       env:
-        CI_WHEEL_BUILD: 0
-        RUNNER_TEMP: ""
+        CIBW_CONFIG_SETTINGS:
+          "--config-setting=cmake.args=-DCI_WHEEL_BUILD=OFF"
       steps:
         - name: Set up Python ${{ matrix.python }}
           uses: actions/setup-python@v5
@@ -129,7 +129,7 @@ jobs:
           with:
             name: sdist
             path: dist
-        
+
         - name: Install sdist artifact
           run: pip install --verbose dist/${{ needs.build_sdist.outputs.sdist_name }}
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -121,6 +121,13 @@ jobs:
           with:
             name: sdist
             path: dist
+        
+        - name: Examinate sdist artifact
+          shell: bash
+          run: |
+            gunzip dist/${{ needs.build_sdist.outputs.sdist_name }}
+            tar -xvf dist/*.tar
+            ls -la dist/tiledb/
 
         - name: Install sdist artifact
           run: pip install --verbose dist/${{ needs.build_sdist.outputs.sdist_name }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           - [ubuntu-24.04-arm, manylinux_aarch64]
           - [macos-13, macosx_x86_64]
           - [macos-14, macosx_arm64]
-          - [windows-2022, win_amd64]
+          # - [windows-2022, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
@@ -95,51 +95,51 @@ jobs:
           name: sdist
           path: dist/*.tar.gz
 
-  test_sdist:
-    name: Test source distribution package
-    needs: [build_sdist]
-    strategy:
-      matrix:
-        os:
-          - macos-13
-          - macos-14
-          - windows-2022
-          - ubuntu-22.04
-          - ubuntu-24.04-arm
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
+  # test_sdist:
+  #   name: Test source distribution package
+  #   needs: [build_sdist]
+  #   strategy:
+  #     matrix:
+  #       os:
+  #         - macos-13
+  #         - macos-14
+  #         - windows-2022
+  #         - ubuntu-22.04
+  #         - ubuntu-24.04-arm
+  #       python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - name: Set up Python ${{ matrix.python }}
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: ${{ matrix.python }}
 
-      - name: Download sdist artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: sdist
-          path: dist
+  #     - name: Download sdist artifact
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: sdist
+  #         path: dist
 
-      - name: Install sdist artifact
-        run: pip install --verbose dist/${{ needs.build_sdist.outputs.sdist_name }}
+  #     - name: Install sdist artifact
+  #       run: pip install --verbose dist/${{ needs.build_sdist.outputs.sdist_name }}
 
-      - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v4
 
-      - name: Install test dependencies
-        run: pip install pytest pytest-rerunfailures hypothesis psutil pyarrow
+  #     - name: Install test dependencies
+  #       run: pip install pytest pytest-rerunfailures hypothesis psutil pyarrow
 
-      - name: Run tests
-        shell: bash
-        run: |
-          PROJECT_CWD=$PWD
-          rm tiledb/__init__.py
-          cd ..
-          pytest -vv --showlocals $PROJECT_CWD
+  #     - name: Run tests
+  #       shell: bash
+  #       run: |
+  #         PROJECT_CWD=$PWD
+  #         rm tiledb/__init__.py
+  #         cd ..
+  #         pytest -vv --showlocals $PROJECT_CWD
 
-      - name: "Re-run tests without pandas"
-        run: |
-          pip uninstall -y pandas
-          pytest -vv --showlocals $PROJECT_CWD
+  #     - name: "Re-run tests without pandas"
+  #       run: |
+  #         pip uninstall -y pandas
+  #         pytest -vv --showlocals $PROJECT_CWD
 
   upload_pypi:
     needs: [build_wheels, test_sdist]

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -122,13 +122,6 @@ jobs:
             name: sdist
             path: dist
         
-        - name: Examinate sdist artifact
-          shell: bash
-          run: |
-            gunzip dist/${{ needs.build_sdist.outputs.sdist_name }}
-            tar -xvf dist/*.tar
-            ls -la dist/tiledb/
-
         - name: Install sdist artifact
           run: pip install --verbose dist/${{ needs.build_sdist.outputs.sdist_name }}
 
@@ -141,6 +134,7 @@ jobs:
           shell: bash
           run: |
             PROJECT_CWD=$PWD
+            ls -la /Users/runner/hostedtoolcache/Python/3.9.23/x64/lib/python3.9/site-packages/tiledb/
             rm tiledb/__init__.py
             cd ..
             pytest -vv --showlocals $PROJECT_CWD

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           - [ubuntu-24.04-arm, manylinux_aarch64]
           - [macos-13, macosx_x86_64]
           - [macos-14, macosx_arm64]
-          # - [windows-2022, win_amd64]
+          - [windows-2022, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -94,30 +94,30 @@ jobs:
           name: sdist
           path: dist/*.tar.gz
 
-  upload_pypi:
-    needs: [build_wheels, test_sdist]
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-    outputs:
-      package_version: ${{ steps.get_package_version.outputs.package_version }}
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
-          merge-multiple: true
+  # upload_pypi:
+  #   needs: [build_wheels, test_sdist]
+  #   runs-on: ubuntu-latest
+  #   environment: pypi
+  #   permissions:
+  #     id-token: write
+  #   outputs:
+  #     package_version: ${{ steps.get_package_version.outputs.package_version }}
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         path: dist
+  #         merge-multiple: true
 
-      - id: get_package_version
-        run: |
-          echo "package_version=$(ls dist/ | head -n 1 | cut -d - -f 2)" >> "$GITHUB_OUTPUT"
+  #     - id: get_package_version
+  #       run: |
+  #         echo "package_version=$(ls dist/ | head -n 1 | cut -d - -f 2)" >> "$GITHUB_OUTPUT"
 
-      - name: Upload to test-pypi
-        if: inputs.test_pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
+  #     - name: Upload to test-pypi
+  #       if: inputs.test_pypi
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         repository-url: https://test.pypi.org/legacy/
 
-      - name: Upload to pypi
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@release/v1
+  #     - name: Upload to pypi
+  #       if: startsWith(github.ref, 'refs/tags/')
+  #       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -49,8 +49,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
         env:
-          CIBW_CONFIG_SETTINGS:
-            "--config-setting=cmake.args=-DCI_WHEEL_BUILD=ON;-DTILEDB_TEMP_DIR=${{ runner.temp }}"
+          CIBW_CONFIG_SETTINGS: "--config-setting=cmake.args=-DCI_WHEEL_BUILD=ON;-DTILEDB_TEMP_DIR=${{ runner.temp }}"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_PASS_LINUX: SETUPTOOLS_SCM_PRETEND_VERSION_FOR_TILEDB S3_BUCKET TILEDB_TOKEN TILEDB_NAMESPACE RUNNER_TEMP
           CIBW_ENVIRONMENT_MACOS: >

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -33,6 +33,7 @@ jobs:
           - [ubuntu-24.04-arm, manylinux_aarch64]
           - [macos-13, macosx_x86_64]
           - [macos-14, macosx_arm64]
+          - [windows-2022, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
 
     steps:
@@ -62,6 +63,8 @@ jobs:
           CIBW_MANYLINUX_AARCH64_IMAGE: "manylinux_2_28"
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export LD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$LD_LIBRARY_PATH\"; fi; auditwheel repair -w {dest_dir} {wheel}'"
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: "bash -c 'if [ -n \"$RUNNER_TEMP\" ] && [ -d \"$RUNNER_TEMP/tiledb-external\" ]; then export DYLD_LIBRARY_PATH=\"$RUNNER_TEMP/tiledb-external:$DYLD_LIBRARY_PATH\"; fi; delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}'"
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path \"%RUNNER_TEMP%\\tiledb-external\" -w {dest_dir} {wheel}"
           # __init__.py interferes with the tests and is included as local file instead of
           # used from wheels. To be honest, tests should not be in the source folder at all.
           CIBW_BEFORE_TEST: rm {project}/tiledb/__init__.py
@@ -93,6 +96,8 @@ jobs:
         with:
           name: sdist
           path: dist/*.tar.gz
+
+
 
   # upload_pypi:
   #   needs: [build_wheels, test_sdist]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ find_package(
 
 find_package(pybind11 CONFIG REQUIRED)
 
+option(CI_WHEEL_BUILD "Enable for CI wheel builds. Do not enable sdist builds." OFF)
+set(TILEDB_EXTERNAL_DIR "${}" CACHE FILEPATH "Temporary directory for storing TileDB for wheel builds.")
+
 if (TILEDB_PATH)
     file(REAL_PATH "${TILEDB_PATH}" USER_TILEDB_PATH EXPAND_TILDE)
     file(GLOB_RECURSE USER_TILEDB_CONFIG_PATH "${TILEDB_PATH}/**/TileDBConfig.cmake")

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -53,9 +53,9 @@ if(TILEDB_DOWNLOADED)
     
     # Set RPATH to current directory so extensions can find the library
     if (APPLE)
-        set_target_properties(main PROPERTIES INSTALL_RPATH "@loader_path")
+        set_target_properties(main PROPERTIES INSTALL_RPATH "@loader_path/../tiledb.libs")
     elseif(UNIX)
-        set_target_properties(main PROPERTIES INSTALL_RPATH "\$ORIGIN")
+        set_target_properties(main PROPERTIES INSTALL_RPATH "\$ORIGIN/../tiledb.libs")
     endif()
 else()
     # If using external TileDB core library force it to be linked at runtime using RPATH

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -45,7 +45,7 @@ install(TARGETS main DESTINATION tiledb)
 
 # Handle TileDB shared library installation and RPATH setup
 if(TILEDB_DOWNLOADED)
-    if(ENV{RUNNER_TEMP})
+    if(ENV{CI_WHEEL_BUILD})
         # For CI builds - install to external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         message(STATUS "CI Build - installing TileDB to: ${TILEDB_EXTERNAL_DIR}")

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -45,23 +45,21 @@ install(TARGETS main DESTINATION tiledb)
 
 # Handle TileDB shared library installation and RPATH setup
 if(TILEDB_DOWNLOADED)
-    message(STATUS "CI_WHEEL_BUILD is set to: '$ENV{CI_WHEEL_BUILD}'")
-    set(CI_BUILD_VAR "$ENV{CI_WHEEL_BUILD}")
-    if(CI_BUILD_VAR OR CIBUILD_VAR STREQUAL "1")
+    if (${CI_WHEEL_BUILD})
         # For CI builds - install to external directory
-        set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         message(STATUS "CI Build - installing TileDB to: ${TILEDB_EXTERNAL_DIR}")
-        install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared 
+        install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared
+
                 DESTINATION "${TILEDB_EXTERNAL_DIR}")
-        
+
         # Set RPATH for CI builds
         if(APPLE)
-            set_target_properties(main PROPERTIES 
+            set_target_properties(main PROPERTIES
                 INSTALL_RPATH "@rpath"
                 BUILD_WITH_INSTALL_RPATH TRUE
             )
         else()
-            set_target_properties(main PROPERTIES 
+            set_target_properties(main PROPERTIES
                 INSTALL_RPATH "${TILEDB_EXTERNAL_DIR}"
                 BUILD_WITH_INSTALL_RPATH TRUE
             )
@@ -70,15 +68,15 @@ if(TILEDB_DOWNLOADED)
         # For local builds - install to tiledb directory
         message(STATUS "Local Build - installing TileDB shared library to tiledb directory")
         install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared DESTINATION tiledb)
-        
+
         # Set RPATH for local builds
         if(APPLE)
-            set_target_properties(main PROPERTIES 
+            set_target_properties(main PROPERTIES
                 INSTALL_RPATH "@loader_path"
                 BUILD_WITH_INSTALL_RPATH TRUE
             )
         elseif(UNIX)
-            set_target_properties(main PROPERTIES 
+            set_target_properties(main PROPERTIES
                 INSTALL_RPATH "\$ORIGIN"
                 BUILD_WITH_INSTALL_RPATH TRUE
             )
@@ -89,14 +87,14 @@ else()
     get_property(TILEDB_LOCATION TARGET TileDB::tiledb_shared PROPERTY LOCATION)
     get_filename_component(TILEDB_LOCATION ${TILEDB_LOCATION} DIRECTORY)
     message(STATUS "External TileDB - setting RPATH to: ${TILEDB_LOCATION}")
-    
+
     if(APPLE)
-        set_target_properties(main PROPERTIES 
+        set_target_properties(main PROPERTIES
             INSTALL_RPATH "@rpath"
             BUILD_WITH_INSTALL_RPATH TRUE
         )
     else()
-        set_target_properties(main PROPERTIES 
+        set_target_properties(main PROPERTIES
             INSTALL_RPATH ${TILEDB_LOCATION}
             BUILD_WITH_INSTALL_RPATH TRUE
         )

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -46,7 +46,8 @@ install(TARGETS main DESTINATION tiledb)
 # Handle TileDB shared library installation and RPATH setup
 if(TILEDB_DOWNLOADED)
     message(STATUS "CI_WHEEL_BUILD is set to: '$ENV{CI_WHEEL_BUILD}'")
-    if(ENV{CI_WHEEL_BUILD} MATCHES "^true")
+    set(CI_BUILD_VAR "$ENV{CI_WHEEL_BUILD}")
+    if(CI_BUILD_VAR OR CIBUILD_VAR STREQUAL "1")
         # For CI builds - install to external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         message(STATUS "CI Build - installing TileDB to: ${TILEDB_EXTERNAL_DIR}")

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -46,7 +46,7 @@ install(TARGETS main DESTINATION tiledb)
 # Handle TileDB shared library installation and RPATH setup
 if(TILEDB_DOWNLOADED)
     message(STATUS "CI_WHEEL_BUILD is set to: '$ENV{CI_WHEEL_BUILD}'")
-    if(ENV{CI_WHEEL_BUILD} MATCHES "true")
+    if(ENV{CI_WHEEL_BUILD} MATCHES "^true")
         # For CI builds - install to external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         message(STATUS "CI Build - installing TileDB to: ${TILEDB_EXTERNAL_DIR}")

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -46,25 +46,32 @@ install(TARGETS main DESTINATION tiledb)
 if(TILEDB_DOWNLOADED)
 
     if(DEFINED ENV{RUNNER_TEMP})
+        # For CI builds
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
+        message(STATUS "Installing TileDB to: ${TILEDB_EXTERNAL_DIR}")
+        install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared 
+                DESTINATION "${TILEDB_EXTERNAL_DIR}")
+        
+        # Set RPATH to use @rpath for proper library isolation on macOS
+        if(APPLE)
+            set_target_properties(main PROPERTIES 
+                INSTALL_RPATH "@rpath"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
+        else()
+            set_target_properties(main PROPERTIES INSTALL_RPATH "${TILEDB_EXTERNAL_DIR}")
+        endif()
     else()
-        set(TILEDB_EXTERNAL_DIR "${CMAKE_BINARY_DIR}/_external/tiledb")
+        # For local builds - auditwheel is not present
+        install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared DESTINATION tiledb)
+        
+        if (APPLE)
+            set_target_properties(main PROPERTIES INSTALL_RPATH "@loader_path")
+        elseif(UNIX)
+            set_target_properties(main PROPERTIES INSTALL_RPATH "\$ORIGIN")
+        endif()
     endif()
-    
-    message(STATUS "Installing TileDB to: ${TILEDB_EXTERNAL_DIR}")
-    
-    install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared 
-            DESTINATION "${TILEDB_EXTERNAL_DIR}")
-    
-    # Set RPATH to use @rpath for proper library isolation on macOS
-    if(APPLE)
-        set_target_properties(main PROPERTIES 
-            INSTALL_RPATH "@rpath"
-            BUILD_WITH_INSTALL_RPATH TRUE
-        )
-    else()
-        set_target_properties(main PROPERTIES INSTALL_RPATH "${TILEDB_EXTERNAL_DIR}")
-    endif()
+
 
 else()
     # If using external TileDB core library force it to be linked at runtime using RPATH

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -45,7 +45,7 @@ install(TARGETS main DESTINATION tiledb)
 
 # Handle TileDB shared library installation and RPATH setup
 if(TILEDB_DOWNLOADED)
-    if(DEFINED ENV{RUNNER_TEMP})
+    if(ENV{RUNNER_TEMP})
         # For CI builds - install to external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         message(STATUS "CI Build - installing TileDB to: ${TILEDB_EXTERNAL_DIR}")

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -1,5 +1,10 @@
 # Pybind11
 
+# Enable @rpath support on macOS for proper library isolation
+if(APPLE)
+    set(CMAKE_MACOSX_RPATH ON)
+endif()
+
 pybind11_add_module(
     main
     main.cc
@@ -50,13 +55,31 @@ if(TILEDB_DOWNLOADED)
     
     install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared 
             DESTINATION "${TILEDB_EXTERNAL_DIR}")
+    
+    # Set RPATH to use @rpath for proper library isolation on macOS
+    if(APPLE)
+        set_target_properties(main PROPERTIES 
+            INSTALL_RPATH "@rpath"
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+    else()
+        set_target_properties(main PROPERTIES INSTALL_RPATH "${TILEDB_EXTERNAL_DIR}")
+    endif()
 
 else()
     # If using external TileDB core library force it to be linked at runtime using RPATH
     get_property(TILEDB_LOCATION TARGET TileDB::tiledb_shared PROPERTY LOCATION)
     get_filename_component(TILEDB_LOCATION ${TILEDB_LOCATION} DIRECTORY)
     message(STATUS "Setting RPATH for targets \"main\" and \"libtiledb\" to ${TILEDB_LOCATION}")
-    set_target_properties(main PROPERTIES INSTALL_RPATH ${TILEDB_LOCATION})
+    
+    if(APPLE)
+        set_target_properties(main PROPERTIES 
+            INSTALL_RPATH "@rpath"
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+    else()
+        set_target_properties(main PROPERTIES INSTALL_RPATH ${TILEDB_LOCATION})
+    endif()
 endif()
 
 add_subdirectory(libtiledb)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -45,7 +45,8 @@ install(TARGETS main DESTINATION tiledb)
 
 # Handle TileDB shared library installation and RPATH setup
 if(TILEDB_DOWNLOADED)
-    if(ENV{CI_WHEEL_BUILD})
+    message(STATUS "CI_WHEEL_BUILD is set to: '$ENV{CI_WHEEL_BUILD}'")
+    if(ENV{CI_WHEEL_BUILD} STREQUAL "true")
         # For CI builds - install to external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         message(STATUS "CI Build - installing TileDB to: ${TILEDB_EXTERNAL_DIR}")

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -43,41 +43,50 @@ endif()
 
 install(TARGETS main DESTINATION tiledb)
 
+# Handle TileDB shared library installation and RPATH setup
 if(TILEDB_DOWNLOADED)
-
     if(DEFINED ENV{RUNNER_TEMP})
-        # For CI builds
+        # For CI builds - install to external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
-        message(STATUS "Installing TileDB to: ${TILEDB_EXTERNAL_DIR}")
+        message(STATUS "CI Build - installing TileDB to: ${TILEDB_EXTERNAL_DIR}")
         install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared 
                 DESTINATION "${TILEDB_EXTERNAL_DIR}")
         
-        # Set RPATH to use @rpath for proper library isolation on macOS
+        # Set RPATH for CI builds
         if(APPLE)
             set_target_properties(main PROPERTIES 
                 INSTALL_RPATH "@rpath"
                 BUILD_WITH_INSTALL_RPATH TRUE
             )
         else()
-            set_target_properties(main PROPERTIES INSTALL_RPATH "${TILEDB_EXTERNAL_DIR}")
+            set_target_properties(main PROPERTIES 
+                INSTALL_RPATH "${TILEDB_EXTERNAL_DIR}"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
         endif()
     else()
-        # For local builds - auditwheel is not present
+        # For local builds - install to tiledb directory
+        message(STATUS "Local Build - installing TileDB shared library to tiledb directory")
         install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared DESTINATION tiledb)
         
-        if (APPLE)
-            set_target_properties(main PROPERTIES INSTALL_RPATH "@loader_path")
+        # Set RPATH for local builds
+        if(APPLE)
+            set_target_properties(main PROPERTIES 
+                INSTALL_RPATH "@loader_path"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
         elseif(UNIX)
-            set_target_properties(main PROPERTIES INSTALL_RPATH "\$ORIGIN")
+            set_target_properties(main PROPERTIES 
+                INSTALL_RPATH "\$ORIGIN"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
         endif()
     endif()
-
-
 else()
-    # If using external TileDB core library force it to be linked at runtime using RPATH
+    # For external TileDB installations - no installation needed, just set RPATH
     get_property(TILEDB_LOCATION TARGET TileDB::tiledb_shared PROPERTY LOCATION)
     get_filename_component(TILEDB_LOCATION ${TILEDB_LOCATION} DIRECTORY)
-    message(STATUS "Setting RPATH for targets \"main\" and \"libtiledb\" to ${TILEDB_LOCATION}")
+    message(STATUS "External TileDB - setting RPATH to: ${TILEDB_LOCATION}")
     
     if(APPLE)
         set_target_properties(main PROPERTIES 
@@ -85,7 +94,10 @@ else()
             BUILD_WITH_INSTALL_RPATH TRUE
         )
     else()
-        set_target_properties(main PROPERTIES INSTALL_RPATH ${TILEDB_LOCATION})
+        set_target_properties(main PROPERTIES 
+            INSTALL_RPATH ${TILEDB_LOCATION}
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
     endif()
 endif()
 

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -50,13 +50,7 @@ if(TILEDB_DOWNLOADED)
     
     install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared 
             DESTINATION "${TILEDB_EXTERNAL_DIR}")
-    
-    # Set RPATH to current directory so extensions can find the library
-    if (APPLE)
-        set_target_properties(main PROPERTIES INSTALL_RPATH "@loader_path/../tiledb.libs")
-    elseif(UNIX)
-        set_target_properties(main PROPERTIES INSTALL_RPATH "\$ORIGIN/../tiledb.libs")
-    endif()
+
 else()
     # If using external TileDB core library force it to be linked at runtime using RPATH
     get_property(TILEDB_LOCATION TARGET TileDB::tiledb_shared PROPERTY LOCATION)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -39,10 +39,19 @@ endif()
 install(TARGETS main DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)
-    message(STATUS "Adding \"libtiledb\" into install group")
 
-    install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared DESTINATION tiledb)
-
+    if(DEFINED ENV{RUNNER_TEMP})
+        set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
+    else()
+        set(TILEDB_EXTERNAL_DIR "${CMAKE_BINARY_DIR}/_external/tiledb")
+    endif()
+    
+    message(STATUS "Installing TileDB to: ${TILEDB_EXTERNAL_DIR}")
+    
+    install(IMPORTED_RUNTIME_ARTIFACTS TileDB::tiledb_shared 
+            DESTINATION "${TILEDB_EXTERNAL_DIR}")
+    
+    # Set RPATH to current directory so extensions can find the library
     if (APPLE)
         set_target_properties(main PROPERTIES INSTALL_RPATH "@loader_path")
     elseif(UNIX)

--- a/tiledb/CMakeLists.txt
+++ b/tiledb/CMakeLists.txt
@@ -46,7 +46,7 @@ install(TARGETS main DESTINATION tiledb)
 # Handle TileDB shared library installation and RPATH setup
 if(TILEDB_DOWNLOADED)
     message(STATUS "CI_WHEEL_BUILD is set to: '$ENV{CI_WHEEL_BUILD}'")
-    if(ENV{CI_WHEEL_BUILD} STREQUAL "true")
+    if(ENV{CI_WHEEL_BUILD} MATCHES "true")
         # For CI builds - install to external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         message(STATUS "CI Build - installing TileDB to: ${TILEDB_EXTERNAL_DIR}")

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -60,7 +60,8 @@ endif()
 install(TARGETS libtiledb DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)
-    if(ENV{CI_WHEEL_BUILD} MATCHES "^true")
+    set(CI_BUILD_VAR "$ENV{CI_WHEEL_BUILD}")
+    if(CI_BUILD_VAR OR CIBUILD_VAR STREQUAL "1")
         # CI builds - shared library is in external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         if(APPLE)

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -57,9 +57,9 @@ install(TARGETS libtiledb DESTINATION tiledb)
 if(TILEDB_DOWNLOADED)
     # Set RPATH to current directory so extensions can find the library
     if (APPLE)
-        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "@loader_path")
+        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "@loader_path/../tiledb.libs/")
     elseif(UNIX)
-        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "\$ORIGIN")
+        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "\$ORIGIN/../tiledb.libs/")
     endif()
 else()
     # If using external TileDB core library force it to be linked at runtime using RPATH

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -59,18 +59,26 @@ endif()
 
 install(TARGETS libtiledb DESTINATION tiledb)
 
-if(NOT TILEDB_DOWNLOADED)    
-    # If using external TileDB core library force it to be linked at runtime using RPATH
+# Set RPATH for proper library resolution at runtime
+if(APPLE)
+    message(STATUS "Setting RPATH for target \"libtiledb\" to @loader_path")
+    set_target_properties(libtiledb PROPERTIES 
+        INSTALL_RPATH "@loader_path"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+elseif(UNIX)
+    message(STATUS "Setting RPATH for target \"libtiledb\" to \$ORIGIN")
+    set_target_properties(libtiledb PROPERTIES 
+        INSTALL_RPATH "\$ORIGIN"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+else()
+    # For Windows or other platforms, use absolute path
     get_property(TILEDB_LOCATION TARGET TileDB::tiledb_shared PROPERTY LOCATION)
     get_filename_component(TILEDB_LOCATION ${TILEDB_LOCATION} DIRECTORY)
     message(STATUS "Setting RPATH for target \"libtiledb\" to ${TILEDB_LOCATION}")
-    
-    if(APPLE)
-        set_target_properties(libtiledb PROPERTIES 
-            INSTALL_RPATH "@rpath"
-            BUILD_WITH_INSTALL_RPATH TRUE
-        )
-    else()
-        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH ${TILEDB_LOCATION})
-    endif()
+    set_target_properties(libtiledb PROPERTIES 
+        INSTALL_RPATH ${TILEDB_LOCATION}
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
 endif()

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 install(TARGETS libtiledb DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)
-    if(ENV{CI_WHEEL_BUILD})
+    if(ENV{CI_WHEEL_BUILD} STREQUAL "true")
         # CI builds - shared library is in external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         if(APPLE)

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -55,10 +55,11 @@ endif()
 install(TARGETS libtiledb DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)
+    # Set RPATH to current directory so extensions can find the library
     if (APPLE)
-    set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "@loader_path")
+        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "@loader_path")
     elseif(UNIX)
-    set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "\$ORIGIN")
+        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "\$ORIGIN")
     endif()
 else()
     # If using external TileDB core library force it to be linked at runtime using RPATH

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 install(TARGETS libtiledb DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)
-    if(ENV{CI_WHEEL_BUILD} STREQUAL "true")
+    if(ENV{CI_WHEEL_BUILD} MATCHES "true")
         # CI builds - shared library is in external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         if(APPLE)

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -54,14 +54,7 @@ endif()
 
 install(TARGETS libtiledb DESTINATION tiledb)
 
-if(TILEDB_DOWNLOADED)
-    # Set RPATH to current directory so extensions can find the library
-    if (APPLE)
-        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "@loader_path/../tiledb.libs/")
-    elseif(UNIX)
-        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH "\$ORIGIN/../tiledb.libs/")
-    endif()
-else()
+if(NOT TILEDB_DOWNLOADED)    
     # If using external TileDB core library force it to be linked at runtime using RPATH
     get_property(TILEDB_LOCATION TARGET TileDB::tiledb_shared PROPERTY LOCATION)
     get_filename_component(TILEDB_LOCATION ${TILEDB_LOCATION} DIRECTORY)

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Enable @rpath support on macOS for proper library isolation
+if(APPLE)
+    set(CMAKE_MACOSX_RPATH ON)
+endif()
+
 pybind11_add_module(
     libtiledb
     array.cc
@@ -59,5 +64,13 @@ if(NOT TILEDB_DOWNLOADED)
     get_property(TILEDB_LOCATION TARGET TileDB::tiledb_shared PROPERTY LOCATION)
     get_filename_component(TILEDB_LOCATION ${TILEDB_LOCATION} DIRECTORY)
     message(STATUS "Setting RPATH for target \"libtiledb\" to ${TILEDB_LOCATION}")
-    set_target_properties(libtiledb PROPERTIES INSTALL_RPATH ${TILEDB_LOCATION})
+    
+    if(APPLE)
+        set_target_properties(libtiledb PROPERTIES 
+            INSTALL_RPATH "@rpath"
+            BUILD_WITH_INSTALL_RPATH TRUE
+        )
+    else()
+        set_target_properties(libtiledb PROPERTIES INSTALL_RPATH ${TILEDB_LOCATION})
+    endif()
 endif()

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 install(TARGETS libtiledb DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)
-    if(ENV{RUNNER_TEMP})
+    if(ENV{CI_WHEEL_BUILD})
         # CI builds - shared library is in external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         if(APPLE)

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 install(TARGETS libtiledb DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)
-    if(ENV{CI_WHEEL_BUILD} MATCHES "true")
+    if(ENV{CI_WHEEL_BUILD} MATCHES "^true")
         # CI builds - shared library is in external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         if(APPLE)

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -59,21 +59,36 @@ endif()
 
 install(TARGETS libtiledb DESTINATION tiledb)
 
-# Set RPATH for proper library resolution at runtime
-if(APPLE)
-    message(STATUS "Setting RPATH for target \"libtiledb\" to @loader_path")
-    set_target_properties(libtiledb PROPERTIES 
-        INSTALL_RPATH "@loader_path"
-        BUILD_WITH_INSTALL_RPATH TRUE
-    )
-elseif(UNIX)
-    message(STATUS "Setting RPATH for target \"libtiledb\" to \$ORIGIN")
-    set_target_properties(libtiledb PROPERTIES 
-        INSTALL_RPATH "\$ORIGIN"
-        BUILD_WITH_INSTALL_RPATH TRUE
-    )
+if(TILEDB_DOWNLOADED)
+    if(ENV{RUNNER_TEMP})
+        # CI builds - shared library is in external directory
+        set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
+        if(APPLE)
+            set_target_properties(libtiledb PROPERTIES 
+                INSTALL_RPATH "@rpath"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
+        else()
+            set_target_properties(libtiledb PROPERTIES 
+                INSTALL_RPATH "${TILEDB_EXTERNAL_DIR}"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
+        endif()
+    else()
+        # Local builds - shared library is in same directory
+        if(APPLE)
+            set_target_properties(libtiledb PROPERTIES 
+                INSTALL_RPATH "@loader_path"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
+        elseif(UNIX)
+            set_target_properties(libtiledb PROPERTIES 
+                INSTALL_RPATH "\$ORIGIN"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
+        endif()
+    endif()
 else()
-    # For Windows or other platforms, use absolute path
     get_property(TILEDB_LOCATION TARGET TileDB::tiledb_shared PROPERTY LOCATION)
     get_filename_component(TILEDB_LOCATION ${TILEDB_LOCATION} DIRECTORY)
     message(STATUS "Setting RPATH for target \"libtiledb\" to ${TILEDB_LOCATION}")


### PR DESCRIPTION
Add new CMake variables for setting and using an external directory to store libraries.