### PR TITLE
Add explicit return type to `_domain` lambda for `pybind11>=3.0.2`

### DIFF
--- a/tiledb/libtiledb/domain.cc
+++ b/tiledb/libtiledb/domain.cc
@@ -49,7 +49,7 @@ void init_domain(py::module& m) {
 
         .def_property_readonly(
             "_domain",
-            [](Dimension& dim) {
+            [](Dimension& dim) -> py::tuple {
                 switch (dim.type()) {
                     case TILEDB_UINT64: {
                         auto dom = dim.domain<uint64_t>();


### PR DESCRIPTION
`pybind11` 3.0.2 changed `py::make_tuple` to return `py::typing::Tuple<Args...>` instead of `py::tuple` (x-ref https://github.com/pybind/pybind11/pull/5881), which breaks lambda return type deduction when different branches return tuples of different types. The `_domain` lambda in `domain.cc` was the only one missing an explicit `-> py::tuple` return type - all other similar lambdas in the codebase already had one. Adding it fixes the build.

Closes #2297
Closes #2298
Closes https://github.com/TileDB-Inc/centralized-tiledb-nightlies/issues/67
Closes https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/245

cc @jdblischak