### PR TITLE
Add support for Pandas 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,13 @@ jobs:
           cd $RUNNER_TEMP
           pytest -vv --showlocals $PROJECT_CWD
 
+      - name: "Re-run tests with pandas 2"
+        run: |
+          PROJECT_CWD=$PWD
+          pip install "pandas>=2,<3"
+          cd $RUNNER_TEMP
+          pytest -vv --showlocals $PROJECT_CWD
+
       - name: "Re-run tests without pandas"
         run: |
           PROJECT_CWD=$PWD

--- a/examples/incomplete_iteration.py
+++ b/examples/incomplete_iteration.py
@@ -40,19 +40,12 @@ import tiledb
 
 
 def check_dataframe_deps():
-    pd_error = """Pandas version >= 1.0 and < 3.0 required for dataframe functionality.
-                  Please `pip install pandas>=1.0,<3.0` to proceed."""
+    pd_error = """Pandas is required for dataframe functionality.
+                  Please `pip install pandas` to proceed."""
 
     try:
-        import pandas as pd
+        import pandas
     except ImportError:
-        raise Exception(pd_error)
-
-    from packaging.version import Version
-
-    if Version(pd.__version__) < Version("1.0") or Version(pd.__version__) >= Version(
-        "3.0.0.dev0"
-    ):
         raise Exception(pd_error)
 
 

--- a/examples/parallel_csv_ingestion.py
+++ b/examples/parallel_csv_ingestion.py
@@ -49,19 +49,12 @@ in_test = "PYTEST_CURRENT_TEST" in os.environ
 
 
 def check_dataframe_deps():
-    pd_error = """Pandas version >= 1.0 and < 3.0 required for dataframe functionality.
-                  Please `pip install pandas>=1.0,<3.0` to proceed."""
+    pd_error = """Pandas is required for dataframe functionality.
+                  Please `pip install pandas` to proceed."""
 
     try:
-        import pandas as pd
+        import pandas
     except ImportError:
-        raise Exception(pd_error)
-
-    from packaging.version import Version
-
-    if Version(pd.__version__) < Version("1.0") or Version(pd.__version__) >= Version(
-        "3.0.0.dev0"
-    ):
         raise Exception(pd_error)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "hypothesis",
     "psutil",
     "pyarrow",
-    "pandas<3",
+    "pandas",
     "dask[distributed]",
 ]
 

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -15,30 +15,13 @@ from .subarray import Subarray
 
 
 def check_dataframe_deps():
-    pd_error = """Pandas version >= 1.0 and < 3.0 required for dataframe functionality.
-                  Please `pip install pandas>=1.0,<3.0` to proceed."""
-    pa_error = """PyArrow version >= 1.0 is suggested for dataframe functionality.
-                  Please `pip install pyarrow>=1.0`."""
+    pd_error = """Pandas is required for dataframe functionality.
+                  Please `pip install pandas` to proceed."""
 
     try:
-        import pandas as pd
+        import pandas
     except ImportError:
         raise Exception(pd_error)
-
-    from packaging.version import Version
-
-    if Version(pd.__version__) < Version("1.0") or Version(pd.__version__) >= Version(
-        "3.0.0.dev0"
-    ):
-        raise Exception(pd_error)
-
-    try:
-        import pyarrow as pa
-
-        if Version(pa.__version__) < Version("1.0"):
-            warnings.warn(pa_error)
-    except ImportError:
-        warnings.warn(pa_error)
 
 
 # Note: 'None' is used to indicate optionality for many of these options

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -17,11 +17,18 @@ from .subarray import Subarray
 def check_dataframe_deps():
     pd_error = """Pandas is required for dataframe functionality.
                   Please `pip install pandas` to proceed."""
+    pa_error = """PyArrow is suggested for dataframe functionality.
+                  Please `pip install pyarrow`."""
 
     try:
         import pandas
     except ImportError:
         raise Exception(pd_error)
+
+    try:
+        import pyarrow
+    except ImportError:
+        warnings.warn(pa_error)
 
 
 # Note: 'None' is used to indicate optionality for many of these options

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -2,7 +2,7 @@ import copy
 import json
 import os
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, List, Optional, Union
 
 import numpy as np
