### PR TITLE
Skip cloud tests if secret env vars are empty strings

### DIFF
--- a/tiledb/tests/test_cloud.py
+++ b/tiledb/tests/test_cloud.py
@@ -18,7 +18,10 @@ s3_bucket = os.getenv("S3_BUCKET")
     os.getenv("CI") == None
     or tiledb_token == None
     or tiledb_namespace == None
-    or s3_bucket == None,
+    or s3_bucket == None
+    or tiledb_token == ""
+    or tiledb_namespace == ""
+    or s3_bucket == "",
     reason="No token was provided in a non-CI environment. Please set the TILEDB_TOKEN environment variable to run this test.",
 )
 class CloudTest(DiskTestCase):


### PR DESCRIPTION
These cloud tests always fail my PRs that I submit from my fork (I don't have write-access to this repo). I finally figured out why. They are only skipped if the secret env vars like `TILEDB_TOKEN` are `None`, but they are empty strings.

https://github.com/TileDB-Inc/TileDB-Py/blob/067e878cef412fd73c1110409b7686b9bffbbdd5/tiledb/tests/test_cloud.py#L17-L24

xref: #2256

Somewhat related, but I don't understand the point of skipping the test if `os.getenv("CI") == None`. This means it won't be run locally even if the developer defines the required env vars. The `reason` instructs to set `TILEDB_TOKEN`  in a "non-CI environment", but if I understand correctly, it would still be skipped anyways. 