### PR TITLE
Avoid unnecessary copying of C-contiguous data.

### DIFF
--- a/tiledb/highlevel.py
+++ b/tiledb/highlevel.py
@@ -145,7 +145,11 @@ def from_numpy(uri, array, config=None, ctx=None, **kwargs):
             if array.dtype == object:
                 arr[:] = array
             else:
-                arr.write_direct(np.ascontiguousarray(array), **kwargs)
+                # Avoid unnecessary copy if already C-contiguous
+                if array.flags.c_contiguous:
+                    arr.write_direct(array, **kwargs)
+                else:
+                    arr.write_direct(np.ascontiguousarray(array), **kwargs)
 
     return tiledb.DenseArray(uri, mode="r", ctx=ctx)
 


### PR DESCRIPTION
This PR skips unnecessary array copies by checking C-contiguity before calling `np.ascontiguousarray()`.