### PR TITLE
Fix `numpy.sum` overflow in aggregate tests

### DIFF
--- a/tiledb/tests/test_aggregates.py
+++ b/tiledb/tests/test_aggregates.py
@@ -87,8 +87,8 @@ class AggregateTest(DiskTestCase):
             assert max_result == max(expected)
 
             # For sum and mean, handle corner cases differently
-            expected_sum = np.sum(expected)
-            expected_mean = np.sum(expected) / len(expected)
+            expected_sum = sum(int(x) for x in expected)
+            expected_mean = expected_sum / len(expected)
 
             assert sum_result == expected_sum
             assert mean_result == expected_mean
@@ -123,8 +123,11 @@ class AggregateTest(DiskTestCase):
             assert sub_count == len(expected_sub)
             assert sub_min == min(expected_sub)
             assert sub_max == max(expected_sub)
-            assert sub_sum == np.sum(expected_sub)
-            assert sub_mean == np.sum(expected_sub) / len(expected_sub)
+
+            expected_sub_sum = sum(int(x) for x in expected_sub)
+            expected_sub_mean = expected_sub_sum / len(expected_sub)
+            assert sub_sum == expected_sub_sum
+            assert sub_mean == expected_sub_mean
 
             assert q.agg({"a": "sum"})[4:7] == sub_sum
             assert q.agg({"a": "min"})[4:7] == sub_min


### PR DESCRIPTION
The changes in https://github.com/TileDB-Inc/TileDB-Py/pull/2244 caused an overflow when applying `numpy.sum` on Windows runners using numpy 1 on Daily Tests last night. The result from the Core appears to be correct, and this behavior seems to have been fixed in numpy 2. To work around this issue without lots of changes, let's just switch back to Python's built-in `sum`.

Daily tests run on this branch: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/17862604593

---

Closes #2240