### PR TITLE
Add support for `pybind11` 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core",
-    "pybind11<3",
+    "pybind11",
     "numpy>=2.0.1"
 ]
 build-backend = "scikit_build_core.build"


### PR DESCRIPTION
The `pybind11` version constraint introduced in https://github.com/TileDB-Inc/TileDB-Py/pull/2215 can now be removed because of the fix in https://github.com/TileDB-Inc/TileDB-Py/pull/2248.

cc @jdblischak 
Closes CORE-304