### PR TITLE
Add support for write mode in `Query`

### DIFF
--- a/examples/global_order_writes.py
+++ b/examples/global_order_writes.py
@@ -1,0 +1,157 @@
+# global_order_writes.py
+#
+# LICENSE
+#
+# The MIT License
+#
+# Copyright (c) 2025 TileDB, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# DESCRIPTION
+#
+# This example demonstrates writing to TileDB arrays in global order using
+# multiple submit() calls before finalize(). This is useful for writing large
+# datasets in batches while ensuring only a single fragment is created.
+#
+
+import numpy as np
+import tiledb
+
+# Name of the arrays to create
+sparse_array_name = "global_order_sparse"
+dense_array_name = "global_order_dense"
+
+
+def create_sparse_array():
+    """Create a simple 1D sparse array."""
+    dim = tiledb.Dim("d1", domain=(1, 1000), tile=100, dtype=np.int32)
+    dom = tiledb.Domain(dim)
+    att = tiledb.Attr("a1", dtype=np.int64)
+    schema = tiledb.ArraySchema(domain=dom, attrs=(att,), sparse=True)
+    tiledb.Array.create(sparse_array_name, schema)
+
+
+def create_dense_array():
+    """Create a simple 1D dense array."""
+    dim = tiledb.Dim("d1", domain=(1, 1000), tile=100, dtype=np.int32)
+    dom = tiledb.Domain(dim)
+    att = tiledb.Attr("a1", dtype=np.int64)
+    schema = tiledb.ArraySchema(domain=dom, attrs=(att,), sparse=False)
+    tiledb.Array.create(dense_array_name, schema)
+
+
+def write_sparse_global_order():
+    """Write to sparse array in global order with multiple submits."""
+    print("Writing sparse array in global order with multiple submits...")
+    
+    with tiledb.open(sparse_array_name, "w") as A:
+        # Create a query with global order layout
+        q = tiledb.Query(A, order="G")
+        
+        # First batch of data
+        coords_batch1 = np.array([1, 5, 10, 20, 50], dtype=np.int32)
+        data_batch1 = np.array([100, 200, 300, 400, 500], dtype=np.int64)
+        q.set_data({"d1": coords_batch1, "a1": data_batch1})
+        q.submit()
+        
+        # Second batch of data (coordinates must be in global order relative to first batch)
+        coords_batch2 = np.array([100, 200, 500], dtype=np.int32)
+        data_batch2 = np.array([600, 700, 800], dtype=np.int64)
+        q.set_data({"d1": coords_batch2, "a1": data_batch2})
+        q.submit()
+        
+        # Finalize to complete the write
+        q.finalize()
+
+    # Verify only one fragment was created
+    fragments = tiledb.array_fragments(sparse_array_name)
+    print(f"Number of fragments created: {len(fragments)}")
+    print("Sparse array written successfully")
+
+
+def write_dense_global_order():
+    """Write to dense array in global order with multiple submits."""
+    print("\nWriting dense array in global order with multiple submits...")
+    
+    with tiledb.open(dense_array_name, "w") as A:
+        # Create a query with global order layout
+        q = tiledb.Query(A, order="G")
+        
+        # Set the subarray to cover the full range we're writing
+        start_coord = 1
+        end_coord = 100
+        q.set_subarray_ranges([(start_coord, end_coord)])
+        
+        # First batch of data (cells 1-50)
+        data_batch1 = np.arange(1, 51, dtype=np.int64)
+        q.set_data({"a1": data_batch1})
+        q.submit()
+        
+        # Second batch of data (cells 51-100)
+        data_batch2 = np.arange(51, 101, dtype=np.int64)
+        q.set_data({"a1": data_batch2})
+        q.submit()
+        
+        # Finalize to complete the write
+        q.finalize()
+    
+    # Verify only one fragment was created
+    fragments = tiledb.array_fragments(dense_array_name)
+    print(f"Number of fragments created: {len(fragments)}")
+    print("Dense array written successfully")
+
+
+def read_and_verify():
+    """Read back the data to verify it was written correctly."""
+    print("\nReading and verifying data...")
+    
+    # Read sparse array
+    with tiledb.open(sparse_array_name, "r") as A:
+        result = A[:]
+        print(f"Sparse array has {len(result['a1'])} cells")
+        print(f"First 5 values: {result['a1'][:5]}")
+    
+    # Read dense array
+    with tiledb.open(dense_array_name, "r") as A:
+        result = A[1:20]  # Read cells 1-19
+        print(f"Dense array cells 1-19: {result['a1'][:5]}...{result['a1'][-3:]}")
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("TileDB Global Order Writes Example")
+    print("=" * 60)
+    
+    # Check if arrays exist, create if not
+    if tiledb.object_type(sparse_array_name) != "array":
+        create_sparse_array()
+    if tiledb.object_type(dense_array_name) != "array":
+        create_dense_array()
+    
+    # Write data
+    write_sparse_global_order()
+    write_dense_global_order()
+    
+    # Read and verify
+    read_and_verify()
+    
+    print("\n" + "=" * 60)
+    print("Example completed successfully!")
+    print("=" * 60)

