### PR TITLE
Initialize `uint32_t` to prevent OS-dependent undefined behavior

### DIFF
--- a/tiledb/libtiledb/metadata.h
+++ b/tiledb/libtiledb/metadata.h
@@ -164,13 +164,13 @@ class MetadataAdapter {
     py::tuple get_metadata(
         T& array_or_group, const std::string& key, bool is_ndarray) {
         tiledb_datatype_t tdb_type;
-        uint32_t value_num;
+        uint32_t value_num = 0;
         const char* value_ptr;
 
         array_or_group.get_metadata(
             key, &tdb_type, &value_num, (const void**)&value_ptr);
 
-        if (value_ptr == nullptr && value_num != 1)
+        if (value_ptr == nullptr && value_num == 0)
             throw py::key_error("Metadata key '" + key + "' not found");
 
         if (is_ndarray) {


### PR DESCRIPTION
This PR fixes an issue introduced with the latest pybind11 release (version 3.0). Specifically, `test_cc.py::test_array` was failing in some macOS-13 jobs with the following error:

```
        arr._open(lt.QueryType.WRITE)
        arr._set_open_timestamp_start(2)
        arr._set_open_timestamp_end(2)
        arr._delete_metadata("key")
        arr._close()
    
        arr._set_open_timestamp_start(3)
        arr._set_open_timestamp_end(3)
        arr._open(lt.QueryType.READ)
>       with pytest.raises(KeyError):
             ^^^^^^^^^^^^^^^^^^^^^^^
E       Failed: DID NOT RAISE <class 'KeyError'>
```

It turns out that initializing the `uint32_t value_num`, which is passed to the `Array::get_metadata` C++ API, fixes the problem. The CI results for this branch should not be considered, since pybind11 is still pinned to <3. I would like to handle this in a separate PR.

CI with pybind11 3.0 after applying the same fix: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/17979314898

---

cc. @jdblischak - I believe you are currently skipping this test.

Ref CORE-304
