### PR TITLE
Add test for copying across filesystems.

### DIFF
--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -70,18 +70,17 @@ def create_vfs_dir(path):
     vfs.create_dir(path)
 
 
-def vfs_path(scheme: str, prefix: str = None) -> str:
-    """Create a VFS-compatible path"""
-    if not prefix:
-        if scheme == "s3":
-            prefix: str = "tiledb-" + str(random.randint(0, 10e10))
-        else:
-            prefix: str = "tiledb-" + str(uuid.uuid4())
+def vfs_path(scheme: str) -> str:
+    prefix = "tiledb-"
+    if scheme == "s3":
+        prefix += str(random.randint(0, 10000000000))
+    else:
+        prefix += str(uuid.uuid4())
+
     if scheme == "file":
         return f"{scheme}://{tempfile.mktemp(prefix=prefix)}"
-    if "/" not in prefix:
-        prefix: str = f"{uuid.uuid4()}/{prefix}"
-    return f"{scheme}://{prefix}"
+    else:
+        return f"{scheme}://{prefix}"
 
 
 class DiskTestCase:

--- a/tiledb/tests/conftest.py
+++ b/tiledb/tests/conftest.py
@@ -72,3 +72,36 @@ def original_os_fork():
     """Provides the original unpatched os.fork."""
     if sys.platform != "win32":
         return os.fork
+
+
+@pytest.fixture
+def vfs_config() -> dict[str, str]:
+    config: dict[str, str] = {}
+    # Configure S3
+    if os.getenv("AWS_ACCESS_KEY_ID") and os.getenv("AWS_SECRET_ACCESS_KEY"):
+        config["vfs.s3.aws_access_key_id"] = os.getenv("AWS_ACCESS_KEY_ID")
+        config["vfs.s3.aws_secret_access_key"] = os.getenv("AWS_SECRET_ACCESS_KEY")
+        if os.getenv("VFS_S3_USE_MINIO"):
+            config["vfs.s3.endpoint_override"] = "localhost:9999"
+            config["vfs.s3.scheme"] = "https"
+            config["vfs.s3.use_virtual_addressing"] = "false"
+            config["vfs.s3.verify_ssl"] = "false"
+
+    #   Configure Azure
+    if os.getenv("AZURE_BLOB_ENDPOINT"):
+        config["vfs.azure.blob_endpoint"] = os.getenv("AZURE_BLOB_ENDPOINT")
+    if os.getenv("AZURE_STORAGE_ACCOUNT_TOKEN"):
+        config["vfs.azure.storage_sas_token"] = os.getenv("AZURE_STORAGE_ACCOUNT_TOKEN")
+    elif os.getenv("AZURE_STORAGE_ACCOUNT_NAME") and os.getenv(
+        "AZURE_STORAGE_ACCOUNT_KEY"
+    ):
+        config["vfs.azure.storage_account_name"] = os.getenv(
+            "AZURE_STORAGE_ACCOUNT_NAME"
+        )
+        config["vfs.azure.storage_account_key"] = os.getenv("AZURE_STORAGE_ACCOUNT_KEY")
+
+    #   Configure Google Cloud
+    if os.getenv("TILEDB_TEST_GCS_ENDPOINT"):
+        config["vfs.gcs.endpoint"] = os.getenv("TILEDB_TEST_GCS_ENDPOINT")
+
+    return config


### PR DESCRIPTION
Add test for copying across filesystems. 

Note: This test validates `libtiledb::copy_dir`, which has been merged to `main`, but not yet released. To integrate this test to `TileDB-Py`, CI support for filesystem emulators is needed. Such support has not yet been added on this branch. 

---

Completes CORE-414