### PR TITLE
Escape quotes in query condition test strings

### DIFF
--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -55,7 +55,13 @@ class QueryConditionTest(DiskTestCase):
                 ),
                 "UTF": np.array(
                     ["$", "£$", "€ह£$", "한ह£", "£$𐍈"]
-                    + [rand_utf8(np.random.randint(1, 100)) for _ in range(5)],
+                    + [
+                        s
+                        for s in [
+                            rand_utf8(np.random.randint(1, 100)) for _ in range(5)
+                        ]
+                        if "'" not in s
+                    ],
                     dtype="|U0",
                 ),
             }

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -54,15 +54,8 @@ class QueryConditionTest(DiskTestCase):
                     dtype="|S",
                 ),
                 "UTF": np.array(
-                    ["$", "£$", "€ह£$", "한ह£", "£$𐍈"]
-                    + [
-                        s
-                        for s in [
-                            rand_utf8(np.random.randint(1, 100)) for _ in range(5)
-                        ]
-                        if "'" not in s
-                    ],
-                    dtype="|U0",
+                    ["$", "£€ह£$", "한ह££$𐍈", "single'quotation", 'double"quotation']
+                    + [rand_utf8(np.random.randint(1, 100)) for _ in range(5)],
                 ),
             }
 
@@ -221,7 +214,7 @@ class QueryConditionTest(DiskTestCase):
 
             if tiledb.libtiledb.version() > (2, 14):
                 for t in A.query(attrs=["UTF"])[:]["UTF"]:
-                    cond = f"""UTF == '{t}'"""
+                    cond = f"""UTF == {repr(t)}"""
                     result = A.query(cond=cond, attrs=["UTF"])[:]
                     assert result["UTF"] == t
 
@@ -242,7 +235,7 @@ class QueryConditionTest(DiskTestCase):
 
             if tiledb.libtiledb.version() > (2, 14):
                 for t in A.query(attrs=["UTF"])[:]["UTF"]:
-                    cond = f"""UTF == '{t}'"""
+                    cond = f"""UTF == {repr(t)}"""
                     result = A.query(cond=cond, attrs=["UTF"])[:]
                     assert all(
                         self.filter_dense(result["UTF"], A.attr("UTF").fill) == t


### PR DESCRIPTION
A frequent failure in `test_string_dense` during daily tests occurs when the generated query condition string contains a single quote (`'`). Previously, this -correctly- caused a parsing error, leading to test failures.

The PR expands the test strings by adding two cases: one with a single quote (which was failing before) and one with a double quote. The strings are now safely escaped using `repr()`.

Ref CORE-377