### PR TITLE
Hotfix for env var pass

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -57,6 +57,7 @@ jobs:
             CC=clang
             CXX=clang++
             RUNNER_TEMP=${{ runner.temp }}
+            CI_WHEEL_BUILD=1
           MACOSX_DEPLOYMENT_TARGET: "11.0"
           CIBW_ARCHS: all
           CIBW_PRERELEASE_PYTHONS: True

--- a/tiledb/libtiledb/CMakeLists.txt
+++ b/tiledb/libtiledb/CMakeLists.txt
@@ -61,7 +61,7 @@ install(TARGETS libtiledb DESTINATION tiledb)
 
 if(TILEDB_DOWNLOADED)
     set(CI_BUILD_VAR "$ENV{CI_WHEEL_BUILD}")
-    if(CI_BUILD_VAR OR CIBUILD_VAR STREQUAL "1")
+    if(CI_BUILD_VAR OR CI_BUILD_VAR STREQUAL "1")
         # CI builds - shared library is in external directory
         set(TILEDB_EXTERNAL_DIR "$ENV{RUNNER_TEMP}/tiledb-external")
         if(APPLE)


### PR DESCRIPTION
In this PR:

- We fix the way the CI_BUILD_WHEEL enviromental variable is being passed in the macos environment and a typo.

Outcome:
- The build now follows the correct path in both Linux and Macos environments and build the wheel.

Requirements:

- macos runners should be updated  #2253 before merge 

