### PR TITLE
Expose `overwrite` parameter for saving a profile

### DIFF
--- a/tiledb/libtiledb/profile.cc
+++ b/tiledb/libtiledb/profile.cc
@@ -39,7 +39,12 @@ void init_profile(py::module& m) {
 
         .def("_get_param", &tiledb::Profile::get_param, py::arg("param"))
 
+#if TILEDB_VERSION_MAJOR > 2 || \
+    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 30)
         .def("_save", &tiledb::Profile::save, py::arg("overwrite"))
+#else
+        .def("_save", &tiledb::Profile::save)
+#endif
 
         .def_static(
             "_load",

--- a/tiledb/profile.py
+++ b/tiledb/profile.py
@@ -80,7 +80,14 @@ class Profile(lt.Profile):
         :param overwrite: Whether to overwrite an existing profile. Defaults to False.
         :raises tiledb.TileDBError:
         """
-        self._save(overwrite)
+        if lt.version() >= (2, 30):
+            self._save(overwrite)
+        else:
+            if overwrite:
+                raise lt.TileDBError(
+                    "The 'overwrite' parameter is only supported in TileDB 2.30.0 and later"
+                )
+            self._save()
 
     @classmethod
     def load(cls, name: str = None, dir: str = None) -> "Profile":

--- a/tiledb/tests/test_profile.py
+++ b/tiledb/tests/test_profile.py
@@ -101,6 +101,10 @@ class ProfileTest(ProfileTestCase):
         # remove the profile
         tiledb.Profile.remove("profile2_name", self.path("profile2_dir"))
 
+    @pytest.mark.skipif(
+        lt.version() < (2, 30),
+        reason="Overwrite parameter is only available in TileDB 2.30.0 and later",
+    )
     def test_profile_save_overwrite(self):
         token1 = "testing_the_token_1"
         token2 = "testing_the_token_2"


### PR DESCRIPTION
Following https://github.com/TileDB-Inc/TileDB/pull/5695, this PR exposes the overwrite parameter for saving a profile introduced in TileDB Core 2.30.0.

Closes CORE-434

cc. @jdblischak