@@ -162,15 +162,13 @@ class ColumnInfo:
                     f"{inferred_dtype} inferred dtype not supported (column {array_like.name})"
                 )
         elif hasattr(array_like, "dtype") and isinstance(array_like.dtype, StringDtype):
-            # Explicit pd.StringDtype() (name="string") is always nullable;
-            # auto-inferred str (name="str") depends on data
-            explicit = array_like.dtype.name == "string"
-            return cls(
-                np.dtype(np.str_),
-                repr="string" if explicit else None,
-                var=True,
-                nullable=explicit or bool(array_like.isna().any()),
-            )
+            info = cls.from_dtype(array_like.dtype, array_like.name)
+            # the NaN-backed "str" dtype holds missing values without being a
+            # nullable dtype; write it as a nullable attribute only when
+            # missing values are actually present
+            if not info.nullable and array_like.isna().any():
+                info = replace(info, nullable=True)
+            return info
         elif hasattr(array_like, "dtype") and isinstance(
             array_like.dtype, CategoricalDtype
         ):
@@ -200,6 +198,7 @@ class ColumnInfo:
 
     @classmethod
     def from_dtype(cls, dtype, column_name, varlen_types=()):
+        from pandas import NA, StringDtype
         from pandas.api import types as pd_types
 
         if isinstance(dtype, str) and dtype == "ascii":
@@ -211,13 +210,17 @@ class ColumnInfo:
         dtype = pd_types.pandas_dtype(dtype)
         # Note: be careful if you rearrange the order of the following checks
 
-        # pandas StringDtype (auto-inferred 'str' and explicit 'string')
-        from pandas import StringDtype
-
+        # pandas string types: the NA-backed "string" dtype maps to a nullable
+        # attribute, while the NaN-backed "str" dtype (the default for strings
+        # since pandas 3) behaves like plain str/object columns
         if isinstance(dtype, StringDtype):
-            repr_val = "string" if dtype.name == "string" else None
-            nullable = dtype.name == "string"
-            return cls(np.dtype(np.str_), repr=repr_val, var=True, nullable=nullable)
+            nullable = dtype.na_value is NA
+            return cls(
+                np.dtype(np.str_),
+                repr="string" if nullable else None,
+                var=True,
+                nullable=nullable,
+            )
 
         # extension types
         if pd_types.is_extension_array_dtype(dtype):
@@ -529,8 +532,8 @@ def _df_to_np_arrays(df, column_infos, fillna):
         if not column_info.var:
             to_numpy_kwargs.update(dtype=column_info.dtype)
 
-        if column_info.nullable and column.isna().any():
-            # Only create nullmap if data actually has nulls
+        if column_info.nullable:
+            # use default 0/empty for the dtype
             to_numpy_kwargs.update(na_value=column_info.dtype.type())
             nullmaps[name] = (~column.isna()).to_numpy(dtype=np.uint8)
 

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -154,7 +154,7 @@ class ColumnInfo:
 
     @classmethod
     def from_values(cls, array_like, varlen_types=()):
-        from pandas import CategoricalDtype
+        from pandas import CategoricalDtype, StringDtype
         from pandas.api import types as pd_types
 
         if pd_types.is_object_dtype(array_like):
@@ -171,6 +171,16 @@ class ColumnInfo:
                 raise NotImplementedError(
                     f"{inferred_dtype} inferred dtype not supported (column {array_like.name})"
                 )
+        elif hasattr(array_like, "dtype") and isinstance(array_like.dtype, StringDtype):
+            # Explicit pd.StringDtype() (name="string") is always nullable;
+            # auto-inferred str (name="str") depends on data
+            explicit = array_like.dtype.name == "string"
+            return cls(
+                np.dtype(np.str_),
+                repr="string" if explicit else None,
+                var=True,
+                nullable=explicit or bool(array_like.isna().any()),
+            )
         elif hasattr(array_like, "dtype") and isinstance(
             array_like.dtype, CategoricalDtype
         ):
