### PR TITLE
Remove llvm dependency

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           set -e pipefail
           brew update
-          brew install automake pkg-config ninja llvm
+          brew install automake pkg-config ninja
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.2.1


### PR DESCRIPTION
The llvm dependency has been causing issues when building on macOS. The problem was that llvm was fetching specific Python versions, which were then used for the rest of the build process.

Build workflow on this branch: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/19149122864