### PR TITLE
Fix PyPI upload job not running on tag-triggered releases

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -248,6 +248,7 @@ jobs:
 
   upload_pypi:
     needs: [build_wheels, test_sdist]
+    if: always() && (startsWith(github.ref, 'refs/tags/') || inputs.test_pypi) && needs.build_wheels.result == 'success' && needs.test_sdist.result == 'success'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
This PR adds missing `if` condition to `upload_pypi` job to ensure it runs on tag pushes.