### PR TITLE
Fix Windows wheel builds failing due to shell redirect in version specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,12 +112,5 @@ select = ["NPY201"]
 "tiledb/__init__.py" = ["F401"]
 
 [tool.cibuildwheel]
-test-requires = [
-    "pytest",
-    "pytest-rerunfailures",
-    "hypothesis",
-    "psutil",
-    "pyarrow",
-    "pandas<3",
-]
+test-extras = ["test"]
 test-command = "pytest {project}"


### PR DESCRIPTION
This PR switches cibuildwheel from `test-requires` to `test-extras` so that test dependencies are read from wheel metadata instead of being passed as shell arguments. This fixes `pandas<3` breaking all Windows builds because `<` is a redirect operator in `cmd.exe`.