--- a/examples/global_order_writes.py
+++ b/examples/global_order_writes.py
@@ -32,6 +32,7 @@
 #
 
 import numpy as np
+
 import tiledb
 
 # Name of the arrays to create
@@ -60,23 +61,23 @@ def create_dense_array():
 def write_sparse_global_order():
     """Write to sparse array in global order with multiple submits."""
     print("Writing sparse array in global order with multiple submits...")
-    
+
     with tiledb.open(sparse_array_name, "w") as A:
         # Create a query with global order layout
         q = tiledb.Query(A, order="G")
-        
+
         # First batch of data
         coords_batch1 = np.array([1, 5, 10, 20, 50], dtype=np.int32)
         data_batch1 = np.array([100, 200, 300, 400, 500], dtype=np.int64)
         q.set_data({"d1": coords_batch1, "a1": data_batch1})
         q.submit()
-        
+
         # Second batch of data (coordinates must be in global order relative to first batch)
         coords_batch2 = np.array([100, 200, 500], dtype=np.int32)
         data_batch2 = np.array([600, 700, 800], dtype=np.int64)
         q.set_data({"d1": coords_batch2, "a1": data_batch2})
         q.submit()
-        
+
         # Finalize to complete the write
         q.finalize()
 
@@ -89,29 +90,29 @@ def write_sparse_global_order():
 def write_dense_global_order():
     """Write to dense array in global order with multiple submits."""
     print("\nWriting dense array in global order with multiple submits...")
-    
+
     with tiledb.open(dense_array_name, "w") as A:
         # Create a query with global order layout
         q = tiledb.Query(A, order="G")
-        
+
         # Set the subarray to cover the full range we're writing
         start_coord = 1
         end_coord = 100
         q.set_subarray_ranges([(start_coord, end_coord)])
-        
+
         # First batch of data (cells 1-50)
         data_batch1 = np.arange(1, 51, dtype=np.int64)
         q.set_data({"a1": data_batch1})
         q.submit()
-        
+
         # Second batch of data (cells 51-100)
         data_batch2 = np.arange(51, 101, dtype=np.int64)
         q.set_data({"a1": data_batch2})
         q.submit()
-        
+
         # Finalize to complete the write
         q.finalize()
-    
+
     # Verify only one fragment was created
     fragments = tiledb.array_fragments(dense_array_name)
     print(f"Number of fragments created: {len(fragments)}")
@@ -121,13 +122,13 @@ def write_dense_global_order():
 def read_and_verify():
     """Read back the data to verify it was written correctly."""
     print("\nReading and verifying data...")
-    
+
     # Read sparse array
     with tiledb.open(sparse_array_name, "r") as A:
         result = A[:]
         print(f"Sparse array has {len(result['a1'])} cells")
         print(f"First 5 values: {result['a1'][:5]}")
-    
+
     # Read dense array
     with tiledb.open(dense_array_name, "r") as A:
         result = A[1:20]  # Read cells 1-19
@@ -138,20 +139,20 @@ if __name__ == "__main__":
     print("=" * 60)
     print("TileDB Global Order Writes Example")
     print("=" * 60)
-    
+
     # Check if arrays exist, create if not
     if tiledb.object_type(sparse_array_name) != "array":
         create_sparse_array()
     if tiledb.object_type(dense_array_name) != "array":
         create_dense_array()
-    
+
     # Write data
     write_sparse_global_order()
     write_dense_global_order()
-    
+
     # Read and verify
     read_and_verify()
-    
+
     print("\n" + "=" * 60)
     print("Example completed successfully!")
     print("=" * 60)

--- a/tiledb/tests/test_query.py
+++ b/tiledb/tests/test_query.py
@@ -38,3 +38,115 @@ class QueryTest(DiskTestCase):
             query._submit()
             output_subarray = query.subarray()
             assert output_subarray.num_dim_ranges(0) == 2
