### PR TITLE
Add default TileDB path setup for workflows when `libtiledb_ref` is not provided

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -110,6 +110,19 @@ jobs:
           echo "TILEDB_BIN_PATH=$TILEDB_PATH/bin" >> $env:GITHUB_ENV
         shell: powershell
 
+      # Set up environment for default TileDB (when libtiledb_ref is not provided)
+      - name: Set default TileDB paths (Unix)
+        if: inputs.libtiledb_ref == '' && runner.os != 'Windows'
+        run: |
+          echo "TILEDB_LIB_PATH=${{ runner.temp }}/tiledb-external" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set default TileDB paths (Windows)
+        if: inputs.libtiledb_ref == '' && runner.os == 'Windows'
+        run: |
+          echo "TILEDB_BIN_PATH=${{ runner.temp }}/tiledb-external" >> $env:GITHUB_ENV
+        shell: powershell
+
       - name: "Brew setup on macOS" # x-ref c8e49ba8f8b9ce
         if: ${{ startsWith(matrix.buildplat[0], 'macos-') == true }}
         run: |


### PR DESCRIPTION
The recent refactor in #2275 introduced support for building wheels against arbitrary `libtiledb_ref` values. However, this broke the default workflow behavior when `libtiledb_ref` is not provided, causing wheel build failures on macOS and Windows. This PR fixes that by adding workflow steps to set `TILEDB_LIB_PATH` and `TILEDB_BIN_PATH` to `$RUNNER_TEMP/tiledb-external` when `libtiledb_ref` is not provided.


Errors:
- Windows: `FileNotFoundError: Unable to find library: tiledb.dll`
- macOS: `@rpath/libtiledb.dylib not found`

Proof workflow: https://github.com/TileDB-Inc/TileDB-Py/actions/runs/19714416387