### PR TITLE
Support NumPy 2.5.0

### DIFF
--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -30,10 +30,10 @@ jobs:
           - { python-version: "3.11", numpy-version: "1.25.2" }
           - { python-version: "3.11", numpy-version: "2.3.4" }
           - { python-version: "3.12", numpy-version: "1.26.4" }
-          - { python-version: "3.12", numpy-version: "2.3.4" }
+          - { python-version: "3.12", numpy-version: "2.5.0" }
           - { python-version: "3.13", numpy-version: "2.1.3" }
-          - { python-version: "3.13", numpy-version: "2.3.4" }
-          - { python-version: "3.14", numpy-version: "2.3.4" }
+          - { python-version: "3.13", numpy-version: "2.5.0" }
+          - { python-version: "3.14", numpy-version: "2.5.0" }
       fail-fast: false
     env:
       TILEDB_VERSION: ${{ inputs.libtiledb_version }}

--- a/.github/workflows/daily-test-build-numpy.yml
+++ b/.github/workflows/daily-test-build-numpy.yml
@@ -28,11 +28,12 @@ jobs:
           - { python-version: "3.10", numpy-version: "1.25.2" }
           - { python-version: "3.10", numpy-version: "2.2.6" }
           - { python-version: "3.11", numpy-version: "1.25.2" }
-          - { python-version: "3.11", numpy-version: "2.3.4" }
+          - { python-version: "3.11", numpy-version: "2.4.6" }
           - { python-version: "3.12", numpy-version: "1.26.4" }
           - { python-version: "3.12", numpy-version: "2.5.0" }
           - { python-version: "3.13", numpy-version: "2.1.3" }
           - { python-version: "3.13", numpy-version: "2.5.0" }
+          - { python-version: "3.14", numpy-version: "2.3.5" }
           - { python-version: "3.14", numpy-version: "2.5.0" }
       fail-fast: false
     env:

--- a/tiledb/array.py
+++ b/tiledb/array.py
@@ -1188,7 +1188,7 @@ class Array:
         out = OrderedDict()
         for name in results.keys():
             arr = results[name][0]
-            arr.dtype = q.buffer_dtype(name)
+            arr = arr.view(q.buffer_dtype(name))
             out[name] = arr
         return out
 

--- a/tiledb/array.py
+++ b/tiledb/array.py
@@ -1187,9 +1187,7 @@ class Array:
 
         out = OrderedDict()
         for name in results.keys():
-            arr = results[name][0]
-            arr = arr.view(q.buffer_dtype(name))
-            out[name] = arr
+            out[name] = results[name][0].view(q.buffer_dtype(name))
         return out
 
     # pickling support: this is a lightweight pickle for distributed use.

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1447,7 +1447,13 @@ class PyQuery {
                 auto arr = py::array(py::dtype("int8"), size, data_ptr);
                 o = py::memoryview(arr);
             } else {
-                // `size` is the cell's byte length, a multiple of the itemsize.
+                // `size` is the cell's byte length and must be a whole number
+                // of dtype elements; a partial element means corrupt offsets.
+                if (size % dtype.itemsize() != 0) {
+                    TPY_ERROR_LOC(
+                        "internal error: buffer size is not a multiple of the "
+                        "attribute itemsize");
+                }
                 o = py::array(dtype, size / dtype.itemsize(), data_ptr);
             }
 

--- a/tiledb/core.cc
+++ b/tiledb/core.cc
@@ -1447,8 +1447,8 @@ class PyQuery {
                 auto arr = py::array(py::dtype("int8"), size, data_ptr);
                 o = py::memoryview(arr);
             } else {
-                o = py::array(py::dtype("uint8"), size, data_ptr);
-                o.attr("dtype") = dtype;
+                // `size` is the cell's byte length, a multiple of the itemsize.
+                o = py::array(dtype, size / dtype.itemsize(), data_ptr);
             }
 
             result_p[i - 1] = o;

--- a/tiledb/dataframe_.py
+++ b/tiledb/dataframe_.py
@@ -372,9 +372,13 @@ def create_dim(dtype, values, full_domain, tile, **kwargs):
         if np.issubdtype(dtype, np.datetime64):
             date_unit = np.datetime_data(dtype)[0]
             dim_min = np.datetime64(dtype_min, date_unit)
-            tile_max = np.iinfo(np.uint64).max - tile
-            if np.uint64(dtype_max - dtype_min) > tile_max:
-                dim_max = np.datetime64(dtype_max - tile, date_unit)
+            # Subtract in Python ints; a full-domain datetime64 difference
+            # overflows int64.
+            dtype_min_i = int(dtype_min.astype(np.int64))
+            dtype_max_i = int(dtype_max.astype(np.int64))
+            tile_max = int(np.iinfo(np.uint64).max) - int(tile)
+            if (dtype_max_i - dtype_min_i) > tile_max:
+                dim_max = np.datetime64(dtype_max_i - int(tile), date_unit)
         elif np.issubdtype(dtype, np.integer):
             tile_max = np.iinfo(np.uint64).max - tile
             if np.uint64(dtype_max - dtype_min) > tile_max:
@@ -383,9 +387,14 @@ def create_dim(dtype, values, full_domain, tile, **kwargs):
         dim_min, dim_max = None, None
 
     # TODO: simplify this logic and/or move to DataType.cast_tile_extent
-    if np.issubdtype(dtype, np.integer) or np.issubdtype(dtype, np.datetime64):
+    if np.issubdtype(dtype, np.integer):
         # we can't make a tile larger than the dimension range or lower than 1
         tile = max(1, min(tile, 1 + np.uint64(dim_max - dim_min)))
+    elif np.issubdtype(dtype, np.datetime64):
+        # Clamp as for integers, computing the range in Python ints since a
+        # full-domain datetime64 difference overflows int64.
+        dim_range = int(dim_max.astype(np.int64)) - int(dim_min.astype(np.int64))
+        tile = max(1, min(tile, 1 + dim_range))
     elif np.issubdtype(dtype, np.floating):
         # this difference can be inf
         with np.errstate(over="ignore"):

--- a/tiledb/dense_array.py
+++ b/tiledb/dense_array.py
@@ -835,8 +835,7 @@ class DenseArrayImpl(Array):
             if len(item[1]) > 0:
                 arr = pyquery.unpack_buffer(name, item[0], item[1])
             else:
-                arr = item[0]
-                arr = arr.view(
+                arr = item[0].view(
                     self.schema.attr_or_dim_dtype(name)
                     if not self.schema.has_dim_label(name)
                     else self.schema.dim_label(name).dtype

--- a/tiledb/dense_array.py
+++ b/tiledb/dense_array.py
@@ -345,7 +345,7 @@ class DenseArrayImpl(Array):
                     # Note: fixed blobs are always 1 byte per cell
                     arr = arr.view("S1")
                 else:
-                    arr.dtype = dtype
+                    arr = arr.view(dtype)
                 if len(arr) == 0:
                     # special case: the C API returns 0 len for blank arrays
                     arr = np.zeros(output_shape, dtype=dtype)
@@ -357,13 +357,11 @@ class DenseArrayImpl(Array):
                     )
 
                 if layout == lt.LayoutType.ROW_MAJOR:
-                    arr.shape = output_shape
-                    arr = np.require(arr, requirements="C")
+                    arr = np.require(arr.reshape(output_shape), requirements="C")
                 elif layout == lt.LayoutType.COL_MAJOR:
-                    arr.shape = output_shape
-                    arr = np.require(arr, requirements="F")
+                    arr = np.require(arr.reshape(output_shape), requirements="F")
                 else:
-                    arr.shape = np.prod(output_shape)
+                    arr = arr.reshape(np.prod(output_shape))
 
                 out[name] = arr
 
@@ -838,12 +836,12 @@ class DenseArrayImpl(Array):
                 arr = pyquery.unpack_buffer(name, item[0], item[1])
             else:
                 arr = item[0]
-                arr.dtype = (
+                arr = arr.view(
                     self.schema.attr_or_dim_dtype(name)
                     if not self.schema.has_dim_label(name)
                     else self.schema.dim_label(name).dtype
                 )
-            arr.shape = result_shape
+            arr = arr.reshape(result_shape)
             result_dict[name if name != "__attr" else ""] = arr
 
         return result_dict

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -825,8 +825,7 @@ def _get_pyquery_results(pyquery: PyQuery, array: Array) -> Dict[str, np.ndarray
         if len(item[1]) > 0:
             arr = pyquery.unpack_buffer(name, item[0], item[1])
         else:
-            arr = item[0]
-            arr = arr.view(
+            arr = item[0].view(
                 schema.attr_or_dim_dtype(name)
                 if not schema.has_dim_label(name)
                 else schema.dim_label(name).dtype

--- a/tiledb/multirange_indexing.py
+++ b/tiledb/multirange_indexing.py
@@ -409,7 +409,7 @@ class MultiRangeIndexer(_BaseIndexer):
             for name, arr in result_dict.items():
                 # TODO check/test layout
                 if not self.array.schema.has_dim_label(name):
-                    arr.shape = self.result_shape
+                    result_dict[name] = arr.reshape(self.result_shape)
         return result_dict
 
 
@@ -826,7 +826,7 @@ def _get_pyquery_results(pyquery: PyQuery, array: Array) -> Dict[str, np.ndarray
             arr = pyquery.unpack_buffer(name, item[0], item[1])
         else:
             arr = item[0]
-            arr.dtype = (
+            arr = arr.view(
                 schema.attr_or_dim_dtype(name)
                 if not schema.has_dim_label(name)
                 else schema.dim_label(name).dtype

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -471,22 +471,17 @@ class NumpyConvert {
     NumpyConvert(py::array input) {
         // require a flat buffer
         if (input.ndim() != 1) {
-            // try to take a 1D view on the input
-            auto v = input.attr("view")();
-            // this will throw if the shape cannot be modified zero-copy,
-            // which is what we want
-            try {
-                v.attr("shape") = py::int_(input.size());
-            } catch (py::error_already_set& e) {
-                if (e.matches(PyExc_AttributeError)) {
-                    use_iter_ = true;
-                } else {
-                    throw;
-                }
-            } catch (std::exception& e) {
-                std::cout << e.what() << std::endl;
+            // reshape(-1) yields a zero-copy view when the array can be
+            // flattened in place and a fresh copy otherwise; the bulk paths
+            // need the view, so compare buffer addresses and fall back to the
+            // element-wise iterator (which handles strided input) on a copy.
+            py::array flat = input.attr("reshape")(py::int_(-1));
+            if (flat.data() == input.data()) {
+                input_ = flat;
+            } else {
+                use_iter_ = true;
+                input_ = input;
             }
-            input_ = v;
         } else {
             input_ = input;
         }

--- a/tiledb/npbuffer.cc
+++ b/tiledb/npbuffer.cc
@@ -471,10 +471,11 @@ class NumpyConvert {
     NumpyConvert(py::array input) {
         // require a flat buffer
         if (input.ndim() != 1) {
-            // reshape(-1) yields a zero-copy view when the array can be
-            // flattened in place and a fresh copy otherwise; the bulk paths
-            // need the view, so compare buffer addresses and fall back to the
-            // element-wise iterator (which handles strided input) on a copy.
+            // reshape(-1) returns a zero-copy view when the array can be
+            // flattened in place; the bulk paths need that view, so use it
+            // when the buffer address is unchanged. Otherwise the array is
+            // not contiguous: discard the copy and iterate the original
+            // element-wise instead.
             py::array flat = input.attr("reshape")(py::int_(-1));
             if (flat.data() == input.data()) {
                 input_ = flat;

--- a/tiledb/sparse_array.py
+++ b/tiledb/sparse_array.py
@@ -440,7 +440,7 @@ class SparseArrayImpl(Array):
                 arr = pyquery.unpack_buffer(name, item[0], item[1])
             else:
                 arr = item[0]
-                arr.dtype = (
+                arr = arr.view(
                     self.schema.attr_or_dim_dtype(name)
                     if not self.schema.has_dim_label(name)
                     else self.schema.dim_label(name).dtype
@@ -598,7 +598,7 @@ class SparseArrayImpl(Array):
                     arr = q.unpack_buffer(name, results[name][0], results[name][1])
                 else:
                     arr = results[name][0]
-                    arr.dtype = self.schema.attr_or_dim_dtype(name)
+                    arr = arr.view(self.schema.attr_or_dim_dtype(name))
                 out[final_name] = arr
             else:
                 arr = results[name][0]
@@ -623,8 +623,7 @@ class SparseArrayImpl(Array):
                     elif el_dtype == np.dtype("U0"):
                         out[final_name] = ""
                     else:
-                        arr.dtype = el_dtype
-                        out[final_name] = arr
+                        out[final_name] = arr.view(el_dtype)
 
             if self.schema.has_attr(final_name) and self.attr(final_name).isnullable:
                 out[final_name] = np.ma.array(

--- a/tiledb/sparse_array.py
+++ b/tiledb/sparse_array.py
@@ -439,8 +439,7 @@ class SparseArrayImpl(Array):
             if len(item[1]) > 0:
                 arr = pyquery.unpack_buffer(name, item[0], item[1])
             else:
-                arr = item[0]
-                arr = arr.view(
+                arr = item[0].view(
                     self.schema.attr_or_dim_dtype(name)
                     if not self.schema.has_dim_label(name)
                     else self.schema.dim_label(name).dtype
@@ -597,8 +596,7 @@ class SparseArrayImpl(Array):
                 if len(results[name][1]) > 0:  # note: len(offsets) > 0
                     arr = q.unpack_buffer(name, results[name][0], results[name][1])
                 else:
-                    arr = results[name][0]
-                    arr = arr.view(self.schema.attr_or_dim_dtype(name))
+                    arr = results[name][0].view(self.schema.attr_or_dim_dtype(name))
                 out[final_name] = arr
             else:
                 arr = results[name][0]

--- a/tiledb/tests/test_core.py
+++ b/tiledb/tests/test_core.py
@@ -37,8 +37,7 @@ class CoreCCTest(DiskTestCase):
             subarray.add_ranges([[(0, 3)]])
             q2.set_subarray(subarray)
             q2.submit()
-            res = q2.results()[""][0]
-            res = res.view(np.double)
+            res = q2.results()[""][0].view(np.double)
             assert_array_equal(res, a[:])
 
     def test_pyquery_init(self):

--- a/tiledb/tests/test_core.py
+++ b/tiledb/tests/test_core.py
@@ -38,7 +38,7 @@ class CoreCCTest(DiskTestCase):
             q2.set_subarray(subarray)
             q2.submit()
             res = q2.results()[""][0]
-            res.dtype = np.double
+            res = res.view(np.double)
             assert_array_equal(res, a[:])
 
     def test_pyquery_init(self):

--- a/tiledb/tests/test_libtiledb.py
+++ b/tiledb/tests/test_libtiledb.py
@@ -2697,7 +2697,11 @@ class TestDatetimeSlicing(DiskTestCase):
                 (np.datetime64("2010-11-01") - start) / np.timedelta64(1, "D")
             )
             read_ndays = int(
-                (np.datetime64("2011-01-31") - np.datetime64("2010-11-01") + 1)
+                (
+                    np.datetime64("2011-01-31")
+                    - np.datetime64("2010-11-01")
+                    + np.timedelta64(1, "D")
+                )
                 / np.timedelta64(1, "D")
             )
             expected = a1_vals[read_offset : read_offset + read_ndays]
@@ -2712,7 +2716,11 @@ class TestDatetimeSlicing(DiskTestCase):
                 (np.datetime64("2010-01-01") - start) / np.timedelta64(1, "D")
             )
             read_ndays = int(
-                (np.datetime64("2011-01-01") - np.datetime64("2010-01-01") + 1)
+                (
+                    np.datetime64("2011-01-01")
+                    - np.datetime64("2010-01-01")
+                    + np.timedelta64(1, "D")
+                )
                 / np.timedelta64(1, "D")
             )
             expected = a1_vals[read_offset : read_offset + read_ndays]
@@ -2725,7 +2733,11 @@ class TestDatetimeSlicing(DiskTestCase):
                 (np.datetime64("2010-01-01") - start) / np.timedelta64(1, "D")
             )
             read_ndays = int(
-                (np.datetime64("2011-01-31") - np.datetime64("2010-01-01") + 1)
+                (
+                    np.datetime64("2011-01-31")
+                    - np.datetime64("2010-01-01")
+                    + np.timedelta64(1, "D")
+                )
                 / np.timedelta64(1, "D")
             )
             expected = a1_vals[read_offset : read_offset + read_ndays]

--- a/tiledb/tests/test_subarray.py
+++ b/tiledb/tests/test_subarray.py
@@ -203,7 +203,7 @@ class SubarrayTest(DiskTestCase):
 
             results = q.results()
             arr = results["a"][0]
-            arr.dtype = np.int32
+            arr = arr.view(np.int32)
             assert arr.shape == (2,)
             assert np.array_equal(arr, np.array([10, 30], dtype=np.int32))
 
@@ -235,6 +235,6 @@ class SubarrayTest(DiskTestCase):
 
             results = q.results()
             arr = results["a"][0]
-            arr.dtype = np.int32
+            arr = arr.view(np.int32)
             assert arr.shape == (2,)
             assert np.array_equal(arr, np.array([10, 30], dtype=np.int32))

--- a/tiledb/tests/test_subarray.py
+++ b/tiledb/tests/test_subarray.py
@@ -202,8 +202,7 @@ class SubarrayTest(DiskTestCase):
             q.submit()
 
             results = q.results()
-            arr = results["a"][0]
-            arr = arr.view(np.int32)
+            arr = results["a"][0].view(np.int32)
             assert arr.shape == (2,)
             assert np.array_equal(arr, np.array([10, 30], dtype=np.int32))
 
@@ -234,7 +233,6 @@ class SubarrayTest(DiskTestCase):
             q.submit()
 
             results = q.results()
-            arr = results["a"][0]
-            arr = arr.view(np.int32)
+            arr = results["a"][0].view(np.int32)
             assert arr.shape == (2,)
             assert np.array_equal(arr, np.array([10, 30], dtype=np.int32))


### PR DESCRIPTION
NumPy 2.5 deprecated setting `.dtype` and `.shape` on an array in place, so those spots now use `view()` / `reshape()` instead. It also made datetime64 arithmetic raise on int64 overflow instead of wrapping silently, so full-domain datetime dimension bounds are now computed on the underlying int64 values.

Also refreshed the nightly matrix to cover the oldest and newest numpy each Python supports (including 2.5).

Tested the full suite on numpy 1.26, 2.3 and 2.5.

Closes #2307

cc @jdblischak