+
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_global_order_write_single_submit(self, sparse):
+        """Test writing in global order with a single submit and finalize."""
+        uri = self.path("test_global_order_single")
+
+        # Create schema
+        dim = tiledb.Dim("d1", domain=(1, 100), tile=10, dtype=np.int32)
+        dom = tiledb.Domain(dim)
+        att = tiledb.Attr("a1", dtype=np.int64)
+        schema = tiledb.ArraySchema(domain=dom, attrs=(att,), sparse=sparse)
+        tiledb.Array.create(uri, schema)
+
+        # Write using Query with global order
+        with tiledb.open(uri, "w") as A:
+            q = tiledb.Query(A, order="G")
+
+            if sparse:
+                coords = np.array([1, 5, 10, 15, 20], dtype=np.int32)
+                data = np.array([100, 200, 300, 400, 500], dtype=np.int64)
+                q.set_data({"d1": coords, "a1": data})
+            else:
+                start_coord = 1
+                end_coord = 20
+                data = np.arange(
+                    100, 100 + (end_coord - start_coord + 1), dtype=np.int64
+                )
+                q.set_subarray_ranges([(start_coord, end_coord)])
+                q.set_data({"a1": data})
+
+            q.submit()
+            q.finalize()
+
+        # Verify only one fragment was created
+        fragments_info = tiledb.array_fragments(uri)
+        assert len(fragments_info) == 1
+
+        # Verify data
+        with tiledb.open(uri, "r") as A:
+            if sparse:
+                result = A[:]
+                np.testing.assert_array_equal(result["a1"], data)
+                np.testing.assert_array_equal(result["d1"], coords)
+            else:
+                result = A[start_coord:end_coord]
+                np.testing.assert_array_equal(result["a1"], data[:-1])
+
+    @pytest.mark.parametrize("sparse", [True, False])
+    def test_global_order_write_multiple_submits(self, sparse):
+        """Test writing in global order with multiple submits before finalize."""
+        uri = self.path("test_global_order_multiple")
+
+        # Create schema
+        dim = tiledb.Dim("d1", domain=(1, 100), tile=10, dtype=np.int32)
+        dom = tiledb.Domain(dim)
+        att = tiledb.Attr("a1", dtype=np.int64)
+        schema = tiledb.ArraySchema(domain=dom, attrs=(att,), sparse=sparse)
+        tiledb.Array.create(uri, schema)
+
+        # Write using Query with global order and multiple submits
+        with tiledb.open(uri, "w") as A:
+            q = tiledb.Query(A, order="G")
+
+            if sparse:
+                # First submit
+                coords_batch1 = np.array([1, 5, 10], dtype=np.int32)
+                data_batch1 = np.array([100, 200, 300], dtype=np.int64)
+                q.set_data({"d1": coords_batch1, "a1": data_batch1})
+                q.submit()
+
+                # Second submit
+                coords_batch2 = np.array([15, 20], dtype=np.int32)
+                data_batch2 = np.array([400, 500], dtype=np.int64)
+                q.set_data({"d1": coords_batch2, "a1": data_batch2})
+                q.submit()
+            else:
+                # For dense arrays, set subarray once to cover full range
+                start_coord = 1
+                end_coord = 20
+                q.set_subarray_ranges([(start_coord, end_coord)])
+
+                # First submit - first batch of cells
+                mid_point = 10
+                data_batch1 = np.arange(100, 100 + mid_point, dtype=np.int64)
+                q.set_data({"a1": data_batch1})
+                q.submit()
+
+                # Second submit - second batch of cells
+                data_batch2 = np.arange(
+                    100 + mid_point, 100 + (end_coord - start_coord + 1), dtype=np.int64
+                )
+                q.set_data({"a1": data_batch2})
+                q.submit()
+
+            q.finalize()
+
+        # Verify only one fragment was created
+        fragments_info = tiledb.array_fragments(uri)
+        assert len(fragments_info) == 1
+
+        # Verify data
+        with tiledb.open(uri, "r") as A:
+            if sparse:
+                result = A[:]
+                expected_data = np.array([100, 200, 300, 400, 500], dtype=np.int64)
+                expected_coords = np.array([1, 5, 10, 15, 20], dtype=np.int32)
+                np.testing.assert_array_equal(result["a1"], expected_data)
+                np.testing.assert_array_equal(result["d1"], expected_coords)
+            else:
+                result = A[1:20]
+                expected_data = np.arange(100, 120, dtype=np.int64)
+                np.testing.assert_array_equal(result["a1"], expected_data[:-1])


### PR DESCRIPTION
This PR adds support for array writes through the `Query` class on the Python layer. This is particularly useful for global-order writes, since incremental writes in that mode were not possible until now.

---

Closes CORE-211