@@ -210,6 +220,14 @@ class ColumnInfo:
 
         dtype = pd_types.pandas_dtype(dtype)
         # Note: be careful if you rearrange the order of the following checks
+
+        # pandas StringDtype (auto-inferred 'str' and explicit 'string')
+        from pandas import StringDtype
+
+        if isinstance(dtype, StringDtype):
+            repr_val = "string" if dtype.name == "string" else None
+            nullable = dtype.name == "string"
+            return cls(np.dtype(np.str_), repr=repr_val, var=True, nullable=nullable)
 
         # extension types
         if pd_types.is_extension_array_dtype(dtype):
@@ -255,12 +273,7 @@ class ColumnInfo:
 
         # datetime types
         if pd_types.is_datetime64_any_dtype(dtype):
-            if dtype == "datetime64[ns]":
-                return cls(dtype)
-            else:
-                raise NotImplementedError(
-                    f"Only 'datetime64[ns]' datetime dtype is supported (column {column_name})"
-                )
+            return cls(dtype)
 
         # string types
         # don't use pd_types.is_string_dtype() because it includes object types too
@@ -526,8 +539,8 @@ def _df_to_np_arrays(df, column_infos, fillna):
         if not column_info.var:
             to_numpy_kwargs.update(dtype=column_info.dtype)
 
-        if column_info.nullable:
-            # use default 0/empty for the dtype
+        if column_info.nullable and column.isna().any():
+            # Only create nullmap if data actually has nulls
             to_numpy_kwargs.update(na_value=column_info.dtype.type())
             nullmaps[name] = (~column.isna()).to_numpy(dtype=np.uint8)
 

--- a/tiledb/dense_array.py
+++ b/tiledb/dense_array.py
@@ -479,6 +479,14 @@ class DenseArrayImpl(Array):
 
                 try:
                     if attr.isvar:
