### PR TITLE
Upcast sum aggregation results to prevent overflows

### DIFF
--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -510,6 +510,8 @@ class PyAgg {
             return py::cast(*((uint64_t*)agg_buf));
 
         // Handle sum operation with upcasting to int64/uint64/double
+        // This has to be done according to
+        // https://github.com/TileDB-Inc/TileDB/blob/d3c3e5f6c3b53b9c9153861e56db7363804da5cc/tiledb/sm/query/readers/aggregators/sum_type.h
         if ("sum" == agg_name) {
             switch (attr.type()) {
                 case TILEDB_INT8:


### PR DESCRIPTION
This PR fixes overflow issues in sum aggregations by upcasting results to wider types (`int8`/`int16`/`int32` → `int64`, `uint8`/`uint16`/`uint32` → `uint64`, `float` → `double`). The results are returned correctly by the Core APIs, but at the pybind11 layer of TileDB-Py they were being cast to types that could not hold them. This PR also adds corner-case tests with extreme values to prevent regressions and ensure mathematically correct results.