+                        # Capture null mask before np.asarray() loses pandas NA info
+                        if (
+                            attr.isnullable
+                            and name not in nullmaps
+                            and hasattr(attr_val, "isna")
+                        ):
+                            nullmaps[name] = (~attr_val.isna()).to_numpy(dtype=np.uint8)
+
                         # ensure that the value is array-convertible, for example: pandas.Series
                         attr_val = np.asarray(attr_val)
                         if attr.isnullable and name not in nullmaps:

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -888,17 +888,22 @@ def _update_df_from_meta(
             if name in df:
                 col_dtypes[name] = dtype
 
-    if col_dtypes:
-        # '<U0' is stored in __pandas_index_dims metadata for var-length string
-        # dimensions (str(np.dtype(np.str_)) == '<U0>'). Applying astype('<U0')
-        # was a no-op on pandas 2 but on pandas 3 it forces StringDtype back to
-        # object, breaking the roundtrip. The string data already has the correct
-        # dtype from pandas' own inference, so we skip it here.
-        col_dtypes = {
-            name: dtype for name, dtype in col_dtypes.items() if dtype != "<U0"
-        }
-        if col_dtypes:
-            df = df.astype(col_dtypes)
+    for name, dtype in col_dtypes.items():
+        # str/bytes dimensions are always written as ASCII bytes and, depending
+        # on the read path, come back as either bytes or str; restore the type
+        # they were written with. astype with the zero-width '<U0'/'|S0' dtypes
+        # stored in the metadata used to do this on pandas < 3, but on
+        # pandas >= 3 it produces object or fixed-width bytes columns instead.
+        if dtype == "<U0":
+            if len(df) and isinstance(df[name].iat[0], bytes):
+                df[name] = df[name].str.decode("utf-8")
+        elif dtype == "|S0":
+            if len(df) and not isinstance(df[name].iat[0], bytes):
+                df[name] = df[name].str.encode("utf-8")
+        # skip columns that already have their target dtype: casting them
+        # would needlessly copy the data on pandas < 3
+        elif str(df[name].dtype) != dtype:
+            df[name] = df[name].astype(dtype)
 
     if index_col:
         if index_col is not True:

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -889,11 +889,16 @@ def _update_df_from_meta(
                 col_dtypes[name] = dtype
 
     if col_dtypes:
-        # Use str instead of '<U0' so pandas uses its native string type
+        # '<U0' is stored in __pandas_index_dims metadata for var-length string
+        # dimensions (str(np.dtype(np.str_)) == '<U0>'). Applying astype('<U0')
+        # was a no-op on pandas 2 but on pandas 3 it forces StringDtype back to
+        # object, breaking the roundtrip. The string data already has the correct
+        # dtype from pandas' own inference, so we skip it here.
         col_dtypes = {
-            name: str if dtype == "<U0" else dtype for name, dtype in col_dtypes.items()
+            name: dtype for name, dtype in col_dtypes.items() if dtype != "<U0"
         }
-        df = df.astype(col_dtypes)
+        if col_dtypes:
+            df = df.astype(col_dtypes, copy=False)
 
     if index_col:
         if index_col is not True:

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -898,7 +898,7 @@ def _update_df_from_meta(
             name: dtype for name, dtype in col_dtypes.items() if dtype != "<U0"
         }
         if col_dtypes:
-            df = df.astype(col_dtypes, copy=False)
+            df = df.astype(col_dtypes)
 
     if index_col:
         if index_col is not True:

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -889,7 +889,11 @@ def _update_df_from_meta(
                 col_dtypes[name] = dtype
 
     if col_dtypes:
-        df = df.astype(col_dtypes, copy=False)
+        # Use str instead of '<U0' so pandas uses its native string type
+        col_dtypes = {
+            name: str if dtype == "<U0" else dtype for name, dtype in col_dtypes.items()
+        }
+        df = df.astype(col_dtypes)
 
     if index_col:
         if index_col is not True:

--- a/tiledb/sparse_array.py
+++ b/tiledb/sparse_array.py
@@ -122,6 +122,15 @@ def _setitem_impl_sparse(self, selection, val, nullmaps: dict):
         attr_val = val[name]
 
         try:
+            # Capture null mask before np.asarray() loses pandas NA info
+            if (
+                attr.isvar
+                and attr.isnullable
+                and name not in nullmaps
+                and hasattr(attr_val, "isna")
+            ):
+                nullmaps[name] = (~attr_val.isna()).to_numpy(dtype=np.uint8)
+
             # ensure that the value is array-convertible, for example: pandas.Series
             attr_val = np.asarray(attr_val)
 

--- a/tiledb/tests/common.py
+++ b/tiledb/tests/common.py
@@ -26,16 +26,11 @@ SUPPORTED_DATETIME64_DTYPES = tuple(
 
 def has_pandas():
     try:
-        import pandas as pd
+        import pandas
+
+        return True
     except ImportError:
         return False
-
-    if Version(pd.__version__) < Version("1.0") or Version(pd.__version__) >= Version(
-        "3.0.0.dev0"
-    ):
-        return False
-
-    return True
 
 
 def has_pyarrow():

--- a/tiledb/tests/datatypes.py
+++ b/tiledb/tests/datatypes.py
@@ -48,7 +48,9 @@ class RaggedArray(pd.api.extensions.ExtensionArray):
         return len(self._flat_arrays)
 
     def __getitem__(self, i):
-        return self._flat_arrays[i]
+        if isinstance(i, (int, np.integer)):
+            return self._flat_arrays[i]
+        return type(self)(self._flat_arrays[i], self._dtype)
 
     @property
     def dtype(self):
@@ -56,3 +58,7 @@ class RaggedArray(pd.api.extensions.ExtensionArray):
 
     def copy(self):
         return type(self)(self._flat_arrays, self._dtype)
+
+    @property
+    def ndim(self):
+        return 1

--- a/tiledb/tests/test_enumeration.py
+++ b/tiledb/tests/test_enumeration.py
@@ -111,7 +111,7 @@ class EnumerationTest(DiskTestCase):
 
     @pytest.mark.skipif(
         not has_pyarrow() or not has_pandas(),
-        reason="pyarrow>=1.0 and/or pandas>=1.0,<3.0 not installed",
+        reason="pyarrow>=1.0 and/or pandas not installed",
     )
     @pytest.mark.parametrize("sparse", [True, False])
     @pytest.mark.parametrize("pass_df", [True, False])
@@ -185,7 +185,7 @@ class EnumerationTest(DiskTestCase):
             assert enmr.dtype == enmr.values().dtype == dtype
             assert_array_equal(enmr.values(), values)
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_from_pandas_dtype_mismatch(self):
         import pandas as pd
 

--- a/tiledb/tests/test_examples.py
+++ b/tiledb/tests/test_examples.py
@@ -43,7 +43,7 @@ class ExamplesTest:
             ]
         ]
         if not has_pandas() and path in requires_pd:
-            pytest.mark.skip("pandas>=1.0,<3.0 not installed")
+            pytest.mark.skip("pandas not installed")
         else:
             with tempfile.TemporaryDirectory() as tmpdir:
                 try:
@@ -73,10 +73,9 @@ class ExamplesTest:
         if failures:
             stderr = capsys.readouterr().out
             if "No module named 'pandas'" in stderr or (
-                "Pandas version >= 1.0 and < 3.0 required for dataframe functionality"
-                in stderr
+                "Pandas is required for dataframe functionality" in stderr
                 and not has_pandas()
             ):
-                pytest.skip("pandas>=1.0,<3.0 not installed")
+                pytest.skip("pandas not installed")
             else:
                 pytest.fail(stderr)

--- a/tiledb/tests/test_fixes.py
+++ b/tiledb/tests/test_fixes.py
@@ -91,7 +91,7 @@ class FixesTest(DiskTestCase):
                 buffers = list(*q._get_buffers().values())
                 assert buffers[0].nbytes == max_val
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_ch10282_concurrent_multi_index(self):
         """Test concurrent access to a single tiledb.Array using
         Array.multi_index and Array.df. We pass an array and slice
@@ -230,7 +230,7 @@ class FixesTest(DiskTestCase):
 
     @pytest.mark.skipif(
         not has_pandas() and has_pyarrow(),
-        reason="pandas>=1.0,<3.0 or pyarrow>=1.0 not installed",
+        reason="pandas or pyarrow>=1.0 not installed",
     )
     def test_py1078_df_all_empty_strings(self):
         uri = self.path()
@@ -246,7 +246,7 @@ class FixesTest(DiskTestCase):
         with tiledb.open(uri) as arr:
             tm.assert_frame_equal(arr.df[:], df)
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     @pytest.mark.parametrize("is_sparse", [True, False])
     def test_sc1430_nonexisting_timestamp(self, is_sparse):
         path = self.path("nonexisting_timestamp")

--- a/tiledb/tests/test_hypothesis.py
+++ b/tiledb/tests/test_hypothesis.py
@@ -13,7 +13,7 @@ pd = pytest.importorskip("pandas")
 tm = pd._testing
 
 
-@pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+@pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
 @pytest.mark.parametrize("mode", ["np", "df"])
 @hp.settings(deadline=None, verbosity=hp.Verbosity.verbose)
 @hp.given(st.binary())

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -418,7 +418,7 @@ class ArrayTest(DiskTestCase):
 
     @pytest.mark.skipif(
         not has_pyarrow() or not has_pandas(),
-        reason="pyarrow>=1.0 and/or pandas>=1.0,<3.0 not installed",
+        reason="pyarrow>=1.0 and/or pandas not installed",
     )
     @pytest.mark.parametrize("sparse", [True, False])
     @pytest.mark.parametrize("pass_df", [True, False])
@@ -1784,7 +1784,7 @@ class TestSparseArray(DiskTestCase):
                 "coords" not in T.query(coords=False).multi_index[-10.0:5.0]
             )
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     @pytest.mark.parametrize("dtype", ["u1", "u2", "u4", "u8", "i1", "i2", "i4", "i8"])
     def test_sparse_index_dtypes(self, dtype):
         path = self.path()
@@ -1805,7 +1805,7 @@ class TestSparseArray(DiskTestCase):
             assert B[data[1]]["attr"] == data[1]
             assert B.multi_index[data[0]]["attr"] == data[0]
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     @pytest.mark.skipif(
         tiledb.libtiledb.version() < (2, 10),
         reason="TILEDB_BOOL introduced in libtiledb 2.10",
@@ -3755,7 +3755,7 @@ class IncompleteTest(DiskTestCase):
                 with self.assertRaises(tiledb.TileDBError):
                     A.query(return_incomplete=True)[:]
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     @pytest.mark.parametrize(
         "use_arrow, return_arrow, indexer",
         [

--- a/tiledb/tests/test_multi_index.py
+++ b/tiledb/tests/test_multi_index.py
@@ -141,7 +141,7 @@ class TestMultiRangeAuxiliary(DiskTestCase):
 class TestMultiRange(DiskTestCase):
     @pytest.mark.skipif(
         not has_pyarrow() or not has_pandas(),
-        reason="pyarrow>=1.0 and/or pandas>=1.0,<3.0 not installed",
+        reason="pyarrow>=1.0 and/or pandas not installed",
     )
     def test_return_arrow_indexers(self):
         uri = self.path("multirange_behavior_sparse")
@@ -183,7 +183,7 @@ class TestMultiRange(DiskTestCase):
 
     @pytest.mark.skipif(
         not has_pyarrow() or not has_pandas(),
-        reason="pyarrow>=1.0 and/or pandas>=1.0,<3.0 not installed",
+        reason="pyarrow>=1.0 and/or pandas not installed",
     )
     @pytest.mark.parametrize("sparse", [True, False])
     def test_return_large_arrow_table(self, sparse):
@@ -727,7 +727,7 @@ class TestMultiRange(DiskTestCase):
                 np.array([], dtype=np.uint64),
             )
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_fixed_multi_attr_df(self):
         uri = self.path("test_fixed_multi_attr_df")
         dom = tiledb.Domain(
@@ -761,7 +761,7 @@ class TestMultiRange(DiskTestCase):
             result = A.query(attrs=["111"], use_arrow=False)
             assert_array_equal(result.df[0]["111"], data_111)
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_var_multi_attr_df(self):
         uri = self.path("test_var_multi_attr_df")
         dom = tiledb.Domain(
@@ -845,7 +845,7 @@ class TestMultiRange(DiskTestCase):
             assert A.nonempty_domain() is None
             assert_array_equal(A.multi_index[:][""], A[:][""])
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_multi_index_query_args(self):
         uri = self.path("test_multi_index_query_args")
         schema = tiledb.ArraySchema(
@@ -871,7 +871,7 @@ class TestMultiRange(DiskTestCase):
             assert_array_equal(q.multi_index[:]["a"], q.df[:]["a"])
             assert all(q[:]["a"] >= 5)
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_multi_index_timing(self):
         path = self.path("test_multi_index_timing")
         attr_name = "a"
@@ -886,7 +886,7 @@ class TestMultiRange(DiskTestCase):
             assert "py.getitem_time.pandas_index_update_time :" in internal_stats
         tiledb.stats_disable()
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_fixed_width_char(self):
         uri = self.path("test_fixed_width_char")
         schema = tiledb.ArraySchema(
@@ -903,7 +903,7 @@ class TestMultiRange(DiskTestCase):
         with tiledb.open(uri, mode="r") as A:
             assert all(A.query(use_arrow=True).df[:][""] == data)
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_empty_idx(self):
         uri = self.path("test_empty_idx")
 

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -29,7 +29,7 @@ from .common import (
 from .datatypes import RaggedDtype
 
 if not has_pandas():
-    pytest.skip("pandas>=1.0,<3.0 not installed", allow_module_level=True)
+    pytest.skip("pandas not installed", allow_module_level=True)
 else:
     import pandas as pd
 

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -204,12 +204,10 @@ class TestColumnInfo(DiskTestCase):
 
     def test_object_dtype(self):
         self.assertColumnInfo(
-            ColumnInfo.from_values(pd.Series(["hello", "world"], dtype=object)),
-            np.dtype("<U"),
+            ColumnInfo.from_values(pd.Series(["hello", "world"])), np.dtype("<U")
         )
         self.assertColumnInfo(
-            ColumnInfo.from_values(pd.Series([b"hello", b"world"], dtype=object)),
-            np.dtype("S"),
+            ColumnInfo.from_values(pd.Series([b"hello", b"world"])), np.dtype("S")
         )
         for s in ["hello", b"world"], ["hello", 1], [b"hello", 1]:
             pytest.raises(NotImplementedError, ColumnInfo.from_values, pd.Series(s))
@@ -610,7 +608,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
 
                 # also ensure that string columns are converted to bytes
                 # b/c only TILEDB_ASCII supported for string dimension
-                if isinstance(df[col].iloc[0], str):
+                if isinstance(df[col][0], str):
                     df[col] = [x.encode("UTF-8") for x in df[col]]
 
             new_df = df.drop_duplicates(subset=col)

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -204,32 +204,34 @@ class TestColumnInfo(DiskTestCase):
 
     def test_object_dtype(self):
         self.assertColumnInfo(
-            ColumnInfo.from_values(pd.Series(["hello", "world"])), np.dtype("<U")
+            ColumnInfo.from_values(pd.Series(["hello", "world"], dtype=object)),
+            np.dtype("<U"),
         )
         self.assertColumnInfo(
-            ColumnInfo.from_values(pd.Series([b"hello", b"world"])), np.dtype("S")
+            ColumnInfo.from_values(pd.Series([b"hello", b"world"], dtype=object)),
+            np.dtype("S"),
         )
         for s in ["hello", b"world"], ["hello", 1], [b"hello", 1]:
             pytest.raises(NotImplementedError, ColumnInfo.from_values, pd.Series(s))
+
+    def test_string_dtype(self):
+        # Auto-inferred str type: non-nullable when data has no nulls
+        info = ColumnInfo.from_values(pd.Series(["hello", "world"]))
+        assert info.dtype == np.dtype("<U")
+        assert info.var is True
+        assert info.nullable is False
+        # With nulls: pandas 3+ auto-infers StringDtype which preserves null info;
+        # pandas 2 uses object dtype where null detection happens in the write path
+        s = pd.Series(["hello", None])
+        info = ColumnInfo.from_values(s)
+        assert info.dtype == np.dtype("<U")
+        assert info.var is True
+        assert info.nullable is isinstance(s.dtype, pd.StringDtype)
 
     unsupported_type_specs = [
         [np.float16, "f2"],
         [np.complex64, "c8"],
         [np.complex128, "c16"],
-        [np.datetime64, "<M8", "datetime64"],
-        [
-            "<M8[Y]",
-            "<M8[M]",
-            "<M8[W]",
-            "<M8[h]",
-            "<M8[m]",
-            "<M8[s]",
-            "<M8[ms]",
-            "<M8[us]",
-            "<M8[ps]",
-            "<M8[fs]",
-            "<M8[as]",
-        ],
     ]
     if hasattr(np, "float128"):
         unsupported_type_specs.append([np.float128, "f16"])
@@ -443,7 +445,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             times = df["time"]
             cccc = df["cccc"]
 
-            df = df.drop(columns=["time", "cccc"], axis=1)
+            df = df.drop(columns=["time", "cccc"])
             A[s_ichars, times, cccc] = df.to_dict(orient="series")
 
         with tiledb.SparseArray(uri) as A:
@@ -603,12 +605,12 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
 
             # ensure that all column which will be used as string dim index
             # is sorted, because that is how it will be returned
-            if df.dtypes[col] == "O":
+            if pd.api.types.is_string_dtype(df.dtypes[col]):
                 df.sort_values(col, inplace=True)
 
                 # also ensure that string columns are converted to bytes
                 # b/c only TILEDB_ASCII supported for string dimension
-                if isinstance(df[col][0], str):
+                if isinstance(df[col].iloc[0], str):
                     df[col] = [x.encode("UTF-8") for x in df[col]]
 
             new_df = df.drop_duplicates(subset=col)
@@ -1446,13 +1448,7 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
             tdb_uri = os.path.join(uri, f"{name}.tdb")
             pq_uri = os.path.join(uri, f"{name}.pq")
 
-            df.to_parquet(
-                pq_uri,
-                # this is required to losslessly serialize timestamps
-                # until Parquet 2.0 is default.
-                use_deprecated_int96_timestamps=True,
-                **pq_args,
-            )
+            df.to_parquet(pq_uri, **pq_args)
 
             tiledb.from_parquet(str(tdb_uri), str(pq_uri))
             df_bk = tiledb.open_dataframe(tdb_uri)
@@ -1995,9 +1991,8 @@ def test_datetime64_days_dtype_read_sc25572(checked_path):
         assert_dict_arrays_equal(array[:], data)
         df_received = array.df[:]
         df_received = df_received.set_index("d1")
-        tm.assert_frame_equal(
-            original_df, df_received, check_datetimelike_compat=True, check_dtype=False
-        )
+        # TileDB returns datetime.date objects for datetime64[D], convert both to strings
+        tm.assert_frame_equal(original_df.astype(str), df_received.astype(str))
 
 
 def test_datetime64_days_dtype_write_sc25572(checked_path):
@@ -2024,9 +2019,7 @@ def test_datetime64_days_dtype_write_sc25572(checked_path):
     with tiledb.open(uri, "r") as array:
         assert_dict_arrays_equal(array[:], data)
         df_received = array.df[:]
-        tm.assert_frame_equal(
-            original_df, df_received, check_datetimelike_compat=True, check_dtype=False
-        )
+        tm.assert_frame_equal(original_df, df_received, check_dtype=False)
 
 
 def test_datetime64_days_dtype_read_out_of_range_sc25572(checked_path):

--- a/tiledb/tests/test_pandas_dataframe.py
+++ b/tiledb/tests/test_pandas_dataframe.py
@@ -626,6 +626,19 @@ class TestPandasDataFrameRoundtrip(DiskTestCase):
                 res_df = pd.DataFrame(res, index=index)
                 tm.assert_frame_equal(new_df, res_df, check_like=True)
 
+    @pytest.mark.parametrize("index_data", [["aa", "b"], [b"aa", b"b"]])
+    def test_dataframe_str_dim_df_roundtrip(self, index_data):
+        # both str and bytes dimensions are stored as ASCII bytes; on read the
+        # type they were written with must be restored, on both read paths
+        uri = self.path("df_str_dim_df_roundtrip")
+
+        df = pd.DataFrame({"data": [1.0, 2.0]}, index=pd.Index(index_data, name="idx"))
+        tiledb.from_pandas(uri, df, sparse=True)
+
+        with tiledb.open(uri) as A:
+            tm.assert_frame_equal(A.df[:], df)
+            tm.assert_frame_equal(A.query(use_arrow=False).df[:], df)
+
     def test_dataframe_set_index_dims(self):
         uri = self.path("df_set_index_dims")
 

--- a/tiledb/tests/test_query_condition.py
+++ b/tiledb/tests/test_query_condition.py
@@ -615,7 +615,7 @@ class QueryConditionTest(DiskTestCase):
             with self.assertRaisesRegex(tiledb.TileDBError, message):
                 A.query(cond=expression)[:]
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_dense_datetime(self):
         import pandas as pd
 
@@ -823,7 +823,7 @@ class QueryConditionTest(DiskTestCase):
             result = A.query(cond='attr("at.tr.thr.ee") in [1, 2, 3]')[:]
             assert_array_equal(result["at.tr.thr.ee"], A[1:4]["at.tr.thr.ee"])
 
-    @pytest.mark.skipif(not has_pandas(), reason="pandas>=1.0,<3.0 not installed")
+    @pytest.mark.skipif(not has_pandas(), reason="pandas not installed")
     def test_do_not_return_attrs(self):
         with tiledb.open(self.create_input_array_UIDSA(sparse=True)) as A:
             cond = None


### PR DESCRIPTION
This PR adds Pandas 3 support while maintaining Pandas 2 compatibility. The main change is handling the new `StringDtype` that Pandas 3 uses by default for strings.

Also, added a CI step to continue on running tests using Pandas 2.

Closes CORE-487